### PR TITLE
fix(security): explicit select on user.me (data exposure)

### DIFF
--- a/packages/api/src/routers/user.ts
+++ b/packages/api/src/routers/user.ts
@@ -8,18 +8,28 @@ import { logSecurityEvent } from '../access/security-audit';
 import { resolveStaffSupabaseUserId } from '../services/staff-provisioning.service';
 
 export const userRouter = router({
-  // Get current user profile
+  // Get current user profile. No real consumer exists today (grepped apps/web
+  // and tests — zero call sites), but this is a session/identity endpoint, so
+  // scope the select to profile-display fields rather than leave it wide open
+  // for whenever a consumer lands (issue #23).
   me: protectedProcedure.query(async ({ ctx }) => {
     return db.user.findUnique({
       where: { id: ctx.user.id },
-      include: {
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        avatar: true,
+        jobTitle: true,
+        isActive: true,
         userRoles: {
-          include: {
+          select: {
             role: { select: { id: true, name: true, slug: true } },
           },
         },
         teams: {
-          include: {
+          select: {
             team: { select: { id: true, name: true } },
           },
         },


### PR DESCRIPTION
Closes #23.

Same bare-`include`-no-`select` pattern as #5, on \`user.me\`. Sensitive fields (\`supabaseUserId\`, \`isPlatformOwner\`, \`mfaEnabled\`, \`phone\`, \`lastLoginAt\`) were being returned by default.

Grepped apps/web + tests for real consumers of this endpoint — found **zero**. #23's stated "broad session/auth blast radius" concern didn't hold up on inspection, so this was a straightforward narrow, not the bigger scoped task it was filed as.

## Verification
- \`pnpm --filter @tims/api exec tsc --noEmit\` — clean
- \`npx vitest run\` — 282 files / 2615 tests, all passing
- gitleaks — no leaks found

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)