### PR TITLE
chore(services): split pipeline/candidate service files under 300-line cap

### DIFF
--- a/packages/api/src/routers/candidate-portal.ts
+++ b/packages/api/src/routers/candidate-portal.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { router, candidateProcedure } from '../trpc';
 import { candidatePortalService } from '../services/candidate-portal.service';
 import { candidateAssessmentService } from '../services/candidate-assessment.service';
+import { candidateAssessmentLifecycleService } from '../services/candidate-assessment-lifecycle.service';
 import { submitAssessmentAnswersSchema } from '@tims/shared';
 
 // Authenticated candidate portal (Wave 1 Slice 2). The candidate is identified by
@@ -52,14 +53,14 @@ export const candidatePortalRouter = router({
   // The signed-in candidate's assessment assignments at this org.
   getMyAssessments: candidateProcedure
     .input(z.object({ orgSlug }))
-    .query(({ ctx, input }) => candidateAssessmentService.getMyAssessments(ctx.supabaseAuth.email, input.orgSlug)),
+    .query(({ ctx, input }) => candidateAssessmentLifecycleService.getMyAssessments(ctx.supabaseAuth.email, input.orgSlug)),
 
   // Accept the Habeas-Data consent and move an assignment into in_progress.
   // Idempotent if already in_progress.
   startAssessment: candidateProcedure
     .input(z.object({ orgSlug, assignmentId: z.string().uuid(), consentAccepted: z.boolean() }))
     .mutation(({ ctx, input }) =>
-      candidateAssessmentService.startAssessment(
+      candidateAssessmentLifecycleService.startAssessment(
         ctx.supabaseAuth.email,
         input.orgSlug,
         input.assignmentId,
@@ -73,7 +74,7 @@ export const candidatePortalRouter = router({
   getAssessmentQuestions: candidateProcedure
     .input(z.object({ orgSlug, assignmentId: z.string().uuid() }))
     .query(({ ctx, input }) =>
-      candidateAssessmentService.getAssessmentQuestions(ctx.supabaseAuth.email, input.orgSlug, input.assignmentId),
+      candidateAssessmentLifecycleService.getAssessmentQuestions(ctx.supabaseAuth.email, input.orgSlug, input.assignmentId),
     ),
 
   // Atomic: grades every answer, upserts the result, marks the assignment

--- a/packages/api/src/routers/candidate/documents.ts
+++ b/packages/api/src/routers/candidate/documents.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, permissionProcedure } from '../../trpc';
-import { candidateService } from '../../services/candidate.service';
+import { candidateDocumentsService } from '../../services/candidate-documents.service';
 import { candidateAiService } from '../../services/candidate-ai.service';
 import { assertScoped } from '../../access';
 
@@ -17,7 +17,7 @@ export const candidateDocumentsRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('candidate', input.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return candidateService.uploadDocument(
+      return candidateDocumentsService.uploadDocument(
         ctx.user.organizationId,
         input.candidateId,
         input.type,
@@ -29,10 +29,10 @@ export const candidateDocumentsRouter = router({
   deleteDocument: permissionProcedure('candidate', 'update')
     .input(z.object({ documentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const doc = await candidateService.getDocument(ctx.user.organizationId, input.documentId);
+      const doc = await candidateDocumentsService.getDocument(ctx.user.organizationId, input.documentId);
       if (!doc) throw new TRPCError({ code: 'NOT_FOUND', message: 'Documento no encontrado' });
       await assertScoped('candidate', doc.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return candidateService.deleteDocument(ctx.user.organizationId, input.documentId);
+      return candidateDocumentsService.deleteDocument(ctx.user.organizationId, input.documentId);
     }),
 
   // Parses CV TEXT the staff member pastes in, via the gated cv-parser agent.
@@ -54,7 +54,7 @@ export const candidateDocumentsRouter = router({
     .mutation(async ({ ctx, input }) => {
       await assertScoped('candidate', input.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
       if (input.documentId) {
-        const doc = await candidateService.getDocument(ctx.user.organizationId, input.documentId);
+        const doc = await candidateDocumentsService.getDocument(ctx.user.organizationId, input.documentId);
         if (!doc || doc.candidateId !== input.candidateId) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Documento no encontrado' });
         }

--- a/packages/api/src/routers/candidate/pool.ts
+++ b/packages/api/src/routers/candidate/pool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { candidateService } from '../../services/candidate.service';
+import { candidatePoolService } from '../../services/candidate-pool.service';
 import { scopeWhereFor, assertScoped } from '../../access';
 import { logPlatformExport } from '../../access/security-audit';
 
@@ -14,12 +14,12 @@ export const candidatePoolRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('candidate', input.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return candidateService.addToPool(ctx.user.organizationId, input.candidateId, input.poolType);
+      return candidatePoolService.addToPool(ctx.user.organizationId, input.candidateId, input.poolType);
     }),
 
   getPoolStats: permissionProcedure('candidate', 'read').query(async ({ ctx }) => {
     const scopeWhere = await scopeWhereFor('candidate', ctx.access, ctx.user.id);
-    return candidateService.getPoolStats(ctx.user.organizationId, scopeWhere);
+    return candidatePoolService.getPoolStats(ctx.user.organizationId, scopeWhere);
   }),
 
   export: permissionProcedure('candidate', 'read')
@@ -32,7 +32,7 @@ export const candidatePoolRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const scopeWhere = await scopeWhereFor('candidate', ctx.access, ctx.user.id);
-      const result = await candidateService.exportPool(ctx.user.organizationId, scopeWhere, {
+      const result = await candidatePoolService.exportPool(ctx.user.organizationId, scopeWhere, {
         poolType: input.poolType,
         tags: input.tags,
       });

--- a/packages/api/src/routers/candidate/tags.ts
+++ b/packages/api/src/routers/candidate/tags.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { candidateService } from '../../services/candidate.service';
+import { candidateTagsService } from '../../services/candidate-tags.service';
 import { scopeWhereFor, assertScoped } from '../../access';
 
 export const candidateTagsRouter = router({
@@ -12,14 +12,14 @@ export const candidateTagsRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       await assertScoped('candidate', input.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return candidateService.addTag(ctx.user.organizationId, input.candidateId, input.tag, input.source);
+      return candidateTagsService.addTag(ctx.user.organizationId, input.candidateId, input.tag, input.source);
     }),
 
   removeTag: permissionProcedure('candidate', 'update')
     .input(z.object({ candidateId: z.string().uuid(), tag: z.string().max(50) }))
     .mutation(async ({ ctx, input }) => {
       await assertScoped('candidate', input.candidateId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return candidateService.removeTag(ctx.user.organizationId, input.candidateId, input.tag);
+      return candidateTagsService.removeTag(ctx.user.organizationId, input.candidateId, input.tag);
     }),
 
   bulkTag: permissionProcedure('candidate', 'update')
@@ -30,6 +30,6 @@ export const candidateTagsRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       const scopeWhere = await scopeWhereFor('candidate', ctx.access, ctx.user.id);
-      return candidateService.bulkTag(ctx.user.organizationId, scopeWhere, input.candidateIds, input.tag, input.source);
+      return candidateTagsService.bulkTag(ctx.user.organizationId, scopeWhere, input.candidateIds, input.tag, input.source);
     }),
 });

--- a/packages/api/src/routers/pipeline/analytics.ts
+++ b/packages/api/src/routers/pipeline/analytics.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { pipelineService } from '../../services/pipeline.service';
+import { pipelineAnalyticsService } from '../../services/pipeline-analytics.service';
 import { assertScoped } from '../../access';
 
 export const pipelineAnalyticsRouter = router({
@@ -9,7 +9,7 @@ export const pipelineAnalyticsRouter = router({
     .input(z.object({ vacancyId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.vacancyId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return pipelineService.getSlaStatus(ctx.user.organizationId, input.vacancyId);
+      return pipelineAnalyticsService.getSlaStatus(ctx.user.organizationId, input.vacancyId);
     }),
 
   // getNextBestAction is per-application — probe the application first.
@@ -17,13 +17,13 @@ export const pipelineAnalyticsRouter = router({
     .input(z.object({ applicationId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await assertScoped('application', input.applicationId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return pipelineService.getNextBestAction(ctx.user.organizationId, input.applicationId);
+      return pipelineAnalyticsService.getNextBestAction(ctx.user.organizationId, input.applicationId);
     }),
 
   getFunnel: permissionProcedure('pipeline', 'read')
     .input(z.object({ vacancyId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.vacancyId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return pipelineService.getFunnel(ctx.user.organizationId, input.vacancyId);
+      return pipelineAnalyticsService.getFunnel(ctx.user.organizationId, input.vacancyId);
     }),
 });

--- a/packages/api/src/routers/pipeline/stages.ts
+++ b/packages/api/src/routers/pipeline/stages.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
 import { TRPCError } from '@trpc/server';
-import { pipelineService } from '../../services/pipeline.service';
+import { pipelineStagesService } from '../../services/pipeline-stages.service';
 import { assertScoped } from '../../access';
 
 const checklistItemSchema = z.object({
@@ -20,7 +20,7 @@ async function probeStageVacancy(
   access: Parameters<typeof assertScoped>[2],
   userId: string,
 ): Promise<void> {
-  const vacancyId = await pipelineService.getStageVacancyId(orgId, stageId);
+  const vacancyId = await pipelineStagesService.getStageVacancyId(orgId, stageId);
   if (!vacancyId) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
   }
@@ -32,7 +32,7 @@ export const pipelineStagesRouter = router({
     .input(z.object({ vacancyId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.vacancyId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return pipelineService.listStages(ctx.user.organizationId, input.vacancyId);
+      return pipelineStagesService.listStages(ctx.user.organizationId, input.vacancyId);
     }),
 
   createStage: permissionProcedure('pipeline', 'create')
@@ -46,7 +46,7 @@ export const pipelineStagesRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.vacancyId, ctx.access, ctx.user.id, ctx.user.organizationId);
-      return pipelineService.createStage(ctx.user.organizationId, input);
+      return pipelineStagesService.createStage(ctx.user.organizationId, input);
     }),
 
   // Fetch-then-probe: stageId → vacancyId → probe vacancy scope.
@@ -63,21 +63,21 @@ export const pipelineStagesRouter = router({
     .mutation(async ({ ctx, input }) => {
       await probeStageVacancy(ctx.user.organizationId, input.id, ctx.access, ctx.user.id);
       const { id, ...data } = input;
-      return pipelineService.updateStage(ctx.user.organizationId, id, data);
+      return pipelineStagesService.updateStage(ctx.user.organizationId, id, data);
     }),
 
   deleteStage: permissionProcedure('pipeline', 'delete')
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await probeStageVacancy(ctx.user.organizationId, input.id, ctx.access, ctx.user.id);
-      return pipelineService.deleteStage(ctx.user.organizationId, input.id);
+      return pipelineStagesService.deleteStage(ctx.user.organizationId, input.id);
     }),
 
   getStageChecklist: permissionProcedure('pipeline', 'read')
     .input(z.object({ stageId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await probeStageVacancy(ctx.user.organizationId, input.stageId, ctx.access, ctx.user.id);
-      return pipelineService.getStageChecklist(ctx.user.organizationId, input.stageId);
+      return pipelineStagesService.getStageChecklist(ctx.user.organizationId, input.stageId);
     }),
 
   updateChecklist: permissionProcedure('pipeline', 'update')
@@ -87,6 +87,6 @@ export const pipelineStagesRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       await probeStageVacancy(ctx.user.organizationId, input.stageId, ctx.access, ctx.user.id);
-      return pipelineService.updateChecklist(ctx.user.organizationId, input.stageId, input.checklist);
+      return pipelineStagesService.updateChecklist(ctx.user.organizationId, input.stageId, input.checklist);
     }),
 });

--- a/packages/api/src/routers/vacancy/stats.ts
+++ b/packages/api/src/routers/vacancy/stats.ts
@@ -5,7 +5,7 @@ import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { scopeWhereFor } from '../../access';
 import { cacheGet, cacheSet } from '../../lib/cache';
-import { pipelineService } from '../../services/pipeline.service';
+import { pipelineAnalyticsService } from '../../services/pipeline-analytics.service';
 
 export const vacancyStatsRouter = router({
   // 4.18 — Get vacancy stats (application counts by stage)
@@ -127,7 +127,7 @@ export const vacancyStatsRouter = router({
         db.vacancy.count({ where: { AND: [{ organizationId: orgId, status: 'published', deletedAt: null }, scopeWhere] } }),
         db.vacancy.count({ where: { AND: [{ organizationId: orgId, status: 'closed', deletedAt: null }, scopeWhere] } }),
         db.application.count({ where: { AND: [{ organizationId: orgId }, appScopeWhere] } }),
-        pipelineService.getOrgSlaOverdueCount(orgId, appScopeWhere),
+        pipelineAnalyticsService.getOrgSlaOverdueCount(orgId, appScopeWhere),
         db.vacancy.findMany({
           where: { AND: [{ organizationId: orgId, deletedAt: null }, scopeWhere] },
           orderBy: { createdAt: 'desc' },

--- a/packages/api/src/services/candidate-assessment-lifecycle.service.ts
+++ b/packages/api/src/services/candidate-assessment-lifecycle.service.ts
@@ -1,0 +1,137 @@
+import { TRPCError } from '@trpc/server';
+import { runWithTenant } from '@tims/db';
+import type { Prisma } from '@tims/db';
+import { candidateAssessmentRepo } from '../repositories/candidate-assessment.repository';
+import { candidatePortalRepo } from '../repositories/candidate-portal.repository';
+import { resolveOrg } from './candidate-portal.service';
+import type { ScoreBand } from '@tims/shared';
+
+// ---------------------------------------------------------------------------
+// Candidate Assessment Lifecycle Service — list/start/questions, no db imports.
+// The single-transaction submitAssessment write flow lives in
+// candidate-assessment.service.ts (split per CLAUDE.md's 300-line service cap
+// — these two files together back the same candidate-portal.ts router).
+// ---------------------------------------------------------------------------
+
+// Versioned Habeas-Data data-processing consent text identifier (non-repudiation
+// record). The actual legal text lives in the Slice 3 FE i18n bundle; the server
+// only needs a stable version id to prove which text the candidate agreed to.
+//
+// IMPORTANT: the copy in en.json/es.json's assessmentPlayer.consentBody and
+// assessmentPlayer.consentCheckboxLabel is currently PLACEHOLDER TEXT pending
+// legal review. This version id MUST be bumped (e.g. to 'habeas-data-assessment-v2')
+// whenever that copy is replaced with the real legal text — otherwise every
+// existing AssessmentConsent.textVersion='v1' record silently points at text that
+// no longer exists, undermining the audit trail this mechanism exists for.
+const HABEAS_DATA_CONSENT_VERSION = 'habeas-data-assessment-v1';
+
+export function isExpired(expiresAt: Date | null): boolean {
+  return expiresAt !== null && expiresAt.getTime() < Date.now();
+}
+
+// AssessmentResult.breakdown is a Prisma Json? column shaped { autoScored, pendingManual }
+// (see candidateAssessmentWriteRepo's upsertResultInTx caller in candidate-assessment.service.ts's
+// submitAssessment) — but Json has no compile-time shape, so this is a runtime guard, never a cast to `any`.
+function hasPendingManualReview(breakdown: Prisma.JsonValue | null | undefined): boolean {
+  if (breakdown === null || breakdown === undefined || typeof breakdown !== 'object' || Array.isArray(breakdown)) {
+    return false;
+  }
+  const pendingManual = (breakdown as Record<string, unknown>).pendingManual;
+  return Array.isArray(pendingManual) && pendingManual.length > 0;
+}
+
+interface AssignmentResultSummary {
+  normalizedScore: number | null;
+  percentile: number | null;
+  band: ScoreBand | null;
+  normSampleSize: number | null;
+  breakdown: Prisma.JsonValue | null;
+}
+
+// Strips the internal `breakdown` JSON and replaces it with a derived `hasPending` boolean —
+// the candidate-facing result screen (Wave 1.5a slice 3) must never receive raw breakdown JSON.
+function withPendingFlag<T extends { result: AssignmentResultSummary | null }>(assignment: T) {
+  const { result, ...rest } = assignment;
+  if (!result) return { ...rest, result: null };
+  const { breakdown, ...resultRest } = result;
+  return { ...rest, result: { ...resultRest, hasPending: hasPendingManualReview(breakdown) } };
+}
+
+const STARTABLE_STATUSES = new Set(['assigned', 'in_progress']);
+
+export const candidateAssessmentLifecycleService = {
+  // An authenticated email with no Candidate record at this org is a valid
+  // state (empty list, not an error) — matches getMyApplications.
+  async getMyAssessments(email: string, orgSlug: string) {
+    const org = await resolveOrg(orgSlug);
+    return runWithTenant(org.id, async () => {
+      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
+      if (!candidate) return [];
+      const assignments = await candidateAssessmentRepo.findAssignmentsForCandidate(org.id, candidate.id);
+      return assignments.map(withPendingFlag);
+    });
+  },
+
+  async startAssessment(
+    email: string,
+    orgSlug: string,
+    assignmentId: string,
+    consentAccepted: boolean,
+    ipAddress: string | null,
+    userAgent: string | null,
+  ) {
+    if (!consentAccepted) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'consent_required' });
+    }
+    const org = await resolveOrg(orgSlug);
+    return runWithTenant(org.id, async () => {
+      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
+      if (!candidate) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
+      }
+      const assignment = await candidateAssessmentRepo.findOwnedAssignment(org.id, candidate.id, assignmentId);
+      if (!assignment) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
+      }
+      if (isExpired(assignment.expiresAt)) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_expired' });
+      }
+      if (!STARTABLE_STATUSES.has(assignment.status)) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_not_startable' });
+      }
+
+      // Idempotent: record consent on first start only (upsertConsent no-ops on
+      // repeat), then (re)confirm in_progress either way.
+      await candidateAssessmentRepo.upsertConsent({
+        organizationId: org.id,
+        assignmentId,
+        candidateId: candidate.id,
+        textVersion: HABEAS_DATA_CONSENT_VERSION,
+        ipAddress,
+        userAgent,
+      });
+      return candidateAssessmentRepo.markStarted(assignmentId);
+    });
+  },
+
+  async getAssessmentQuestions(email: string, orgSlug: string, assignmentId: string) {
+    const org = await resolveOrg(orgSlug);
+    return runWithTenant(org.id, async () => {
+      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
+      if (!candidate) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
+      }
+      const assignment = await candidateAssessmentRepo.findOwnedAssignment(org.id, candidate.id, assignmentId);
+      if (!assignment) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
+      }
+      if (assignment.status !== 'in_progress') {
+        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_not_in_progress' });
+      }
+      if (isExpired(assignment.expiresAt)) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_expired' });
+      }
+      return candidateAssessmentRepo.findQuestionsForType(org.id, assignment.assessmentTypeId);
+    });
+  },
+};

--- a/packages/api/src/services/candidate-assessment.service.ts
+++ b/packages/api/src/services/candidate-assessment.service.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '@tims/db';
 import { candidateAssessmentRepo, candidateAssessmentWriteRepo } from '../repositories/candidate-assessment.repository';
 import { candidatePortalRepo } from '../repositories/candidate-portal.repository';
 import { resolveOrg } from './candidate-portal.service';
+import { isExpired } from './candidate-assessment-lifecycle.service';
 import {
   scoreChoice,
   computeResult,
@@ -13,128 +14,14 @@ import {
   type ScoreBand,
 } from '@tims/shared';
 
-// Versioned Habeas-Data data-processing consent text identifier (non-repudiation
-// record). The actual legal text lives in the Slice 3 FE i18n bundle; the server
-// only needs a stable version id to prove which text the candidate agreed to.
-//
-// IMPORTANT: the copy in en.json/es.json's assessmentPlayer.consentBody and
-// assessmentPlayer.consentCheckboxLabel is currently PLACEHOLDER TEXT pending
-// legal review. This version id MUST be bumped (e.g. to 'habeas-data-assessment-v2')
-// whenever that copy is replaced with the real legal text — otherwise every
-// existing AssessmentConsent.textVersion='v1' record silently points at text that
-// no longer exists, undermining the audit trail this mechanism exists for.
-const HABEAS_DATA_CONSENT_VERSION = 'habeas-data-assessment-v1';
-
-function isExpired(expiresAt: Date | null): boolean {
-  return expiresAt !== null && expiresAt.getTime() < Date.now();
-}
-
-// AssessmentResult.breakdown is a Prisma Json? column shaped { autoScored, pendingManual }
-// (see candidateAssessmentWriteRepo's upsertResultInTx caller in submitAssessment below) — but
-// Json has no compile-time shape, so this is a runtime guard, never a cast to `any`.
-function hasPendingManualReview(breakdown: Prisma.JsonValue | null | undefined): boolean {
-  if (breakdown === null || breakdown === undefined || typeof breakdown !== 'object' || Array.isArray(breakdown)) {
-    return false;
-  }
-  const pendingManual = (breakdown as Record<string, unknown>).pendingManual;
-  return Array.isArray(pendingManual) && pendingManual.length > 0;
-}
-
-interface AssignmentResultSummary {
-  normalizedScore: number | null;
-  percentile: number | null;
-  band: ScoreBand | null;
-  normSampleSize: number | null;
-  breakdown: Prisma.JsonValue | null;
-}
-
-// Strips the internal `breakdown` JSON and replaces it with a derived `hasPending` boolean —
-// the candidate-facing result screen (Wave 1.5a slice 3) must never receive raw breakdown JSON.
-function withPendingFlag<T extends { result: AssignmentResultSummary | null }>(assignment: T) {
-  const { result, ...rest } = assignment;
-  if (!result) return { ...rest, result: null };
-  const { breakdown, ...resultRest } = result;
-  return { ...rest, result: { ...resultRest, hasPending: hasPendingManualReview(breakdown) } };
-}
-
-const STARTABLE_STATUSES = new Set(['assigned', 'in_progress']);
+// ---------------------------------------------------------------------------
+// Candidate Assessment Service — the single-transaction submitAssessment write
+// flow. List/start/questions lifecycle now lives in
+// candidate-assessment-lifecycle.service.ts (split per CLAUDE.md's 300-line
+// service cap — this method can't be split further, it's one atomic tx).
+// ---------------------------------------------------------------------------
 
 export const candidateAssessmentService = {
-  // An authenticated email with no Candidate record at this org is a valid
-  // state (empty list, not an error) — matches getMyApplications.
-  async getMyAssessments(email: string, orgSlug: string) {
-    const org = await resolveOrg(orgSlug);
-    return runWithTenant(org.id, async () => {
-      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
-      if (!candidate) return [];
-      const assignments = await candidateAssessmentRepo.findAssignmentsForCandidate(org.id, candidate.id);
-      return assignments.map(withPendingFlag);
-    });
-  },
-
-  async startAssessment(
-    email: string,
-    orgSlug: string,
-    assignmentId: string,
-    consentAccepted: boolean,
-    ipAddress: string | null,
-    userAgent: string | null,
-  ) {
-    if (!consentAccepted) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'consent_required' });
-    }
-    const org = await resolveOrg(orgSlug);
-    return runWithTenant(org.id, async () => {
-      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
-      if (!candidate) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
-      }
-      const assignment = await candidateAssessmentRepo.findOwnedAssignment(org.id, candidate.id, assignmentId);
-      if (!assignment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
-      }
-      if (isExpired(assignment.expiresAt)) {
-        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_expired' });
-      }
-      if (!STARTABLE_STATUSES.has(assignment.status)) {
-        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_not_startable' });
-      }
-
-      // Idempotent: record consent on first start only (upsertConsent no-ops on
-      // repeat), then (re)confirm in_progress either way.
-      await candidateAssessmentRepo.upsertConsent({
-        organizationId: org.id,
-        assignmentId,
-        candidateId: candidate.id,
-        textVersion: HABEAS_DATA_CONSENT_VERSION,
-        ipAddress,
-        userAgent,
-      });
-      return candidateAssessmentRepo.markStarted(assignmentId);
-    });
-  },
-
-  async getAssessmentQuestions(email: string, orgSlug: string, assignmentId: string) {
-    const org = await resolveOrg(orgSlug);
-    return runWithTenant(org.id, async () => {
-      const candidate = await candidatePortalRepo.findActiveCandidate(org.id, email);
-      if (!candidate) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
-      }
-      const assignment = await candidateAssessmentRepo.findOwnedAssignment(org.id, candidate.id, assignmentId);
-      if (!assignment) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Asignacion no encontrada' });
-      }
-      if (assignment.status !== 'in_progress') {
-        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_not_in_progress' });
-      }
-      if (isExpired(assignment.expiresAt)) {
-        throw new TRPCError({ code: 'CONFLICT', message: 'assignment_expired' });
-      }
-      return candidateAssessmentRepo.findQuestionsForType(org.id, assignment.assessmentTypeId);
-    });
-  },
-
   async submitAssessment(email: string, orgSlug: string, assignmentId: string, answers: AnswerInput[]) {
     const org = await resolveOrg(orgSlug);
     const candidate = await runWithTenant(org.id, () => candidatePortalRepo.findActiveCandidate(org.id, email));

--- a/packages/api/src/services/candidate-documents.service.ts
+++ b/packages/api/src/services/candidate-documents.service.ts
@@ -1,0 +1,37 @@
+import { TRPCError } from '@trpc/server';
+import { candidateRepository } from '../repositories/candidate.repository';
+import { candidateService } from './candidate.service';
+
+// ---------------------------------------------------------------------------
+// Candidate Documents Service — document CRUD, no db imports.
+// Split from candidate.service.ts (CLAUDE.md 300-line service cap).
+// ---------------------------------------------------------------------------
+
+export const candidateDocumentsService = {
+  // This staff-side upload path is still a mock (fabricates fileUrl, never accepts real
+  // bytes) — unlike the public apply flow's real S3 upload (portalApplicationService,
+  // packages/api/src/routers/portal.ts), which is out of scope for this staff path.
+  async uploadDocument(orgId: string, candidateId: string, type: string, fileName: string, fileSize?: number) {
+    await candidateService.verifyExists(orgId, candidateId);
+    const mockUrl = `https://storage.tims.app/${orgId}/${candidateId}/${fileName}`;
+    const doc = await candidateRepository.createDocument(orgId, {
+      candidateId,
+      type,
+      fileName,
+      fileUrl: mockUrl,
+      fileSize,
+    });
+    return { document: doc, uploadUrl: mockUrl };
+  },
+
+  async getDocument(orgId: string, documentId: string) {
+    return candidateRepository.findDocument(orgId, documentId);
+  },
+
+  async deleteDocument(orgId: string, documentId: string) {
+    const doc = await candidateRepository.findDocument(orgId, documentId);
+    if (!doc) throw new TRPCError({ code: 'NOT_FOUND', message: 'Documento no encontrado' });
+    await candidateRepository.deleteDocument(documentId);
+    return { success: true };
+  },
+};

--- a/packages/api/src/services/candidate-pool.service.ts
+++ b/packages/api/src/services/candidate-pool.service.ts
@@ -1,0 +1,67 @@
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@tims/db';
+import { csvRow } from '@tims/shared';
+import { candidateRepository } from '../repositories/candidate.repository';
+
+// ---------------------------------------------------------------------------
+// Candidate Pool Service — pool membership + CSV export, no db imports.
+// Split from candidate.service.ts (CLAUDE.md 300-line service cap).
+// ---------------------------------------------------------------------------
+
+export const candidatePoolService = {
+  async addToPool(orgId: string, candidateId: string, poolType: string) {
+    const existing = await candidateRepository.exists(orgId, candidateId);
+    if (!existing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Candidato no encontrado' });
+    return candidateRepository.updatePool(candidateId, poolType);
+  },
+
+  async getPoolStats(orgId: string, scopeWhere: Prisma.CandidateWhereInput) {
+    const stats = await candidateRepository.getPoolStats(orgId, scopeWhere);
+    const total = stats.reduce((sum, s) => sum + s._count.id, 0);
+    return { total, byPool: stats.map((s) => ({ poolType: s.poolType, count: s._count.id })) };
+  },
+
+  async exportPool(
+    orgId: string,
+    scopeWhere: Prisma.CandidateWhereInput,
+    input: { poolType?: string; tags?: string[] },
+  ) {
+    const LIMIT = 5000;
+    const rows = await candidateRepository.findForExport(orgId, scopeWhere, input, LIMIT);
+    const truncated = rows.length > LIMIT;
+    const page = truncated ? rows.slice(0, LIMIT) : rows;
+
+    const header = csvRow([
+      'First Name',
+      'Last Name',
+      'Email',
+      'Phone',
+      'Source',
+      'Pool Type',
+      'Current Title',
+      'Current Company',
+      'Years Experience',
+      'Location',
+      'Tags',
+      'Created At',
+    ]);
+    const lines = page.map((c) =>
+      csvRow([
+        c.firstName,
+        c.lastName,
+        c.email,
+        c.phone,
+        c.source,
+        c.poolType,
+        c.currentTitle,
+        c.currentCompany,
+        c.yearsExperience == null ? '' : String(c.yearsExperience),
+        c.location,
+        c.tags.map((t) => t.tag).join('; '),
+        c.createdAt.toISOString(),
+      ]),
+    );
+
+    return { csv: [header, ...lines].join('\n'), count: page.length, truncated };
+  },
+};

--- a/packages/api/src/services/candidate-tags.service.ts
+++ b/packages/api/src/services/candidate-tags.service.ts
@@ -1,0 +1,40 @@
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@tims/db';
+import { candidateRepository } from '../repositories/candidate.repository';
+
+// ---------------------------------------------------------------------------
+// Candidate Tags Service — tag CRUD + bulk tagging, no db imports.
+// Split from candidate.service.ts (CLAUDE.md 300-line service cap).
+// ---------------------------------------------------------------------------
+
+export const candidateTagsService = {
+  async addTag(orgId: string, candidateId: string, tag: string, source: string) {
+    return candidateRepository.createTag(orgId, { candidateId, tag, source });
+  },
+
+  async removeTag(orgId: string, candidateId: string, tag: string) {
+    const existing = await candidateRepository.findTag(orgId, candidateId, tag);
+    if (!existing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Tag no encontrado' });
+    await candidateRepository.deleteTag(existing.id);
+    return { success: true };
+  },
+
+  async bulkTag(
+    orgId: string,
+    scopeWhere: Prisma.CandidateWhereInput,
+    candidateIds: string[],
+    tag: string,
+    source: string,
+  ) {
+    const uniqueIds = [...new Set(candidateIds)];
+    const count = await candidateRepository.countCandidatesInScope(orgId, uniqueIds, scopeWhere);
+    if (count !== uniqueIds.length) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Candidato no encontrado' });
+    }
+
+    const result = await candidateRepository.bulkCreateTags(
+      uniqueIds.map((candidateId) => ({ organizationId: orgId, candidateId, tag, source })),
+    );
+    return { tagged: result.count };
+  },
+};

--- a/packages/api/src/services/candidate.service.ts
+++ b/packages/api/src/services/candidate.service.ts
@@ -1,11 +1,12 @@
 import { TRPCError } from '@trpc/server';
 import type { Prisma } from '@tims/db';
-import { csvRow } from '@tims/shared';
 import { candidateRepository } from '../repositories/candidate.repository';
 import { candidateAiService } from './candidate-ai.service';
 
 // ---------------------------------------------------------------------------
-// Candidate Service — business logic only, no db imports
+// Candidate Service — business logic only, no db imports.
+// Tag CRUD lives in candidate-tags.service.ts; pool membership + CSV export in
+// candidate-pool.service.ts (split per CLAUDE.md's 300-line service cap).
 // ---------------------------------------------------------------------------
 
 export const candidateService = {
@@ -255,124 +256,11 @@ export const candidateService = {
     return candidateRepository.getAfterMerge(primaryId);
   },
 
-  // Documents
-  // This staff-side upload path is still a mock (fabricates fileUrl, never accepts real
-  // bytes) — unlike the public apply flow's real S3 upload (portalApplicationService,
-  // packages/api/src/routers/portal.ts), which is out of scope for this staff path.
-  async uploadDocument(orgId: string, candidateId: string, type: string, fileName: string, fileSize?: number) {
-    await candidateService.verifyExists(orgId, candidateId);
-    const mockUrl = `https://storage.tims.app/${orgId}/${candidateId}/${fileName}`;
-    const doc = await candidateRepository.createDocument(orgId, {
-      candidateId,
-      type,
-      fileName,
-      fileUrl: mockUrl,
-      fileSize,
-    });
-    return { document: doc, uploadUrl: mockUrl };
-  },
-
-  async getDocument(orgId: string, documentId: string) {
-    return candidateRepository.findDocument(orgId, documentId);
-  },
-
-  async deleteDocument(orgId: string, documentId: string) {
-    const doc = await candidateRepository.findDocument(orgId, documentId);
-    if (!doc) throw new TRPCError({ code: 'NOT_FOUND', message: 'Documento no encontrado' });
-    await candidateRepository.deleteDocument(documentId);
-    return { success: true };
-  },
-
+  // Documents now live in candidate-documents.service.ts.
   // CV parsing now lives in candidate-ai.service.ts (parseCV) — it runs behind
   // the gated @tims/ai cv-parser agent and operates on CV text.
-
-  // Tags
-  async addTag(orgId: string, candidateId: string, tag: string, source: string) {
-    return candidateRepository.createTag(orgId, { candidateId, tag, source });
-  },
-
-  async removeTag(orgId: string, candidateId: string, tag: string) {
-    const existing = await candidateRepository.findTag(orgId, candidateId, tag);
-    if (!existing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Tag no encontrado' });
-    await candidateRepository.deleteTag(existing.id);
-    return { success: true };
-  },
-
-  async bulkTag(
-    orgId: string,
-    scopeWhere: Prisma.CandidateWhereInput,
-    candidateIds: string[],
-    tag: string,
-    source: string,
-  ) {
-    const uniqueIds = [...new Set(candidateIds)];
-    const count = await candidateRepository.countCandidatesInScope(orgId, uniqueIds, scopeWhere);
-    if (count !== uniqueIds.length) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Candidato no encontrado' });
-    }
-
-    const result = await candidateRepository.bulkCreateTags(
-      uniqueIds.map((candidateId) => ({ organizationId: orgId, candidateId, tag, source })),
-    );
-    return { tagged: result.count };
-  },
-
-  // Pool
-  async addToPool(orgId: string, candidateId: string, poolType: string) {
-    const existing = await candidateRepository.exists(orgId, candidateId);
-    if (!existing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Candidato no encontrado' });
-    return candidateRepository.updatePool(candidateId, poolType);
-  },
-
-  async getPoolStats(orgId: string, scopeWhere: Prisma.CandidateWhereInput) {
-    const stats = await candidateRepository.getPoolStats(orgId, scopeWhere);
-    const total = stats.reduce((sum, s) => sum + s._count.id, 0);
-    return { total, byPool: stats.map((s) => ({ poolType: s.poolType, count: s._count.id })) };
-  },
-
-  async exportPool(
-    orgId: string,
-    scopeWhere: Prisma.CandidateWhereInput,
-    input: { poolType?: string; tags?: string[] },
-  ) {
-    const LIMIT = 5000;
-    const rows = await candidateRepository.findForExport(orgId, scopeWhere, input, LIMIT);
-    const truncated = rows.length > LIMIT;
-    const page = truncated ? rows.slice(0, LIMIT) : rows;
-
-    const header = csvRow([
-      'First Name',
-      'Last Name',
-      'Email',
-      'Phone',
-      'Source',
-      'Pool Type',
-      'Current Title',
-      'Current Company',
-      'Years Experience',
-      'Location',
-      'Tags',
-      'Created At',
-    ]);
-    const lines = page.map((c) =>
-      csvRow([
-        c.firstName,
-        c.lastName,
-        c.email,
-        c.phone,
-        c.source,
-        c.poolType,
-        c.currentTitle,
-        c.currentCompany,
-        c.yearsExperience == null ? '' : String(c.yearsExperience),
-        c.location,
-        c.tags.map((t) => t.tag).join('; '),
-        c.createdAt.toISOString(),
-      ]),
-    );
-
-    return { csv: [header, ...lines].join('\n'), count: page.length, truncated };
-  },
+  // Tag CRUD/bulk-tag now lives in candidate-tags.service.ts.
+  // Pool membership + CSV export now lives in candidate-pool.service.ts.
 
   // Recommendations — real Bedrock-backed candidate<->vacancy matching via the
   // gated candidate-matcher agent (candidate-ai.service.ts keeps AI/PII concerns

--- a/packages/api/src/services/pipeline-analytics.service.ts
+++ b/packages/api/src/services/pipeline-analytics.service.ts
@@ -1,0 +1,119 @@
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@tims/db';
+import { suggestNextBestAction } from '@tims/ai';
+import { pipelineRepository } from '../repositories/pipeline.repository';
+
+// ---------------------------------------------------------------------------
+// Pipeline Analytics Service — SLA/funnel/next-best-action, no db imports.
+// Split from pipeline.service.ts (CLAUDE.md 300-line service cap).
+// ---------------------------------------------------------------------------
+
+export const pipelineAnalyticsService = {
+  // Org-wide SLA-overdue count (dashboard KPI strip). scopeWhere is computed
+  // in the router (access machinery is not imported in services) and is
+  // REQUIRED: a defaulted fragment would fail open, same as bulkMove in
+  // pipeline.service.ts.
+  async getOrgSlaOverdueCount(orgId: string, appScopeWhere: Prisma.ApplicationWhereInput) {
+    const applications = await pipelineRepository.getActiveApplicationsForOrgSla(orgId, appScopeWhere);
+    const now = Date.now();
+
+    return applications.filter((app) => {
+      const slaHours = app.currentStage.slaHours;
+      if (slaHours == null) return false;
+      const enteredStageAt = app.movements[0]?.movedAt ?? app.appliedAt;
+      const hoursInStage = (now - enteredStageAt.getTime()) / (1000 * 60 * 60);
+      return hoursInStage > slaHours;
+    }).length;
+  },
+
+  async getSlaStatus(orgId: string, vacancyId: string) {
+    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
+    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
+
+    const stages = await pipelineRepository.getStagesForVacancy(vacancyId);
+    const applications = await pipelineRepository.getActiveApplicationsWithMovements(vacancyId);
+    const now = new Date();
+
+    const items = applications.map((app) => {
+      const stage = stages.find((s) => s.id === app.currentStageId);
+      const enteredStageAt = app.movements[0]?.movedAt ?? app.appliedAt;
+      // hoursInStage is floored for display (e.g. "8h in stage"); isOverdue
+      // must compare against the PRECISE elapsed time so a sub-hour SLA
+      // breach (e.g. 8.5h against an 8h SLA) is caught immediately instead
+      // of only after the floored value ticks over to a full extra hour.
+      const preciseHoursInStage = (now.getTime() - enteredStageAt.getTime()) / (1000 * 60 * 60);
+      const hoursInStage = Math.floor(preciseHoursInStage);
+      const isOverdue = stage?.slaHours != null && preciseHoursInStage > stage.slaHours;
+
+      return {
+        applicationId: app.id,
+        candidateId: app.candidate.id,
+        candidateName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+        stageId: app.currentStageId,
+        stageName: stage?.name ?? 'Desconocida',
+        enteredStageAt,
+        hoursInStage,
+        slaHours: stage?.slaHours ?? null,
+        isOverdue,
+      };
+    });
+
+    return {
+      vacancyId,
+      totalActive: items.length,
+      overdueCount: items.filter((s) => s.isOverdue).length,
+      items,
+    };
+  },
+
+  // Next best action (Bedrock-backed via the 'pipeline-optimizer' agent).
+  async getNextBestAction(orgId: string, applicationId: string) {
+    const app = await pipelineRepository.getApplicationForAction(orgId, applicationId);
+    if (!app) throw new TRPCError({ code: 'NOT_FOUND', message: 'Aplicacion no encontrada' });
+
+    const candidateName = `${app.candidate.firstName} ${app.candidate.lastName}`;
+    const { result, model } = await suggestNextBestAction(orgId, {
+      candidateName,
+      currentStageName: app.currentStage.name,
+      currentStageOrder: app.currentStage.order,
+    });
+
+    return {
+      applicationId,
+      candidateName,
+      currentStage: app.currentStage.name,
+      recommendation: result.recommendation,
+      confidence: result.confidence,
+      suggestedActions: result.suggestedActions,
+      model,
+    };
+  },
+
+  async getFunnel(orgId: string, vacancyId: string) {
+    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
+    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
+
+    const stages = await pipelineRepository.getStagesForVacancy(vacancyId);
+    const funnelCounts = await pipelineRepository.getFunnelCounts(vacancyId, stages);
+    const { total: totalApplications, rejected: rejectedCount } =
+      await pipelineRepository.getApplicationCounts(vacancyId);
+
+    const funnel = stages.map((stage, idx) => {
+      const counts = funnelCounts.find((f) => f.stageId === stage.id);
+      const prevCount = idx === 0 ? totalApplications : (funnelCounts[idx - 1]?.everReachedCount ?? 0);
+      const everReached = counts?.everReachedCount ?? 0;
+      const conversionRate = prevCount > 0 ? Math.round((everReached / prevCount) * 100) : 0;
+
+      return {
+        stageId: stage.id,
+        stageName: stage.name,
+        order: stage.order,
+        currentCount: counts?.currentCount ?? 0,
+        everReachedCount: everReached,
+        conversionRate,
+      };
+    });
+
+    return { vacancyId, totalApplications, rejectedCount, funnel };
+  },
+};

--- a/packages/api/src/services/pipeline-stages.service.ts
+++ b/packages/api/src/services/pipeline-stages.service.ts
@@ -1,0 +1,74 @@
+import { TRPCError } from '@trpc/server';
+import { pipelineRepository } from '../repositories/pipeline.repository';
+
+// ---------------------------------------------------------------------------
+// Pipeline Stages Service — stage config business logic, no db imports.
+// Split from pipeline.service.ts (CLAUDE.md 300-line service cap).
+// ---------------------------------------------------------------------------
+
+export const pipelineStagesService = {
+  async listStages(orgId: string, vacancyId: string) {
+    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
+    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
+    return pipelineRepository.listStages(orgId, vacancyId);
+  },
+
+  async createStage(
+    orgId: string,
+    input: {
+      vacancyId: string;
+      name: string;
+      order: number;
+      slaHours?: number;
+      checklist?: unknown;
+      isDefault: boolean;
+    },
+  ) {
+    const vacancy = await pipelineRepository.vacancyExists(orgId, input.vacancyId);
+    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
+    return pipelineRepository.createStage(orgId, input);
+  },
+
+  // Thin lookup used by routers to get a stage's parent vacancyId so they can
+  // probe 'vacancy' scope before delegating the full mutation. Returns null when
+  // the stage does not exist or does not belong to the org.
+  async getStageVacancyId(orgId: string, stageId: string): Promise<string | null> {
+    const stage = await pipelineRepository.findStage(orgId, stageId);
+    return stage?.vacancyId ?? null;
+  },
+
+  async updateStage(orgId: string, stageId: string, data: Record<string, unknown>) {
+    const stage = await pipelineRepository.findStage(orgId, stageId);
+    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
+    return pipelineRepository.updateStage(stageId, data);
+  },
+
+  async deleteStage(orgId: string, stageId: string) {
+    const stage = await pipelineRepository.getStageWithApplicationCount(orgId, stageId);
+    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
+    if (stage._count.applications > 0) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'No se puede eliminar una etapa con candidatos. Muevelos primero.',
+      });
+    }
+    await pipelineRepository.deleteStage(stageId);
+    return { success: true };
+  },
+
+  async getStageChecklist(orgId: string, stageId: string) {
+    const stage = await pipelineRepository.getStageChecklist(orgId, stageId);
+    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
+    return {
+      stageId: stage.id,
+      stageName: stage.name,
+      checklist: (stage.checklist as Array<Record<string, unknown>>) ?? [],
+    };
+  },
+
+  async updateChecklist(orgId: string, stageId: string, checklist: unknown) {
+    const stage = await pipelineRepository.findStage(orgId, stageId);
+    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
+    return pipelineRepository.updateChecklist(stageId, checklist);
+  },
+};

--- a/packages/api/src/services/pipeline.service.ts
+++ b/packages/api/src/services/pipeline.service.ts
@@ -1,10 +1,11 @@
 import { TRPCError } from '@trpc/server';
 import type { Prisma } from '@tims/db';
-import { suggestNextBestAction } from '@tims/ai';
 import { pipelineRepository } from '../repositories/pipeline.repository';
 
 // ---------------------------------------------------------------------------
-// Pipeline Service — business logic, no db imports
+// Pipeline Service — board/movement business logic, no db imports.
+// Stage config lives in pipeline-stages.service.ts; analytics in
+// pipeline-analytics.service.ts (split per CLAUDE.md's 300-line service cap).
 // ---------------------------------------------------------------------------
 
 // Shape of a PipelineStage.checklist entry (matches checklistItemSchema in
@@ -154,72 +155,6 @@ export const pipelineService = {
     return pipelineRepository.getMovementHistory(applicationId);
   },
 
-  // Stages
-  async listStages(orgId: string, vacancyId: string) {
-    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
-    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
-    return pipelineRepository.listStages(orgId, vacancyId);
-  },
-
-  async createStage(
-    orgId: string,
-    input: {
-      vacancyId: string;
-      name: string;
-      order: number;
-      slaHours?: number;
-      checklist?: unknown;
-      isDefault: boolean;
-    },
-  ) {
-    const vacancy = await pipelineRepository.vacancyExists(orgId, input.vacancyId);
-    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
-    return pipelineRepository.createStage(orgId, input);
-  },
-
-  // Thin lookup used by routers to get a stage's parent vacancyId so they can
-  // probe 'vacancy' scope before delegating the full mutation. Returns null when
-  // the stage does not exist or does not belong to the org.
-  async getStageVacancyId(orgId: string, stageId: string): Promise<string | null> {
-    const stage = await pipelineRepository.findStage(orgId, stageId);
-    return stage?.vacancyId ?? null;
-  },
-
-  async updateStage(orgId: string, stageId: string, data: Record<string, unknown>) {
-    const stage = await pipelineRepository.findStage(orgId, stageId);
-    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
-    return pipelineRepository.updateStage(stageId, data);
-  },
-
-  async deleteStage(orgId: string, stageId: string) {
-    const stage = await pipelineRepository.getStageWithApplicationCount(orgId, stageId);
-    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
-    if (stage._count.applications > 0) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'No se puede eliminar una etapa con candidatos. Muevelos primero.',
-      });
-    }
-    await pipelineRepository.deleteStage(stageId);
-    return { success: true };
-  },
-
-  async getStageChecklist(orgId: string, stageId: string) {
-    const stage = await pipelineRepository.getStageChecklist(orgId, stageId);
-    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
-    return {
-      stageId: stage.id,
-      stageName: stage.name,
-      checklist: (stage.checklist as Array<Record<string, unknown>>) ?? [],
-    };
-  },
-
-  async updateChecklist(orgId: string, stageId: string, checklist: unknown) {
-    const stage = await pipelineRepository.findStage(orgId, stageId);
-    if (!stage) throw new TRPCError({ code: 'NOT_FOUND', message: 'Etapa no encontrada' });
-    return pipelineRepository.updateChecklist(stageId, checklist);
-  },
-
   // Per-application checklist item toggle. SINGLE atomic UPDATE (Postgres
   // jsonb_set) — no read-merge-write. Only the [stageId][itemKey] entry is
   // touched at the DB level, so two toggles for DIFFERENT items on the SAME
@@ -241,114 +176,5 @@ export const pipelineService = {
     const updated = await pipelineRepository.setChecklistItem(orgId, applicationId, stageId, itemKey, entry);
     if (!updated) throw new TRPCError({ code: 'NOT_FOUND', message: 'Aplicacion no encontrada' });
     return updated;
-  },
-
-  // Analytics — SLA
-  // Org-wide SLA-overdue count (dashboard KPI strip). scopeWhere is computed
-  // in the router (access machinery is not imported in services) and is
-  // REQUIRED: a defaulted fragment would fail open, same as bulkMove above.
-  async getOrgSlaOverdueCount(orgId: string, appScopeWhere: Prisma.ApplicationWhereInput) {
-    const applications = await pipelineRepository.getActiveApplicationsForOrgSla(orgId, appScopeWhere);
-    const now = Date.now();
-
-    return applications.filter((app) => {
-      const slaHours = app.currentStage.slaHours;
-      if (slaHours == null) return false;
-      const enteredStageAt = app.movements[0]?.movedAt ?? app.appliedAt;
-      const hoursInStage = (now - enteredStageAt.getTime()) / (1000 * 60 * 60);
-      return hoursInStage > slaHours;
-    }).length;
-  },
-
-  async getSlaStatus(orgId: string, vacancyId: string) {
-    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
-    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
-
-    const stages = await pipelineRepository.getStagesForVacancy(vacancyId);
-    const applications = await pipelineRepository.getActiveApplicationsWithMovements(vacancyId);
-    const now = new Date();
-
-    const items = applications.map((app) => {
-      const stage = stages.find((s) => s.id === app.currentStageId);
-      const enteredStageAt = app.movements[0]?.movedAt ?? app.appliedAt;
-      // hoursInStage is floored for display (e.g. "8h in stage"); isOverdue
-      // must compare against the PRECISE elapsed time so a sub-hour SLA
-      // breach (e.g. 8.5h against an 8h SLA) is caught immediately instead
-      // of only after the floored value ticks over to a full extra hour.
-      const preciseHoursInStage = (now.getTime() - enteredStageAt.getTime()) / (1000 * 60 * 60);
-      const hoursInStage = Math.floor(preciseHoursInStage);
-      const isOverdue = stage?.slaHours != null && preciseHoursInStage > stage.slaHours;
-
-      return {
-        applicationId: app.id,
-        candidateId: app.candidate.id,
-        candidateName: `${app.candidate.firstName} ${app.candidate.lastName}`,
-        stageId: app.currentStageId,
-        stageName: stage?.name ?? 'Desconocida',
-        enteredStageAt,
-        hoursInStage,
-        slaHours: stage?.slaHours ?? null,
-        isOverdue,
-      };
-    });
-
-    return {
-      vacancyId,
-      totalActive: items.length,
-      overdueCount: items.filter((s) => s.isOverdue).length,
-      items,
-    };
-  },
-
-  // Analytics — Next best action (Bedrock-backed via the 'pipeline-optimizer' agent).
-  async getNextBestAction(orgId: string, applicationId: string) {
-    const app = await pipelineRepository.getApplicationForAction(orgId, applicationId);
-    if (!app) throw new TRPCError({ code: 'NOT_FOUND', message: 'Aplicacion no encontrada' });
-
-    const candidateName = `${app.candidate.firstName} ${app.candidate.lastName}`;
-    const { result, model } = await suggestNextBestAction(orgId, {
-      candidateName,
-      currentStageName: app.currentStage.name,
-      currentStageOrder: app.currentStage.order,
-    });
-
-    return {
-      applicationId,
-      candidateName,
-      currentStage: app.currentStage.name,
-      recommendation: result.recommendation,
-      confidence: result.confidence,
-      suggestedActions: result.suggestedActions,
-      model,
-    };
-  },
-
-  // Analytics — Funnel
-  async getFunnel(orgId: string, vacancyId: string) {
-    const vacancy = await pipelineRepository.vacancyExists(orgId, vacancyId);
-    if (!vacancy) throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
-
-    const stages = await pipelineRepository.getStagesForVacancy(vacancyId);
-    const funnelCounts = await pipelineRepository.getFunnelCounts(vacancyId, stages);
-    const { total: totalApplications, rejected: rejectedCount } =
-      await pipelineRepository.getApplicationCounts(vacancyId);
-
-    const funnel = stages.map((stage, idx) => {
-      const counts = funnelCounts.find((f) => f.stageId === stage.id);
-      const prevCount = idx === 0 ? totalApplications : (funnelCounts[idx - 1]?.everReachedCount ?? 0);
-      const everReached = counts?.everReachedCount ?? 0;
-      const conversionRate = prevCount > 0 ? Math.round((everReached / prevCount) * 100) : 0;
-
-      return {
-        stageId: stage.id,
-        stageName: stage.name,
-        order: stage.order,
-        currentCount: counts?.currentCount ?? 0,
-        everReachedCount: everReached,
-        conversionRate,
-      };
-    });
-
-    return { vacancyId, totalApplications, rejectedCount, funnel };
   },
 };

--- a/tests/access/scope-wiring-candidate.test.ts
+++ b/tests/access/scope-wiring-candidate.test.ts
@@ -39,7 +39,7 @@ describe('candidate module scope wiring', () => {
   });
 
   it('bulkTag dedupes candidateIds before the scoped count-check', () => {
-    const src = read('packages/api/src/services/candidate.service.ts');
+    const src = read('packages/api/src/services/candidate-tags.service.ts');
     const block = src.slice(src.indexOf('bulkTag'));
     expect(block).toMatch(/new Set\(/);
   });

--- a/tests/assessment/candidate-assessment-lifecycle-service.test.ts
+++ b/tests/assessment/candidate-assessment-lifecycle-service.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../packages/api/src/repositories/candidate-assessment.repository', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../packages/api/src/repositories/candidate-assessment.repository')
+  >('../../packages/api/src/repositories/candidate-assessment.repository');
+  return {
+    ...actual,
+    candidateAssessmentRepo: {
+      findAssignmentsForCandidate: vi.fn(),
+      findOwnedAssignment: vi.fn(),
+      findQuestionsForType: vi.fn(),
+      upsertConsent: vi.fn(),
+      markStarted: vi.fn(),
+    },
+  };
+});
+vi.mock('../../packages/api/src/repositories/candidate-portal.repository', () => ({
+  candidatePortalRepo: {
+    findOrgBySlug: vi.fn(),
+    findActiveCandidate: vi.fn(),
+  },
+}));
+vi.mock('@tims/db', () => ({
+  runWithTenant: (_o: string, f: () => unknown) => f(),
+}));
+
+import { candidateAssessmentLifecycleService } from '../../packages/api/src/services/candidate-assessment-lifecycle.service';
+import { candidateAssessmentRepo } from '../../packages/api/src/repositories/candidate-assessment.repository';
+import { candidatePortalRepo } from '../../packages/api/src/repositories/candidate-portal.repository';
+
+const ORG = { id: 'org-1', name: 'TIMS', isActive: true };
+const EMAIL = 'candidate@example.com';
+const SLUG = 'tims';
+const ASSIGNMENT_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(candidatePortalRepo.findOrgBySlug).mockResolvedValue(ORG as never);
+});
+
+describe('candidateAssessmentLifecycleService.getMyAssessments', () => {
+  it('throws NOT_FOUND for a missing/inactive org', async () => {
+    vi.mocked(candidatePortalRepo.findOrgBySlug).mockResolvedValue(null);
+    await expect(candidateAssessmentLifecycleService.getMyAssessments(EMAIL, SLUG)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('returns an empty list when the session email has no candidate at this org', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue(null);
+    expect(await candidateAssessmentLifecycleService.getMyAssessments(EMAIL, SLUG)).toEqual([]);
+    expect(candidateAssessmentRepo.findAssignmentsForCandidate).not.toHaveBeenCalled();
+  });
+
+  it("returns the candidate's assignments", async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
+      { id: 'a1', status: 'assigned', result: null },
+    ] as never);
+    expect(await candidateAssessmentLifecycleService.getMyAssessments(EMAIL, SLUG)).toEqual([
+      { id: 'a1', status: 'assigned', result: null },
+    ]);
+  });
+
+  it('derives hasPending=true and strips breakdown when the result has pending manual questions', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
+      {
+        id: 'a1',
+        status: 'completed',
+        result: { normalizedScore: 80, percentile: null, breakdown: { autoScored: 3, pendingManual: ['q1'] } },
+      },
+    ] as never);
+    const result = await candidateAssessmentLifecycleService.getMyAssessments(EMAIL, SLUG);
+    expect(result).toEqual([
+      { id: 'a1', status: 'completed', result: { normalizedScore: 80, percentile: null, hasPending: true } },
+    ]);
+  });
+
+  it('derives hasPending=false when breakdown.pendingManual is empty', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
+      {
+        id: 'a2',
+        status: 'completed',
+        result: { normalizedScore: 100, percentile: 90, breakdown: { autoScored: 3, pendingManual: [] } },
+      },
+    ] as never);
+    const result = await candidateAssessmentLifecycleService.getMyAssessments(EMAIL, SLUG);
+    expect(result).toEqual([
+      { id: 'a2', status: 'completed', result: { normalizedScore: 100, percentile: 90, hasPending: false } },
+    ]);
+  });
+});
+
+describe('candidateAssessmentLifecycleService.startAssessment', () => {
+  it('rejects when consentAccepted is not true, before any write', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    await expect(
+      candidateAssessmentLifecycleService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, false, null, null),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'consent_required' });
+    expect(candidateAssessmentRepo.upsertConsent).not.toHaveBeenCalled();
+  });
+
+  it('throws NOT_FOUND when the assignment is not owned by this candidate', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue(null);
+    await expect(
+      candidateAssessmentLifecycleService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects an expired assignment', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'assigned',
+      expiresAt: new Date('2020-01-01'),
+      assessmentTypeId: 'type-1',
+    } as never);
+    await expect(
+      candidateAssessmentLifecycleService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
+    ).rejects.toMatchObject({ code: 'CONFLICT', message: 'assignment_expired' });
+    expect(candidateAssessmentRepo.markStarted).not.toHaveBeenCalled();
+  });
+
+  it('rejects a completed/cancelled assignment (out of {assigned, in_progress})', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'completed',
+      expiresAt: null,
+      assessmentTypeId: 'type-1',
+    } as never);
+    await expect(
+      candidateAssessmentLifecycleService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
+    ).rejects.toMatchObject({ code: 'CONFLICT', message: 'assignment_not_startable' });
+  });
+
+  it('records consent then marks in_progress on first start', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'assigned',
+      expiresAt: null,
+      assessmentTypeId: 'type-1',
+    } as never);
+    vi.mocked(candidateAssessmentRepo.markStarted).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'in_progress',
+    } as never);
+
+    const result = await candidateAssessmentLifecycleService.startAssessment(
+      EMAIL,
+      SLUG,
+      ASSIGNMENT_ID,
+      true,
+      '1.2.3.4',
+      'ua',
+    );
+
+    expect(candidateAssessmentRepo.upsertConsent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: ASSIGNMENT_ID,
+        candidateId: 'cand-1',
+        ipAddress: '1.2.3.4',
+        userAgent: 'ua',
+      }),
+    );
+    expect(candidateAssessmentRepo.markStarted).toHaveBeenCalledWith(ASSIGNMENT_ID);
+    expect(result).toEqual({ id: ASSIGNMENT_ID, status: 'in_progress' });
+  });
+
+  it('is idempotent when already in_progress — re-marks started without erroring', async () => {
+    // markStarted is mocked here (candidateAssessmentRepo is fully vi.fn()'d
+    // at the top of this file), so this only proves the SERVICE's control
+    // flow tolerates a repeat call. The actual guarantee that a repeat call
+    // does not overwrite startedAt lives in the repository's conditional
+    // updateMany and is proven against a real tenantDb mock in
+    // tests/assessment/candidate-assessment-repository.test.ts (review
+    // finding #2).
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'in_progress',
+      expiresAt: null,
+      assessmentTypeId: 'type-1',
+    } as never);
+    vi.mocked(candidateAssessmentRepo.markStarted).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'in_progress',
+    } as never);
+
+    const result = await candidateAssessmentLifecycleService.startAssessment(
+      EMAIL,
+      SLUG,
+      ASSIGNMENT_ID,
+      true,
+      null,
+      null,
+    );
+    expect(result.status).toBe('in_progress');
+  });
+});
+
+describe('candidateAssessmentLifecycleService.getAssessmentQuestions', () => {
+  it('throws NOT_FOUND when the assignment is not owned by this candidate', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue(null);
+    await expect(
+      candidateAssessmentLifecycleService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID),
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('rejects when the assignment has not been started', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'assigned',
+      expiresAt: null,
+      assessmentTypeId: 'type-1',
+    } as never);
+    await expect(
+      candidateAssessmentLifecycleService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'assignment_not_in_progress',
+    });
+  });
+
+  it('rejects an expired in_progress assignment', async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'in_progress',
+      expiresAt: new Date('2020-01-01'),
+      assessmentTypeId: 'type-1',
+    } as never);
+    await expect(
+      candidateAssessmentLifecycleService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'assignment_expired',
+    });
+  });
+
+  it("returns the assessment type's questions without correctOptionIds", async () => {
+    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
+    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
+      id: ASSIGNMENT_ID,
+      status: 'in_progress',
+      expiresAt: null,
+      assessmentTypeId: 'type-1',
+    } as never);
+    const questions = [
+      { id: 'q1', order: 0, type: 'single_choice', prompt: 'p', options: [{ id: 'a', label: 'A' }], points: 1 },
+    ];
+    vi.mocked(candidateAssessmentRepo.findQuestionsForType).mockResolvedValue(questions as never);
+
+    const result = await candidateAssessmentLifecycleService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID);
+
+    expect(result).toEqual(questions);
+    expect(JSON.stringify(result)).not.toContain('correctOptionIds');
+    expect(candidateAssessmentRepo.findQuestionsForType).toHaveBeenCalledWith('org-1', 'type-1');
+  });
+});

