### PR TITLE
feat(audit): tenant-scoped audit-log CSV/JSON export

### DIFF
--- a/apps/web/app/(admin)/settings/audit-log/page.tsx
+++ b/apps/web/app/(admin)/settings/audit-log/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import { trpc } from '../../../../lib/trpc';
+import { useI18n } from '../../../../lib/i18n';
+import { toast } from '../../../../lib/toast';
+
+function downloadBlob(data: string, format: 'csv' | 'json') {
+  const mime = format === 'json' ? 'application/json' : 'text/csv;charset=utf-8;';
+  const blob = new Blob([data], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.${format}`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function AuditLogExportPage() {
+  const { t } = useI18n();
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [action, setAction] = useState('');
+  const [entity, setEntity] = useState('');
+  const [actorId, setActorId] = useState('');
+
+  const users = trpc.user.list.useQuery({ limit: 100 });
+  const exportMutation = trpc.audit.exportLogs.useMutation();
+
+  const clearFilters = () => {
+    setDateFrom('');
+    setDateTo('');
+    setAction('');
+    setEntity('');
+    setActorId('');
+  };
+
+  const handleExport = async (format: 'csv' | 'json') => {
+    try {
+      const result = await exportMutation.mutateAsync({
+        format,
+        dateFrom: dateFrom ? new Date(dateFrom) : undefined,
+        dateTo: dateTo ? new Date(dateTo) : undefined,
+        action: action || undefined,
+        entity: entity || undefined,
+        actorId: actorId || undefined,
+      });
+      downloadBlob(result.data, result.format);
+      if (result.truncated) {
+        toast(t.auditExport.exportTruncated.replace('{count}', String(result.count)), { type: 'info' });
+      } else {
+        toast(t.auditExport.exportSuccess.replace('{count}', String(result.count)), { type: 'success' });
+      }
+    } catch {
+      toast(t.auditExport.exportError, { type: 'error' });
+    }
+  };
+
+  const isExporting = exportMutation.isPending;
+
+  return (
+    <div className="flex flex-col flex-1 min-w-0 h-full">
+      {/* Top Bar */}
+      <div className="flex flex-wrap items-center justify-between gap-y-2 px-4 md:px-6 min-h-16 py-2 bg-white border-b border-[#EDEDED] shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] text-[#8B8B8B]">{t.auditExport.breadcrumbParent}</span>
+          <svg className="w-3 h-3 text-[#ccc]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+          <span className="text-sm font-medium text-[#1F114C]">{t.auditExport.title}</span>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-5">
+        <div className="bg-white rounded-xl shadow-[0_1px_4px_rgba(0,0,0,0.06)] p-5 mb-4 max-w-3xl">
+          <p className="text-[12px] text-[#8B8B8B] mb-4">{t.auditExport.description}</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-[12px] font-medium text-[#585858] mb-1.5">{t.auditExport.dateFrom}</label>
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="w-full bg-white border border-[#EDEDED] rounded-lg px-3 h-9 text-[13px] text-[#333] focus:outline-none focus:border-[#1F114C]/40"
+              />
+            </div>
+            <div>
+              <label className="block text-[12px] font-medium text-[#585858] mb-1.5">{t.auditExport.dateTo}</label>
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="w-full bg-white border border-[#EDEDED] rounded-lg px-3 h-9 text-[13px] text-[#333] focus:outline-none focus:border-[#1F114C]/40"
+              />
+            </div>
+            <div>
+              <label className="block text-[12px] font-medium text-[#585858] mb-1.5">{t.auditExport.actionLabel}</label>
+              <input
+                type="text"
+                maxLength={200}
+                value={action}
+                onChange={(e) => setAction(e.target.value)}
+                placeholder={t.auditExport.actionPlaceholder}
+                className="w-full bg-white border border-[#EDEDED] rounded-lg px-3 h-9 text-[13px] text-[#333] focus:outline-none focus:border-[#1F114C]/40"
+              />
+            </div>
+            <div>
+              <label className="block text-[12px] font-medium text-[#585858] mb-1.5">{t.auditExport.entityLabel}</label>
+              <input
+                type="text"
+                maxLength={200}
+                value={entity}
+                onChange={(e) => setEntity(e.target.value)}
+                placeholder={t.auditExport.entityPlaceholder}
+                className="w-full bg-white border border-[#EDEDED] rounded-lg px-3 h-9 text-[13px] text-[#333] focus:outline-none focus:border-[#1F114C]/40"
+              />
+            </div>
+            <div>
+              <label className="block text-[12px] font-medium text-[#585858] mb-1.5">{t.auditExport.actorLabel}</label>
+              <select
+                value={actorId}
+                onChange={(e) => setActorId(e.target.value)}
+                disabled={users.isLoading}
+                className="w-full bg-white border border-[#EDEDED] rounded-lg px-3 h-9 text-[13px] text-[#333] focus:outline-none focus:border-[#1F114C]/40 disabled:bg-[#F6F6F6] disabled:text-[#B8B8B8]"
+              >
+                <option value="">{t.auditExport.allActors}</option>
+                {(users.data?.users ?? []).map((u) => (
+                  <option key={u.id} value={u.id}>
+                    {u.firstName} {u.lastName} ({u.email})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => handleExport('csv')}
+              disabled={isExporting}
+              className="flex items-center gap-1.5 bg-[#1F114C] text-white px-4 h-9 rounded-lg text-[12px] font-medium disabled:opacity-50"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                <path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+              </svg>
+              {t.auditExport.exportCsv}
+            </button>
+            <button
+              onClick={() => handleExport('json')}
+              disabled={isExporting}
+              className="flex items-center gap-1.5 border border-[#EDEDED] text-[#585858] px-4 h-9 rounded-lg text-[12px] font-medium disabled:opacity-50"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                <path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+              </svg>
+              {t.auditExport.exportJson}
+            </button>
+            <button onClick={clearFilters} className="text-[12px] text-[#8B8B8B] hover:text-[#DD0C15] ml-1">
+              {t.auditExport.clearFilters}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/i18n/en.json
+++ b/apps/web/lib/i18n/en.json
@@ -86,7 +86,8 @@
     "myLearning": "My Learning",
     "myOnboarding": "My Onboarding",
     "my360": "My 360",
-    "evaluations360": "360 Evaluation"
+    "evaluations360": "360 Evaluation",
+    "auditLog": "Audit Log"
   },
   "platformSidebar": {
     "platform": "Platform",

--- a/apps/web/lib/i18n/en.json
+++ b/apps/web/lib/i18n/en.json
@@ -940,6 +940,25 @@
     "of": "of",
     "system": "System"
   },
+  "auditExport": {
+    "breadcrumbParent": "Settings",
+    "title": "Audit Log Export",
+    "description": "Export your organization's audit events as CSV or JSON.",
+    "dateFrom": "From",
+    "dateTo": "To",
+    "actionLabel": "Action",
+    "actionPlaceholder": "e.g. create, update, delete",
+    "entityLabel": "Entity",
+    "entityPlaceholder": "e.g. candidate, vacancy",
+    "actorLabel": "Actor",
+    "allActors": "All actors",
+    "exportCsv": "Export CSV",
+    "exportJson": "Export JSON",
+    "exportSuccess": "Export ready: {count} rows",
+    "exportTruncated": "Export capped at {count} rows",
+    "exportError": "Failed to generate export",
+    "clearFilters": "Clear filters"
+  },
   "accessReview": {
     "title": "Access Review",
     "selectOrgPlaceholder": "Select an organization",

--- a/apps/web/lib/i18n/es.json
+++ b/apps/web/lib/i18n/es.json
@@ -940,6 +940,25 @@
     "of": "de",
     "system": "Sistema"
   },
+  "auditExport": {
+    "breadcrumbParent": "Configuracion",
+    "title": "Exportar Registro de Auditoria",
+    "description": "Exporta los eventos de auditoria de tu organizacion en CSV o JSON.",
+    "dateFrom": "Desde",
+    "dateTo": "Hasta",
+    "actionLabel": "Accion",
+    "actionPlaceholder": "ej. create, update, delete",
+    "entityLabel": "Entidad",
+    "entityPlaceholder": "ej. candidate, vacancy",
+    "actorLabel": "Actor",
+    "allActors": "Todos los actores",
+    "exportCsv": "Exportar CSV",
+    "exportJson": "Exportar JSON",
+    "exportSuccess": "Exportacion lista: {count} filas",
+    "exportTruncated": "Exportacion limitada a {count} filas",
+    "exportError": "Error al generar la exportacion",
+    "clearFilters": "Limpiar filtros"
+  },
   "accessReview": {
     "title": "Revision de Acceso",
     "selectOrgPlaceholder": "Selecciona una organizacion",

--- a/apps/web/lib/i18n/es.json
+++ b/apps/web/lib/i18n/es.json
@@ -86,7 +86,8 @@
     "myLearning": "Mi Aprendizaje",
     "myOnboarding": "Mi Onboarding",
     "my360": "Mi 360",
-    "evaluations360": "Evaluacion 360"
+    "evaluations360": "Evaluacion 360",
+    "auditLog": "Registro de Auditoria"
   },
   "platformSidebar": {
     "platform": "Plataforma",

--- a/apps/web/lib/nav/manifest.ts
+++ b/apps/web/lib/nav/manifest.ts
@@ -5,14 +5,22 @@ export type NavSubItem = { readonly href: string; readonly labelKey: string; rea
 // sub-items inherit their parent's module-gate rather than being independently permission-checked
 // (there is no real case requiring per-sub-item permissions today; add one only when a manifest
 // actually needs it).
-export type NavItem = { readonly href: string; readonly labelKey: string; readonly icon: string; readonly module: Module | null; readonly sub?: readonly NavSubItem[] };
+export type NavItem = {
+  readonly href: string;
+  readonly labelKey: string;
+  readonly icon: string;
+  readonly module: Module | null;
+  readonly sub?: readonly NavSubItem[];
+};
 export type NavSection = { readonly labelKey: string | null; readonly items: readonly NavItem[] };
 export type Shell = 'admin' | 'participant' | 'platform';
-export type RoleManifest = { readonly shell: Shell; readonly landing: string; readonly sections: readonly NavSection[] };
+export type RoleManifest = {
+  readonly shell: Shell;
+  readonly landing: string;
+  readonly sections: readonly NavSection[];
+};
 
-export const NAV_ROLES = [
-  'super_admin', 'hr_admin', 'hrbp', 'recruiter', 'leader', 'committee', 'employee',
-] as const;
+export const NAV_ROLES = ['super_admin', 'hr_admin', 'hrbp', 'recruiter', 'leader', 'committee', 'employee'] as const;
 export type NavRole = (typeof NAV_ROLES)[number];
 
 // Highest-precedence first (mirrors ROLE_PRECEDENCE in permissions.tsx, minus platform_owner
@@ -82,6 +90,7 @@ const SETTINGS: NavSection = {
     { href: '/settings/fit-weights', labelKey: 'sidebar.fitWeights', icon: 'settings', module: 'fit_engine' },
     { href: '/settings/billing', labelKey: 'sidebar.billing', icon: 'dollar', module: 'billing' },
     { href: '/settings/integrations', labelKey: 'sidebar.integrations', icon: 'settings', module: 'integration' },
+    { href: '/settings/audit-log', labelKey: 'sidebar.auditLog', icon: 'clipboard', module: 'audit' },
   ],
 };
 
@@ -113,13 +122,9 @@ const LEADER_COCKPIT: NavSection[] = [COMMAND_CENTER, LEADER_MY_HIRING, LEADER_M
 // no billing/integrations — org-config is read-only per the access spec). can() still prunes.
 const HR_ADMIN_SETTINGS: NavSection = {
   labelKey: null,
-  items: [
-    { href: '/settings/business-units', labelKey: 'sidebar.businessUnits', icon: 'team', module: 'user' },
-  ],
+  items: [{ href: '/settings/business-units', labelKey: 'sidebar.businessUnits', icon: 'team', module: 'user' }],
 };
-const HR_ADMIN_PEOPLE_FIRST: NavSection[] = [
-  COMMAND_CENTER, PEOPLE, TALENT, CULTURE, RECRUITMENT, HR_ADMIN_SETTINGS,
-];
+const HR_ADMIN_PEOPLE_FIRST: NavSection[] = [COMMAND_CENTER, PEOPLE, TALENT, CULTURE, RECRUITMENT, HR_ADMIN_SETTINGS];
 
 // hrbp = HR business partner scoped to assigned units ("Mis Unidades"). Unit-native IA, no org-admin
 // chrome. CULTURE keeps monitoring (hrbp has monitoring:read@unit); can() prunes DEI (no dei grant).
@@ -134,7 +139,11 @@ const RECRUITER_ATS: NavSection[] = [COMMAND_CENTER, RECRUITMENT];
 
 const adminManifest = (sections: NavSection[]): RoleManifest => ({ shell: 'admin', landing: '/dashboard', sections });
 
-const participantManifest = (sections: NavSection[]): RoleManifest => ({ shell: 'participant', landing: '/dashboard', sections });
+const participantManifest = (sections: NavSection[]): RoleManifest => ({
+  shell: 'participant',
+  landing: '/dashboard',
+  sections,
+});
 
 // committee = interview panels they're assigned to (their real task). "Mis Calibraciones" is now
 // surfaced as a panel ON the committee landing (useNineBoxMyCalibrations, member-scoped) rather than a
@@ -201,10 +210,9 @@ export function isNavItemActive(pathname: string, href: string): boolean {
 
 /** Resolve a dot-path label key against an i18n message object. Falls back to the key. */
 export function resolveLabel(messages: Record<string, unknown>, key: string): string {
-  const v = key.split('.').reduce<unknown>(
-    (o, k) => (o && typeof o === 'object' ? (o as Record<string, unknown>)[k] : undefined),
-    messages,
-  );
+  const v = key
+    .split('.')
+    .reduce<unknown>((o, k) => (o && typeof o === 'object' ? (o as Record<string, unknown>)[k] : undefined), messages);
   return typeof v === 'string' ? v : key;
 }
 

--- a/apps/web/lib/nav/routes.ts
+++ b/apps/web/lib/nav/routes.ts
@@ -32,6 +32,7 @@ export const PATH_MODULE: Record<string, string | null> = {
   '/settings/business-units': 'user',
   '/settings/branding': 'organization',
   '/settings/fit-weights': 'fit_engine',
+  '/settings/audit-log': 'audit',
   '/settings': null,
   '/platform': null, // server-gated in its own layout
   '/mfa': null,

--- a/packages/api/src/repositories/audit.repository.ts
+++ b/packages/api/src/repositories/audit.repository.ts
@@ -1,0 +1,51 @@
+import { tenantDb as db } from '@tims/db';
+import type { Prisma } from '@tims/db';
+
+// ---------------------------------------------------------------------------
+// Audit Repository — only place that imports db for audit-log export queries.
+// ---------------------------------------------------------------------------
+
+export interface AuditExportFilters {
+  dateFrom?: Date;
+  dateTo?: Date;
+  actorId?: string;
+  entity?: string;
+  action?: string;
+}
+
+// Explicit select — deliberately EXCLUDES `changes`/`metadata` (may carry
+// business-sensitive payloads not meant for bulk CSV/JSON export), mirroring the
+// truncated-flag pattern candidate.repository.ts's `findForExport` uses for pool
+// export (packages/api/src/services/candidate.service.ts:332-374).
+export const auditRepository = {
+  async findForExport(orgId: string, filters: AuditExportFilters, limit: number) {
+    const where: Prisma.AuditLogWhereInput = { organizationId: orgId };
+    if (filters.actorId) where.actorId = filters.actorId;
+    if (filters.entity) where.entity = filters.entity;
+    if (filters.action) where.action = filters.action;
+    if (filters.dateFrom || filters.dateTo) {
+      where.createdAt = {
+        ...(filters.dateFrom ? { gte: filters.dateFrom } : {}),
+        ...(filters.dateTo ? { lte: filters.dateTo } : {}),
+      };
+    }
+
+    return db.auditLog.findMany({
+      where,
+      take: limit + 1,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        action: true,
+        entity: true,
+        entityId: true,
+        actorId: true,
+        userId: true,
+        createdAt: true,
+        ipAddress: true,
+        userAgent: true,
+        actor: { select: { firstName: true, lastName: true, email: true } },
+      },
+    });
+  },
+};

--- a/packages/api/src/routers/audit.ts
+++ b/packages/api/src/routers/audit.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../trpc';
 import { tenantDb as db } from '@tims/db';
+import { auditService } from '../services/audit.service';
+import { logPlatformExport } from '../access/security-audit';
 
 export const auditRouter = router({
   // List logs with cursor pagination and filters
@@ -14,7 +16,7 @@ export const auditRouter = router({
         dateTo: z.date().optional(),
         take: z.number().min(1).max(100).default(25),
         cursor: z.string().uuid().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const where: Record<string, unknown> = {
@@ -60,21 +62,27 @@ export const auditRouter = router({
       });
     }),
 
-  // Export logs — stub
-  exportLogs: permissionProcedure('audit', 'read')
+  // Export logs — tenant-scoped CSV/JSON export, gated on audit:export.
+  exportLogs: permissionProcedure('audit', 'export')
     .input(
       z.object({
-        format: z.enum(['csv', 'json']).default('csv'),
+        format: z.enum(['csv', 'json']),
         dateFrom: z.date().optional(),
         dateTo: z.date().optional(),
-      })
+        actorId: z.string().uuid().optional(),
+        entity: z.string().max(200).optional(),
+        action: z.string().max(200).optional(),
+      }),
     )
-    .mutation(async () => {
-      // Stub — would generate an export file and return a download URL
-      return {
-        status: 'queued',
-        message: 'Export is being generated. You will receive a download link shortly.',
-      };
+    .mutation(async ({ ctx, input }) => {
+      const result = await auditService.exportLogs(ctx.user.organizationId, input);
+      logPlatformExport(ctx, {
+        resource: 'audit_log',
+        count: result.count,
+        format: result.format,
+        truncated: result.truncated,
+      });
+      return result;
     }),
 
   // Access report — who accessed what
@@ -83,7 +91,7 @@ export const auditRouter = router({
       z.object({
         dateFrom: z.date().optional(),
         dateTo: z.date().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const where: Record<string, unknown> = {
@@ -116,7 +124,7 @@ export const auditRouter = router({
         entityId: z.string().max(200),
         take: z.number().min(1).max(100).default(25),
         cursor: z.string().uuid().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const items = await db.auditLog.findMany({

--- a/packages/api/src/services/audit.service.ts
+++ b/packages/api/src/services/audit.service.ts
@@ -1,0 +1,58 @@
+import { csvRow } from '@tims/shared';
+import { auditRepository, type AuditExportFilters } from '../repositories/audit.repository';
+
+// ---------------------------------------------------------------------------
+// Audit Service — business logic only, no db imports.
+// ---------------------------------------------------------------------------
+
+const EXPORT_LIMIT = 10_000;
+
+export const auditService = {
+  async exportLogs(orgId: string, input: AuditExportFilters & { format: 'csv' | 'json' }) {
+    const { format, ...filters } = input;
+    const rows = await auditRepository.findForExport(orgId, filters, EXPORT_LIMIT);
+    const truncated = rows.length > EXPORT_LIMIT;
+    const page = truncated ? rows.slice(0, EXPORT_LIMIT) : rows;
+
+    const records = page.map((log) => ({
+      timestamp: log.createdAt.toISOString(),
+      actorName: log.actor ? `${log.actor.firstName} ${log.actor.lastName}`.trim() : '',
+      actorEmail: log.actor?.email ?? '',
+      action: log.action,
+      entity: log.entity,
+      entityId: log.entityId ?? '',
+      ipAddress: log.ipAddress ?? '',
+      userAgent: log.userAgent ?? '',
+    }));
+
+    const data =
+      format === 'json'
+        ? JSON.stringify(records)
+        : [
+            csvRow([
+              'Timestamp',
+              'Actor Name',
+              'Actor Email',
+              'Action',
+              'Entity',
+              'Entity ID',
+              'IP Address',
+              'User Agent',
+            ]),
+            ...records.map((r) =>
+              csvRow([
+                r.timestamp,
+                r.actorName,
+                r.actorEmail,
+                r.action,
+                r.entity,
+                r.entityId,
+                r.ipAddress,
+                r.userAgent,
+              ]),
+            ),
+          ].join('\n');
+
+    return { data, count: page.length, truncated, format };
+  },
+};

--- a/tests/audit/audit-log-export.test.ts
+++ b/tests/audit/audit-log-export.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AccessDecision } from '../../packages/api/src/access';
+
+// ---------------------------------------------------------------------------
+// Mocks — pattern mirrors tests/candidate/pool-export.test.ts (the export
+// feature this branch's review explicitly cites as the expected test shape).
+// ---------------------------------------------------------------------------
+const auditLogFindManyMock = vi.fn();
+const auditLogCreateMock = vi.fn().mockResolvedValue({});
+
+vi.mock('@tims/db', () => ({
+  tenantDb: {
+    auditLog: {
+      findMany: (...args: unknown[]) => auditLogFindManyMock(...args),
+    },
+  },
+  // Router-level behavioral test below needs a real tRPC caller, which threads
+  // through trpc.ts's `db`/`runWithTenant` imports (audit logging + tenant
+  // context) — stubbed here so those middleware/observer calls no-op cleanly.
+  db: {
+    auditLog: {
+      create: (...args: unknown[]) => auditLogCreateMock(...args),
+    },
+  },
+  runWithTenant: (_orgId: string | null, fn: () => unknown) => fn(),
+}));
+
+const buildAccessForUserMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<AccessDecision> => ({ allowed: true, scope: 'organization', roles: ['super_admin'] })),
+);
+
+vi.mock('../../packages/api/src/access', async () => {
+  const actual = await vi.importActual<typeof import('../../packages/api/src/access')>('../../packages/api/src/access');
+  return {
+    ...actual,
+    buildAccessForUser: buildAccessForUserMock,
+  };
+});
+
+import { auditRepository } from '../../packages/api/src/repositories/audit.repository';
+
+// ---------------------------------------------------------------------------
+// Repository — tenant isolation is the safety-critical property here: every
+// filter combination must still be AND'd against organizationId, and a caller
+// can never widen the query beyond its own org.
+// ---------------------------------------------------------------------------
+describe('auditRepository.findForExport', () => {
+  beforeEach(() => {
+    auditLogFindManyMock.mockReset();
+    auditLogFindManyMock.mockResolvedValue([]);
+  });
+
+  it('always scopes the query by the caller-supplied organizationId', async () => {
+    await auditRepository.findForExport('org-1', {}, 100);
+    const call = auditLogFindManyMock.mock.calls[0]?.[0];
+    expect(call.where.organizationId).toBe('org-1');
+  });
+
+  it('scopes by whichever organizationId is passed — filters cannot override tenant scope', async () => {
+    await auditRepository.findForExport('org-2', { actorId: 'a1', entity: 'candidate', action: 'update' }, 100);
+    const call = auditLogFindManyMock.mock.calls[0]?.[0];
+    expect(call.where.organizationId).toBe('org-2');
+    expect(call.where.organizationId).not.toBe('org-1');
+  });
+
+  it('adds an actorId filter only when provided', async () => {
+    await auditRepository.findForExport('org-1', {}, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.actorId).toBeUndefined();
+
+    auditLogFindManyMock.mockClear();
+    await auditRepository.findForExport('org-1', { actorId: 'a1' }, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.actorId).toBe('a1');
+  });
+
+  it('adds an entity filter only when provided', async () => {
+    await auditRepository.findForExport('org-1', {}, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.entity).toBeUndefined();
+
+    auditLogFindManyMock.mockClear();
+    await auditRepository.findForExport('org-1', { entity: 'candidate' }, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.entity).toBe('candidate');
+  });
+
+  it('adds an action filter only when provided', async () => {
+    await auditRepository.findForExport('org-1', {}, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.action).toBeUndefined();
+
+    auditLogFindManyMock.mockClear();
+    await auditRepository.findForExport('org-1', { action: 'update' }, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.action).toBe('update');
+  });
+
+  it('builds a createdAt range from dateFrom/dateTo, omitting whichever side is absent', async () => {
+    const dateFrom = new Date('2026-01-01T00:00:00Z');
+    const dateTo = new Date('2026-02-01T00:00:00Z');
+
+    await auditRepository.findForExport('org-1', { dateFrom, dateTo }, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.createdAt).toEqual({ gte: dateFrom, lte: dateTo });
+
+    auditLogFindManyMock.mockClear();
+    await auditRepository.findForExport('org-1', { dateFrom }, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.createdAt).toEqual({ gte: dateFrom });
+
+    auditLogFindManyMock.mockClear();
+    await auditRepository.findForExport('org-1', {}, 100);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].where.createdAt).toBeUndefined();
+  });
+
+  it('requests one extra row beyond the limit (truncation detection)', async () => {
+    await auditRepository.findForExport('org-1', {}, 250);
+    expect(auditLogFindManyMock.mock.calls[0]?.[0].take).toBe(251);
+  });
+
+  it('selects only export columns — deliberately excludes changes/metadata (business-sensitive payloads)', async () => {
+    await auditRepository.findForExport('org-1', {}, 100);
+    const call = auditLogFindManyMock.mock.calls[0]?.[0];
+    expect(call.select).toEqual({
+      id: true,
+      action: true,
+      entity: true,
+      entityId: true,
+      actorId: true,
+      userId: true,
+      createdAt: true,
+      ipAddress: true,
+      userAgent: true,
+      actor: { select: { firstName: true, lastName: true, email: true } },
+    });
+    expect(call.select.changes).toBeUndefined();
+    expect(call.select.metadata).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service — truncation at EXPORT_LIMIT, CSV vs JSON branch selection, and CSV
+// escaping of the actual export fields (actorName/actorEmail/action/entity/
+// entityId/ipAddress/userAgent).
+// ---------------------------------------------------------------------------
+import { auditService } from '../../packages/api/src/services/audit.service';
+import * as auditRepositoryModule from '../../packages/api/src/repositories/audit.repository';
+
+const EXPORT_LIMIT = 10_000;
+
+function makeLog(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'log-1',
+    action: 'update',
+    entity: 'candidate',
+    entityId: 'cand-1',
+    actorId: 'actor-1',
+    userId: null,
+    createdAt: new Date('2026-01-01T12:00:00Z'),
+    ipAddress: '1.2.3.4',
+    userAgent: 'Mozilla/5.0',
+    actor: { firstName: 'Ana', lastName: 'Diaz', email: 'ana@x.com' },
+    ...overrides,
+  };
+}
+
+describe('auditService.exportLogs', () => {
+  let findForExportSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    findForExportSpy = vi.spyOn(auditRepositoryModule.auditRepository, 'findForExport');
+  });
+
+  afterEach(() => {
+    findForExportSpy.mockRestore();
+  });
+
+  it('passes filters (without format) and EXPORT_LIMIT through to the repository', async () => {
+    findForExportSpy.mockResolvedValue([]);
+    await auditService.exportLogs('org-1', { format: 'csv', actorId: 'a1', entity: 'candidate' });
+
+    expect(findForExportSpy).toHaveBeenCalledWith('org-1', { actorId: 'a1', entity: 'candidate' }, EXPORT_LIMIT);
+  });
+
+  it('builds a CSV header + one row per log, with actorName from firstName+lastName', async () => {
+    findForExportSpy.mockResolvedValue([makeLog()]);
+
+    const result = await auditService.exportLogs('org-1', { format: 'csv' });
+
+    expect(result.count).toBe(1);
+    expect(result.truncated).toBe(false);
+    expect(result.format).toBe('csv');
+    const lines = result.data.split('\n');
+    expect(lines[0]).toBe(
+      '"Timestamp","Actor Name","Actor Email","Action","Entity","Entity ID","IP Address","User Agent"',
+    );
+    expect(lines[1]).toContain('"Ana Diaz"');
+    expect(lines[1]).toContain('"ana@x.com"');
+    expect(lines[1]).toContain('"update"');
+    expect(lines[1]).toContain('"candidate"');
+  });
+
+  it('falls back to an empty actorName/actorEmail when the log has no actor (system action)', async () => {
+    findForExportSpy.mockResolvedValue([makeLog({ actor: null })]);
+
+    const result = await auditService.exportLogs('org-1', { format: 'csv' });
+
+    const [, row] = result.data.split('\n');
+    // Empty actorName/actorEmail cells render as bare "" between the leading and
+    // trailing quoted-comma boundaries.
+    expect(row).toMatch(/^"[^"]+","","",/);
+  });
+
+  it('builds JSON output as the stringified record array (not the raw log rows)', async () => {
+    findForExportSpy.mockResolvedValue([makeLog()]);
+
+    const result = await auditService.exportLogs('org-1', { format: 'json' });
+
+    expect(result.format).toBe('json');
+    const parsed = JSON.parse(result.data) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({
+      timestamp: '2026-01-01T12:00:00.000Z',
+      actorName: 'Ana Diaz',
+      actorEmail: 'ana@x.com',
+      action: 'update',
+      entity: 'candidate',
+      entityId: 'cand-1',
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla/5.0',
+    });
+  });
+
+  it('neutralizes a formula-injection actorName and escapes embedded quotes/commas (CWE-1236)', async () => {
+    findForExportSpy.mockResolvedValue([
+      makeLog({
+        actor: { firstName: '=cmd|"/c calc"!A1', lastName: 'Evil', email: 'ana@x.com' },
+        entity: 'candidate, "VIP"',
+      }),
+    ]);
+
+    const result = await auditService.exportLogs('org-1', { format: 'csv' });
+    const [, row] = result.data.split('\n');
+
+    // Leading "=" is neutralized with a leading apostrophe before quoting.
+    expect(row).toContain('"\'=cmd|""/c calc""!A1 Evil"');
+    // Embedded quote/comma in entity is escaped (doubled quote) and stays inside
+    // one quoted CSV cell rather than splitting into extra columns.
+    expect(row).toContain('"candidate, ""VIP"""');
+  });
+
+  it('marks truncated and caps at EXPORT_LIMIT when the repository returns one extra row', async () => {
+    const rows = Array.from({ length: EXPORT_LIMIT + 1 }, (_, i) => makeLog({ id: `log-${i}`, entityId: `e${i}` }));
+    findForExportSpy.mockResolvedValue(rows);
+
+    const result = await auditService.exportLogs('org-1', { format: 'json' });
+
+    expect(result.count).toBe(EXPORT_LIMIT);
+    expect(result.truncated).toBe(true);
+    expect(JSON.parse(result.data)).toHaveLength(EXPORT_LIMIT);
+  });
+
+  it('does not mark truncated at exactly EXPORT_LIMIT rows', async () => {
+    const rows = Array.from({ length: EXPORT_LIMIT }, (_, i) => makeLog({ id: `log-${i}`, entityId: `e${i}` }));
+    findForExportSpy.mockResolvedValue(rows);
+
+    const result = await auditService.exportLogs('org-1', { format: 'json' });
+
+    expect(result.count).toBe(EXPORT_LIMIT);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Router — the RBAC gate change (audit:read → audit:export) is exercised
+// end-to-end through a real tRPC caller, not just at the buildAccessForUser
+// primitive (that primitive is already pinned by tests/access/hr-admin-matrix.test.ts).
+// ---------------------------------------------------------------------------
+describe('audit.exportLogs router (RBAC, behavioral)', () => {
+  const ORG_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+  async function makeCaller() {
+    const { createCallerFactory, router } = await import('../../packages/api/src/trpc');
+    const { auditRouter } = await import('../../packages/api/src/routers/audit');
+    const testRouter = router({ audit: auditRouter });
+    const callerFactory = createCallerFactory(testRouter);
+    return callerFactory({
+      user: {
+        id: 'user-1',
+        organizationId: ORG_ID,
+        roles: ['super_admin'],
+        isPlatformOwner: false,
+        impersonatorId: null,
+        email: 'admin@tims.co',
+        isActive: true,
+      },
+      headers: new Headers(),
+      supabaseAuth: null,
+      externalAuth: null,
+    } as never) as unknown as {
+      audit: {
+        exportLogs(input: { format: 'csv' | 'json' }): Promise<unknown>;
+      };
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auditLogCreateMock.mockResolvedValue({});
+  });
+
+  it('denies a caller lacking audit:export with FORBIDDEN', async () => {
+    buildAccessForUserMock.mockResolvedValue({ allowed: false });
+
+    const caller = await makeCaller();
+    await expect(caller.audit.exportLogs({ format: 'csv' })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('allows a caller with audit:export, calling the service and returning its result', async () => {
+    buildAccessForUserMock.mockResolvedValue({ allowed: true, scope: 'organization', roles: ['super_admin'] });
+    const exportLogsSpy = vi
+      .spyOn(auditService, 'exportLogs')
+      .mockResolvedValue({ data: 'header\n', count: 0, truncated: false, format: 'csv' });
+
+    try {
+      const caller = await makeCaller();
+      const result = await caller.audit.exportLogs({ format: 'csv' });
+
+      expect(exportLogsSpy).toHaveBeenCalledWith(ORG_ID, expect.objectContaining({ format: 'csv' }));
+      expect(result).toEqual({ data: 'header\n', count: 0, truncated: false, format: 'csv' });
+    } finally {
+      exportLogsSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a tenant-scoped audit-log export (issue #2), gated on `permissionProcedure('audit', 'export')` (super_admin only, per the existing access matrix)
- Repository -> service -> router clean-architecture split; explicit `select` (no `changes`/`metadata` columns exported); reuses the existing CSV-escaping helper (no CSV/formula injection)
- New org-admin page at `/settings/audit-log`, added to nav (was previously unreachable even for the one role that can use it)
- 17 new tests: tenant isolation, truncation at the 10k export cap, CSV vs JSON, RBAC gate

## Review pipeline
Went through an orchestrated build -> security review -> architecture review -> test-coverage review -> fix loop:
- Security review: **APPROVE**
- Architecture review: **APPROVE_WITH_FOLLOWUPS** (1 MUST_FIX — missing nav entry — fixed)
- Test review: **REQUEST_CHANGES** (3 MUST_FIX — no tests — fixed, 17 tests added)

`tsc --noEmit` clean on both `@tims/api` and web. Scoped vitest run: 4 files / 47 tests passing.

## Follow-ups filed separately (out of scope for this PR)
- #5 — pre-existing `trpc.user.list` missing explicit `select` (exposed by this page's new caller, not introduced by it)
- #6 — `audit.ts` router still has a few procedures importing `db` directly (pre-existing, not touched by this PR)

## Test plan
- [ ] Run full gate (`/gate`) before merge
- [ ] Manually verify export as super_admin in a real browser