### PR TITLE
fix(ci): resolve gitleaks license and missing pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # gitleaks/gitleaks-action@v3 requires a paid org license for org repos (gitleaks.io).
+      # Run the free OSS CLI directly instead — identical scan, no license needed.
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+      - name: Run gitleaks
+        run: gitleaks git --no-banner .
 
   # ========================================
   # Code Quality Gates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       # Run the free OSS CLI directly instead — identical scan, no license needed.
       - name: Install gitleaks
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz gitleaks
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Run gitleaks
         run: gitleaks git --no-banner .

--- a/.github/workflows/dotnet-platform.yml
+++ b/.github/workflows/dotnet-platform.yml
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 22


### PR DESCRIPTION
Fixes both CI failures seen on PRs #8/#9/#10: gitleaks-action needs a paid org license (swapped for the free CLI, same scan), and the table-ownership job never installed pnpm before setup-node tried to cache it.