--- a/tests/assessment/candidate-assessment-service.test.ts
+++ b/tests/assessment/candidate-assessment-service.test.ts
@@ -51,214 +51,9 @@ beforeEach(() => {
   vi.mocked(candidatePortalRepo.findOrgBySlug).mockResolvedValue(ORG as never);
 });
 
-describe('candidateAssessmentService.getMyAssessments', () => {
-  it('throws NOT_FOUND for a missing/inactive org', async () => {
-    vi.mocked(candidatePortalRepo.findOrgBySlug).mockResolvedValue(null);
-    await expect(candidateAssessmentService.getMyAssessments(EMAIL, SLUG)).rejects.toMatchObject({
-      code: 'NOT_FOUND',
-    });
-  });
-
-  it('returns an empty list when the session email has no candidate at this org', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue(null);
-    expect(await candidateAssessmentService.getMyAssessments(EMAIL, SLUG)).toEqual([]);
-    expect(candidateAssessmentRepo.findAssignmentsForCandidate).not.toHaveBeenCalled();
-  });
-
-  it("returns the candidate's assignments", async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
-      { id: 'a1', status: 'assigned', result: null },
-    ] as never);
-    expect(await candidateAssessmentService.getMyAssessments(EMAIL, SLUG)).toEqual([
-      { id: 'a1', status: 'assigned', result: null },
-    ]);
-  });
-
-  it('derives hasPending=true and strips breakdown when the result has pending manual questions', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
-      {
-        id: 'a1',
-        status: 'completed',
-        result: { normalizedScore: 80, percentile: null, breakdown: { autoScored: 3, pendingManual: ['q1'] } },
-      },
-    ] as never);
-    const result = await candidateAssessmentService.getMyAssessments(EMAIL, SLUG);
-    expect(result).toEqual([
-      { id: 'a1', status: 'completed', result: { normalizedScore: 80, percentile: null, hasPending: true } },
-    ]);
-  });
-
-  it('derives hasPending=false when breakdown.pendingManual is empty', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findAssignmentsForCandidate).mockResolvedValue([
-      {
-        id: 'a2',
-        status: 'completed',
-        result: { normalizedScore: 100, percentile: 90, breakdown: { autoScored: 3, pendingManual: [] } },
-      },
-    ] as never);
-    const result = await candidateAssessmentService.getMyAssessments(EMAIL, SLUG);
-    expect(result).toEqual([
-      { id: 'a2', status: 'completed', result: { normalizedScore: 100, percentile: 90, hasPending: false } },
-    ]);
-  });
-});
-
-describe('candidateAssessmentService.startAssessment', () => {
-  it('rejects when consentAccepted is not true, before any write', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    await expect(
-      candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, false, null, null),
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'consent_required' });
-    expect(candidateAssessmentRepo.upsertConsent).not.toHaveBeenCalled();
-  });
-
-  it('throws NOT_FOUND when the assignment is not owned by this candidate', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue(null);
-    await expect(
-      candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
-  });
-
-  it('rejects an expired assignment', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'assigned',
-      expiresAt: new Date('2020-01-01'),
-      assessmentTypeId: 'type-1',
-    } as never);
-    await expect(
-      candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
-    ).rejects.toMatchObject({ code: 'CONFLICT', message: 'assignment_expired' });
-    expect(candidateAssessmentRepo.markStarted).not.toHaveBeenCalled();
-  });
-
-  it('rejects a completed/cancelled assignment (out of {assigned, in_progress})', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'completed',
-      expiresAt: null,
-      assessmentTypeId: 'type-1',
-    } as never);
-    await expect(
-      candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null),
-    ).rejects.toMatchObject({ code: 'CONFLICT', message: 'assignment_not_startable' });
-  });
-
-  it('records consent then marks in_progress on first start', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'assigned',
-      expiresAt: null,
-      assessmentTypeId: 'type-1',
-    } as never);
-    vi.mocked(candidateAssessmentRepo.markStarted).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'in_progress',
-    } as never);
-
-    const result = await candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, '1.2.3.4', 'ua');
-
-    expect(candidateAssessmentRepo.upsertConsent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assignmentId: ASSIGNMENT_ID,
-        candidateId: 'cand-1',
-        ipAddress: '1.2.3.4',
-        userAgent: 'ua',
-      }),
-    );
-    expect(candidateAssessmentRepo.markStarted).toHaveBeenCalledWith(ASSIGNMENT_ID);
-    expect(result).toEqual({ id: ASSIGNMENT_ID, status: 'in_progress' });
-  });
-
-  it('is idempotent when already in_progress — re-marks started without erroring', async () => {
-    // markStarted is mocked here (candidateAssessmentRepo is fully vi.fn()'d
-    // at the top of this file), so this only proves the SERVICE's control
-    // flow tolerates a repeat call. The actual guarantee that a repeat call
-    // does not overwrite startedAt lives in the repository's conditional
-    // updateMany and is proven against a real tenantDb mock in
-    // tests/assessment/candidate-assessment-repository.test.ts (review
-    // finding #2).
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'in_progress',
-      expiresAt: null,
-      assessmentTypeId: 'type-1',
-    } as never);
-    vi.mocked(candidateAssessmentRepo.markStarted).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'in_progress',
-    } as never);
-
-    const result = await candidateAssessmentService.startAssessment(EMAIL, SLUG, ASSIGNMENT_ID, true, null, null);
-    expect(result.status).toBe('in_progress');
-  });
-});
-
-describe('candidateAssessmentService.getAssessmentQuestions', () => {
-  it('throws NOT_FOUND when the assignment is not owned by this candidate', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue(null);
-    await expect(candidateAssessmentService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID)).rejects.toMatchObject({
-      code: 'NOT_FOUND',
-    });
-  });
-
-  it('rejects when the assignment has not been started', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'assigned',
-      expiresAt: null,
-      assessmentTypeId: 'type-1',
-    } as never);
-    await expect(candidateAssessmentService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID)).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'assignment_not_in_progress',
-    });
-  });
-
-  it('rejects an expired in_progress assignment', async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'in_progress',
-      expiresAt: new Date('2020-01-01'),
-      assessmentTypeId: 'type-1',
-    } as never);
-    await expect(candidateAssessmentService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID)).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'assignment_expired',
-    });
-  });
-
-  it("returns the assessment type's questions without correctOptionIds", async () => {
-    vi.mocked(candidatePortalRepo.findActiveCandidate).mockResolvedValue({ id: 'cand-1' } as never);
-    vi.mocked(candidateAssessmentRepo.findOwnedAssignment).mockResolvedValue({
-      id: ASSIGNMENT_ID,
-      status: 'in_progress',
-      expiresAt: null,
-      assessmentTypeId: 'type-1',
-    } as never);
-    const questions = [
-      { id: 'q1', order: 0, type: 'single_choice', prompt: 'p', options: [{ id: 'a', label: 'A' }], points: 1 },
-    ];
-    vi.mocked(candidateAssessmentRepo.findQuestionsForType).mockResolvedValue(questions as never);
-
-    const result = await candidateAssessmentService.getAssessmentQuestions(EMAIL, SLUG, ASSIGNMENT_ID);
-
-    expect(result).toEqual(questions);
-    expect(JSON.stringify(result)).not.toContain('correctOptionIds');
-    expect(candidateAssessmentRepo.findQuestionsForType).toHaveBeenCalledWith('org-1', 'type-1');
-  });
-});
+// getMyAssessments/startAssessment/getAssessmentQuestions now live in
+// candidate-assessment-lifecycle.service.ts — see
+// tests/assessment/candidate-assessment-lifecycle-service.test.ts.
 
 const SINGLE_CHOICE_Q = { id: 'q1', type: 'single_choice', correctOptionIds: ['b'], points: 5 };
 const FREE_TEXT_Q = { id: 'q2', type: 'free_text', correctOptionIds: [], points: 20 };
@@ -403,7 +198,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
     vi.mocked(candidateAssessmentWriteRepo.findQuestionsWithAnswerKeyInTx).mockResolvedValue([
       SINGLE_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 0, countEqual: 0, sampleSize: 0 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 0,
+      countEqual: 0,
+      sampleSize: 0,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 0 } as never);
 
     await expect(
@@ -435,7 +234,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
     vi.mocked(candidateAssessmentWriteRepo.findQuestionsWithAnswerKeyInTx).mockResolvedValue([
       SINGLE_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 0, countEqual: 0, sampleSize: 0 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 0,
+      countEqual: 0,
+      sampleSize: 0,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 1 } as never);
 
     // q1 submitted twice — a correct answer then a wrong one. The Map keeps
@@ -472,7 +275,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
       SINGLE_CHOICE_Q,
       SECOND_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 0, countEqual: 0, sampleSize: 0 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 0,
+      countEqual: 0,
+      sampleSize: 0,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 1 } as never);
 
     // Only q1 (of 2 questions) is answered, correctly.
@@ -514,7 +321,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
     vi.mocked(candidateAssessmentWriteRepo.findQuestionsWithAnswerKeyInTx).mockResolvedValue([
       SINGLE_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 0, countEqual: 0, sampleSize: 0 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 0,
+      countEqual: 0,
+      sampleSize: 0,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 1 } as never);
 
     // (a) A correct answer on the ONE active question yields normalizedScore
@@ -598,7 +409,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
     vi.mocked(candidateAssessmentWriteRepo.findQuestionsWithAnswerKeyInTx).mockResolvedValue([
       SINGLE_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 5, countEqual: 0, sampleSize: 5 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 5,
+      countEqual: 0,
+      sampleSize: 5,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 1 } as never);
 
     await candidateAssessmentService.submitAssessment(EMAIL, SLUG, ASSIGNMENT_ID, [
@@ -629,7 +444,11 @@ describe('candidateAssessmentService.submitAssessment', () => {
     vi.mocked(candidateAssessmentWriteRepo.findQuestionsWithAnswerKeyInTx).mockResolvedValue([
       SINGLE_CHOICE_Q,
     ] as never);
-    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({ countBelow: 2, countEqual: 0, sampleSize: 2 });
+    vi.mocked(candidateAssessmentWriteRepo.getNormCountsInTx).mockResolvedValue({
+      countBelow: 2,
+      countEqual: 0,
+      sampleSize: 2,
+    });
     vi.mocked(candidateAssessmentWriteRepo.completeAssignmentInTx).mockResolvedValue({ count: 1 } as never);
 
     await candidateAssessmentService.submitAssessment(EMAIL, SLUG, ASSIGNMENT_ID, [

--- a/tests/candidate/documents-router.test.ts
+++ b/tests/candidate/documents-router.test.ts
@@ -24,8 +24,8 @@ vi.mock('../../packages/api/src/services/candidate-ai.service', () => ({
 const getDocumentMock = vi.fn();
 const uploadDocumentMock = vi.fn();
 const deleteDocumentMock = vi.fn();
-vi.mock('../../packages/api/src/services/candidate.service', () => ({
-  candidateService: {
+vi.mock('../../packages/api/src/services/candidate-documents.service', () => ({
+  candidateDocumentsService: {
     getDocument: (...a: unknown[]) => getDocumentMock(...a),
     uploadDocument: (...a: unknown[]) => uploadDocumentMock(...a),
     deleteDocument: (...a: unknown[]) => deleteDocumentMock(...a),
@@ -63,8 +63,18 @@ async function makeCaller() {
   const testRouter = router({ candidate: candidateRouter });
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
-    user: { id: 'user-1', organizationId: ORG_ID, roles: ['hr_admin'], isPlatformOwner: false, impersonatorId: null, email: 'hr@tims.co', isActive: true },
-    headers: new Headers(), supabaseAuth: null, externalAuth: null,
+    user: {
+      id: 'user-1',
+      organizationId: ORG_ID,
+      roles: ['hr_admin'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'hr@tims.co',
+      isActive: true,
+    },
+    headers: new Headers(),
+    supabaseAuth: null,
+    externalAuth: null,
   } as never) as unknown as {
     candidate: {
       parseCV(input: { candidateId: string; text: string; documentId?: string }): Promise<unknown>;
@@ -126,9 +136,9 @@ describe('candidate.parseCV wiring', () => {
   it('throws FORBIDDEN and never queries when the caller lacks candidate:update', async () => {
     setAccessAllowed(false);
     const caller = await makeCaller();
-    await expect(
-      caller.candidate.parseCV({ candidateId: CANDIDATE_ID, text: 'cv text' }),
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(caller.candidate.parseCV({ candidateId: CANDIDATE_ID, text: 'cv text' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
     expect(parseCVMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/candidate/pool-export.test.ts
+++ b/tests/candidate/pool-export.test.ts
@@ -25,7 +25,7 @@ vi.mock('@tims/db', () => ({
 
 // Scope-filtering (the router's headline security property) is mocked so the
 // behavioral test below can assert the resolved scopeWhere fragment actually
-// flows into candidateService.exportPool — see the "router (behavioral)"
+// flows into candidatePoolService.exportPool — see the "router (behavioral)"
 // describe block. Pattern mirrors tests/candidate/documents-router.test.ts.
 const buildAccessForUserMock = vi.hoisted(() =>
   vi.fn(async () => ({ allowed: true, scope: 'organization', roles: ['hr_admin'] })),
@@ -96,10 +96,10 @@ describe('candidateRepository.findForExport', () => {
   });
 });
 
-import { candidateService } from '../../packages/api/src/services/candidate.service';
+import { candidatePoolService } from '../../packages/api/src/services/candidate-pool.service';
 import * as candidateRepositoryModule from '../../packages/api/src/repositories/candidate.repository';
 
-describe('candidateService.exportPool', () => {
+describe('candidatePoolService.exportPool', () => {
   let findForExportSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -128,7 +128,7 @@ describe('candidateService.exportPool', () => {
       },
     ]);
 
-    const result = await candidateService.exportPool('org-1', {} as never, {});
+    const result = await candidatePoolService.exportPool('org-1', {} as never, {});
 
     expect(result.count).toBe(1);
     expect(result.truncated).toBe(false);
@@ -155,7 +155,7 @@ describe('candidateService.exportPool', () => {
     }));
     findForExportSpy.mockResolvedValue(rows);
 
-    const result = await candidateService.exportPool('org-1', {} as never, {});
+    const result = await candidatePoolService.exportPool('org-1', {} as never, {});
 
     expect(result.count).toBe(5000);
     expect(result.truncated).toBe(true);
@@ -179,7 +179,7 @@ describe('candidateService.exportPool', () => {
     }));
     findForExportSpy.mockResolvedValue(rows);
 
-    const result = await candidateService.exportPool('org-1', {} as never, {});
+    const result = await candidatePoolService.exportPool('org-1', {} as never, {});
 
     expect(result.count).toBe(5000);
     expect(result.truncated).toBe(false);
@@ -203,14 +203,14 @@ describe('candidateService.exportPool', () => {
       },
     ]);
 
-    const result = await candidateService.exportPool('org-1', {} as never, {});
+    const result = await candidatePoolService.exportPool('org-1', {} as never, {});
 
     expect(result.csv).toContain('"\'=SUM(A1:A10)"');
   });
 
   it('passes poolType/tags input through to the repository as filters', async () => {
     findForExportSpy.mockResolvedValue([]);
-    await candidateService.exportPool('org-1', {} as never, { poolType: 'active', tags: ['vip'] });
+    await candidatePoolService.exportPool('org-1', {} as never, { poolType: 'active', tags: ['vip'] });
 
     expect(findForExportSpy).toHaveBeenCalledWith('org-1', {}, { poolType: 'active', tags: ['vip'] }, 5000);
   });
@@ -225,7 +225,7 @@ describe('candidate.pool.export router (source text checks)', () => {
   });
 
   it('calls the real service and logs the export', () => {
-    expect(src).toContain('candidateService.exportPool');
+    expect(src).toContain('candidatePoolService.exportPool');
     expect(src).toContain('logPlatformExport');
     expect(src).not.toContain('stub_generated');
     expect(src).not.toContain('storage.tims.app');
@@ -235,7 +235,7 @@ describe('candidate.pool.export router (source text checks)', () => {
 // Behavioral replacement for the old "applies scope filtering" source-text check:
 // a real tRPC caller is built for candidatePoolRouter with scopeWhereFor mocked to
 // return a distinctive marker fragment, and we assert that marker actually flows
-// into candidateService.exportPool's scopeWhere argument — proving the tenant/scope
+// into candidatePoolService.exportPool's scopeWhere argument — proving the tenant/scope
 // filter reaches the service call, not just that the source text mentions it.
 // Pattern mirrors tests/candidate/documents-router.test.ts.
 describe('candidate.pool.export router (behavioral)', () => {
@@ -273,9 +273,9 @@ describe('candidate.pool.export router (behavioral)', () => {
     auditLogCreate.mockResolvedValue({});
   });
 
-  it('threads the scopeWhereFor result into candidateService.exportPool as scopeWhere', async () => {
+  it('threads the scopeWhereFor result into candidatePoolService.exportPool as scopeWhere', async () => {
     const exportPoolSpy = vi
-      .spyOn(candidateService, 'exportPool')
+      .spyOn(candidatePoolService, 'exportPool')
       .mockResolvedValue({ csv: 'header\n', count: 0, truncated: false });
 
     try {

--- a/tests/pipeline/org-sla-overdue.test.ts
+++ b/tests/pipeline/org-sla-overdue.test.ts
@@ -6,12 +6,12 @@ vi.mock('../../packages/api/src/repositories/pipeline.repository', () => ({
   },
 }));
 
-import { pipelineService } from '../../packages/api/src/services/pipeline.service';
+import { pipelineAnalyticsService } from '../../packages/api/src/services/pipeline-analytics.service';
 import { pipelineRepository } from '../../packages/api/src/repositories/pipeline.repository';
 
 beforeEach(() => vi.clearAllMocks());
 
-describe('pipelineService.getOrgSlaOverdueCount', () => {
+describe('pipelineAnalyticsService.getOrgSlaOverdueCount', () => {
   it('counts an application overdue using time-in-CURRENT-stage, not time since application', async () => {
     const now = Date.now();
     vi.mocked(pipelineRepository.getActiveApplicationsForOrgSla).mockResolvedValue([
@@ -40,7 +40,7 @@ describe('pipelineService.getOrgSlaOverdueCount', () => {
       },
     ] as never);
 
-    const count = await pipelineService.getOrgSlaOverdueCount('org-1', {});
+    const count = await pipelineAnalyticsService.getOrgSlaOverdueCount('org-1', {});
 
     expect(count).toBe(1);
   });

--- a/tests/pipeline/sla-status-precision.test.ts
+++ b/tests/pipeline/sla-status-precision.test.ts
@@ -8,14 +8,14 @@ vi.mock('../../packages/api/src/repositories/pipeline.repository', () => ({
   },
 }));
 
-import { pipelineService } from '../../packages/api/src/services/pipeline.service';
+import { pipelineAnalyticsService } from '../../packages/api/src/services/pipeline-analytics.service';
 import { pipelineRepository } from '../../packages/api/src/repositories/pipeline.repository';
 
 const candidate = { id: 'c1', firstName: 'A', lastName: 'B' };
 
 beforeEach(() => vi.clearAllMocks());
 
-describe('pipelineService.getSlaStatus — hourly precision', () => {
+describe('pipelineAnalyticsService.getSlaStatus — hourly precision', () => {
   it('flags an application overdue on a sub-hour SLA breach, not just after a full extra hour', async () => {
     vi.mocked(pipelineRepository.vacancyExists).mockResolvedValue({ id: 'vac-1' } as never);
     vi.mocked(pipelineRepository.getStagesForVacancy).mockResolvedValue([
@@ -35,7 +35,7 @@ describe('pipelineService.getSlaStatus — hourly precision', () => {
       },
     ] as never);
 
-    const result = await pipelineService.getSlaStatus('org-1', 'vac-1');
+    const result = await pipelineAnalyticsService.getSlaStatus('org-1', 'vac-1');
 
     expect(result.items[0]!.isOverdue).toBe(true);
   });


### PR DESCRIPTION
## Summary
Closes #20. Pure extraction, no behavior change — splits each oversized service by subdomain, matching the router file boundaries that already existed:

| File | Before | After |
|---|---|---|
| `pipeline.service.ts` | 354 | 180 |
| + `pipeline-stages.service.ts` | — | 74 |
| + `pipeline-analytics.service.ts` | — | 119 |
| `candidate.service.ts` | 391 | 279 |
| + `candidate-pool.service.ts` | — | 67 |
| + `candidate-tags.service.ts` | — | 40 |
| + `candidate-documents.service.ts` | — | 37 |
| `candidate-assessment.service.ts` | 311 | 198 |
| + `candidate-assessment-lifecycle.service.ts` | — | 137 |

`submitAssessment` (the norm-scoring write transaction) stays alone in `candidate-assessment.service.ts` — it's one atomic `runTenantTransaction` call, can't be split further without breaking transaction semantics.

Router call sites and existing tests updated to import the new split services; one test file split to match (`candidate-assessment-lifecycle-service.test.ts`).

Closes #20.

## Verification
- `pnpm --filter @tims/api exec tsc --noEmit` — clean
- `cd apps/web && npx tsc --noEmit` — clean
- `npx vitest run` — 282 files / 2615 tests, all passing (same test count as before — pure move, no tests added/removed)
- gitleaks — no leaks found

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)