### PR TITLE
fix(verification): make the Codex gate fail loud instead of silently passing (#38)

### DIFF
--- a/.claude/commands/gate.md
+++ b/.claude/commands/gate.md
@@ -43,6 +43,7 @@ pnpm --filter @tims/db exec prisma generate --schema prisma/schema
 | 12  | Secret scan                    | `gitleaks git --no-banner .` (full history, same as CI)                                                                                                                                                                                                                                                                            |
 | 13  | Scope AND-composition          | `grep -rn '\.\.\.[[:alnum:]_$.]*access\.where\|\.\.\.[[:alnum:]_$.]*scopeWhere' packages/api/src --include="*.ts"` → must be empty                                                                                                                                                                                                 |
 | 14  | RLS tenant isolation (live DB) | `npx tsx scripts/security/verify-rls-isolation.ts` → exit 0. Auto-loads `packages/db/.env`; needs the **session pooler** (:5432 — :6543 cannot `SET LOCAL ROLE`). If credentials are broken, run `bash scripts/dev/setup-db-env.sh` (#41). If no DB is reachable, report this check as ⚠️ SKIPPED with the reason — never as PASS. |
+| 15  | Cross-model review (Codex)     | `bash scripts/verification/codex-review.sh` → exit 0. **Exit 2 = Codex could not run** (quota/auth/network) — report ⚠️ NOT RUN, never PASS, and use the tier-2 fallback in `.claude/rules/verification.md`. Codex is quota-blocked until 2026-08-15, so exit 2 is currently expected.                                             |
 
 Notes:
 

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,12 +1,83 @@
 ---
 paths:
-  - "**"
+  - '**'
 ---
-# Cross-Model Verification (Codex)
 
-Every build phase gets an adversarial **Codex** cross-model verification pass at its review gate,
-alongside the per-slice reviewer and the opus whole-branch review (superpowers:subagent-driven-development).
-Dispatch the `codex:codex-rescue` agent; instruct it to catch overstated/incorrect claims, cite file:line,
-and surface what was missed — honesty over agreement. Enforcement = build-gate + this rule (NOT the hard
-per-turn `--enable-review-gate`). Proven (2026-06-30 perf analysis): Codex caught 2 overstated findings +
-1 missed issue on its first run.
+# Cross-Model Verification
+
+Every build phase gets an adversarial cross-model verification pass at its review gate, alongside the
+per-slice reviewer and the opus whole-branch review (superpowers:subagent-driven-development). The
+reviewer's job is to catch overstated or incorrect claims, cite `file:line`, and surface what was
+missed — **honesty over agreement**.
+
+Proven value (2026-06-30 perf analysis): Codex caught 2 overstated findings + 1 missed issue on its
+first run.
+
+## How to run it
+
+```bash
+bash scripts/verification/codex-review.sh [BASE_REF]     # defaults to origin/main
+```
+
+Also wired as **/gate check 15**.
+
+| Exit | Meaning                                               |
+| ---- | ----------------------------------------------------- |
+| `0`  | Codex ran and raised no blocking findings             |
+| `1`  | Codex ran and raised blocking findings                |
+| `2`  | **Codex could not run** — verification did not happen |
+
+**Exit 2 is not a pass.** It is precisely the state this rule previously failed to distinguish.
+
+## Why a script instead of calling the CLI directly
+
+> **The Codex CLI exits `0` when it is quota-blocked.**
+>
+> ```
+> $ echo "Reply OK" | codex exec --sandbox read-only -
+> ERROR: You've hit your usage limit ... try again at Aug 15th, 2026 11:44 PM.
+> $ echo $?
+> 0
+> ```
+
+Verified 2026-08-02. Any wrapper that trusts the exit code reads a refusal as a pass. The script
+therefore inspects output for refusal signatures — quota, auth, network, empty response, missing
+`VERDICT:` line — and fails closed on every one.
+
+This is not hypothetical. Between 2026-07-22 and 2026-08-02 the gate did not run once and every build
+reported green. **PRs #18, #19, #22, #24, #112 and #113 all merged without cross-model review** —
+including #22 and #24, which were data-exposure security fixes, and #112, which changed RLS policies
+on 76 production tables.
+
+## Tier-2 fallback — when Codex is unavailable
+
+Codex is **quota-blocked until 2026-08-15**. Until then exit 2 is expected, and the required
+substitute is a **3-lens same-model adversarial panel**:
+
+1. **Security / tenant-isolation** — data exposure, authz bypass, RLS, secrets, race conditions.
+2. **Claim auditor** — take every claim in the commit messages and PR body and verify it against
+   `file:line`. Overstated claims are the highest-value finding class, and the one a same-model
+   reviewer is still reliably good at.
+3. **Coverage** — what is missing: an untested path, an unhandled error, a doc that now contradicts
+   the code.
+
+Each lens must be prompted to **refute**, not confirm, and must re-read the source itself rather than
+trusting the implementer's summary. This pattern produced 22 confirmed findings (0 rebutted) against
+the ownership-flip runbook in #63.
+
+**While the fallback is active, do not call this rule "cross-model."** It is same-model adversarial
+review, which is weaker — it shares the original author's blind spots. Record in the PR body which
+tier actually ran.
+
+## Enforcement — what is and isn't real
+
+- **/gate check 15** runs the script. A skipped or exit-2 result must be reported as ⚠️ NOT RUN,
+  never as PASS.
+- **CI job `verification-gate`** fails any PR whose body contains neither a `## Verification` section
+  nor an explicit `Verification-waiver: <reason>` line. That does not prove a review happened — it
+  makes an absent one visible in GitHub instead of buried in a session log.
+- There is **no automated enforcement beyond those two.**
+
+An earlier version of this rule claimed "Enforcement = build-gate + this rule". That was false:
+`/gate` had no Codex check and neither CI workflow mentioned Codex. It also instructed dispatching a
+`codex:codex-rescue` agent that is not installed in this environment. Both corrected 2026-08-02 (#38).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,55 @@ jobs:
         run: pnpm --filter @tims/web build
         env:
           SKIP_ENV_VALIDATION: "true"
+
+  # ========================================
+  # Verification gate (#38)
+  #
+  # Does NOT prove a review happened — it makes an ABSENT one visible in GitHub
+  # instead of buried in a session log.
+  #
+  # Context: `.claude/rules/verification.md` mandates an adversarial cross-model
+  # pass at every review gate. It did not run once between 2026-07-22 and
+  # 2026-08-02, and every build stayed green, because the Codex CLI exits 0 when
+  # quota-blocked. PRs #18, #19, #22, #24, #112 and #113 all merged without it —
+  # #22 and #24 were data-exposure security fixes.
+  #
+  # Zero-cost: no checkout, no install, pure API read. Modeled on table-ownership.
+  # ========================================
+  verification-gate:
+    name: Verification section present
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Require a Verification section or an explicit waiver
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if grep -qiE '^[[:space:]]*#{1,4}[[:space:]]*Verification' <<<"$BODY"; then
+            echo "✓ PR body has a Verification section."
+            exit 0
+          fi
+          if grep -qiE '^[[:space:]]*Verification-waiver:[[:space:]]*\S' <<<"$BODY"; then
+            echo "⚠ Verification WAIVED:"
+            grep -iE '^[[:space:]]*Verification-waiver:' <<<"$BODY" | sed 's/^/    /'
+            echo ""
+            echo "Recorded in the PR body, which is the point — a skipped review is now visible."
+            exit 0
+          fi
+          echo "::error::PR body has no '## Verification' section and no 'Verification-waiver:' line."
+          echo ""
+          echo "Add a '## Verification' section listing what you actually ran, e.g.:"
+          echo ""
+          echo "  ## Verification"
+          echo "  - [x] pnpm --filter @tims/api exec tsc --noEmit"
+          echo "  - [x] npx vitest run"
+          echo "  - [x] bash scripts/verification/codex-review.sh   (exit 2 — quota-blocked; ran 3-lens fallback)"
+          echo ""
+          echo "Or, if verification genuinely does not apply, state why on one line:"
+          echo ""
+          echo "  Verification-waiver: docs-only change, no code paths touched"
+          echo ""
+          echo "See .claude/rules/verification.md"
+          exit 1

--- a/scripts/verification/codex-review.sh
+++ b/scripts/verification/codex-review.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# codex-review.sh — adversarial cross-model verification that FAILS LOUD (issue #38).
+#
+# ── WHY THIS EXISTS ──────────────────────────────────────────────────────────────────────────────
+# `.claude/rules/verification.md` mandates an adversarial Codex pass at every review gate. It had not
+# actually run since 2026-07-22. PRs #18, #19, #22, #24, #112 and #113 all merged without it —
+# including #22 and #24, which were data-exposure security fixes.
+#
+# The reason is not that Codex is missing. Verified 2026-08-02: `codex-cli 0.145.0` is installed,
+# authenticated (chatgpt mode) and reachable. The reason is this:
+#
+#     $ echo "Reply OK" | codex exec --sandbox read-only -
+#     ERROR: You've hit your usage limit ... try again at Aug 15th, 2026 11:44 PM.
+#     $ echo $?
+#     0
+#
+# **The CLI exits 0 when it is quota-blocked.** Any wrapper that trusts the exit code reads a refusal
+# as a pass. That is the silent-pass mechanism, and it is why a mandated control evaporated for weeks
+# while every gate stayed green.
+#
+# So this script deliberately does NOT trust the exit code. It inspects the output for refusal
+# signatures and treats "the reviewer never ran" as a FAILURE, distinct from "the reviewer ran and
+# found nothing".
+#
+# ── EXIT CODES ───────────────────────────────────────────────────────────────────────────────────
+#   0  Codex ran and raised no blocking findings
+#   1  Codex ran and raised blocking findings
+#   2  Codex COULD NOT RUN (quota, auth, network, empty output) — verification did not happen
+#
+# Exit 2 must never be treated as a pass. Use the documented fallback (see --help).
+#
+# ── USAGE ────────────────────────────────────────────────────────────────────────────────────────
+#   bash scripts/verification/codex-review.sh [BASE_REF]     # defaults to origin/main
+#
+set -uo pipefail
+
+BASE="${1:-origin/main}"
+cd "$(git rev-parse --show-toplevel)"
+
+say()   { printf '%s\n' "$*"; }
+ok()    { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn()  { printf '  \033[33m!\033[0m %s\n' "$*"; }
+bad()   { printf '  \033[31m✖\033[0m %s\n' "$*" >&2; }
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '3,40p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+fi
+
+command -v codex >/dev/null || { bad "codex CLI not on PATH — verification cannot run."; exit 2; }
+
+DIFF="$(git diff "$BASE"...HEAD --stat 2>/dev/null)"
+if [[ -z "$DIFF" ]]; then
+  warn "no changes vs $BASE — nothing to review."
+  exit 0
+fi
+
+say ""
+say "Adversarial cross-model review (Codex) vs $BASE"
+say "───────────────────────────────────────────────"
+say "$DIFF" | tail -20 | sed 's/^/  /'
+say ""
+
+PROMPT=$(cat <<'EOP'
+You are an adversarial code reviewer. Your job is to DISAGREE, not to agree.
+
+Review the changes on this branch against its merge base. Honesty over agreement — a review that
+finds nothing is only useful if you genuinely tried to break the change.
+
+Focus on, in order:
+1. Claims in the commit messages or PR body that the diff does NOT actually support. Overstated or
+   unverified claims are the highest-value finding.
+2. Security: tenant isolation, data exposure (Prisma queries without explicit select), authz bypass,
+   secrets, unbounded input, race conditions in multi-step DB writes.
+3. What is MISSING — an untested path, an unhandled error, a doc that now contradicts the code.
+
+Cite file:line for every finding. Do not restate what the change does; assume the reader wrote it.
+
+End your response with exactly one line, on its own:
+  VERDICT: BLOCKING   (if any finding should stop the merge)
+  VERDICT: CLEAN      (if nothing should stop the merge)
+EOP
+)
+
+OUT_FILE="$(mktemp)"
+trap 'rm -f "$OUT_FILE"' EXIT
+
+# NOTE: exit code is deliberately captured but NOT trusted — see the header.
+printf '%s\n' "$PROMPT" | codex exec --sandbox read-only --skip-git-repo-check - \
+  >"$OUT_FILE" 2>&1
+CODEX_RC=$?
+
+OUTPUT="$(cat "$OUT_FILE")"
+
+# ── Refusal detection — the whole point of this script ───────────────────────────────────────────
+QUOTA_RE='hit your usage limit|rate limit|quota|Upgrade to Plus|try again at'
+AUTH_RE='not logged in|authentication|unauthorized|401|please run .?codex login'
+NET_RE='network|ECONNREFUSED|ETIMEDOUT|could not reach|dns'
+
+if grep -qiE "$QUOTA_RE" <<<"$OUTPUT"; then
+  bad "Codex is QUOTA-BLOCKED — the review did not happen."
+  say ""
+  grep -iE "$QUOTA_RE" <<<"$OUTPUT" | head -2 | sed 's/^/      /'
+  say ""
+  say "  ⚠  The CLI exits 0 in this state. This is NOT a pass."
+  say ""
+  say "  Fallback (declared tier-2 in .claude/rules/verification.md): run a 3-lens same-model"
+  say "  adversarial panel instead — security/tenant-isolation, a claim-auditor that checks every"
+  say "  PR-body claim against file:line, and a coverage 'what's missing' lens. Record in the PR body"
+  say "  that cross-model verification was unavailable and which fallback ran."
+  exit 2
+fi
+
+if grep -qiE "$AUTH_RE" <<<"$OUTPUT"; then
+  bad "Codex is NOT AUTHENTICATED — the review did not happen. Run: codex login"
+  exit 2
+fi
+
+if grep -qiE "$NET_RE" <<<"$OUTPUT"; then
+  bad "Codex could not reach the service — the review did not happen."
+  exit 2
+fi
+
+# An empty or near-empty response means it produced no review, whatever the exit code said.
+if [[ "$(tr -d '[:space:]' <<<"$OUTPUT" | wc -c)" -lt 200 ]]; then
+  bad "Codex returned no meaningful output (${CODEX_RC} exit) — treating as NOT RUN."
+  printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/      /'
+  exit 2
+fi
+
+if ! grep -qE '^VERDICT: (BLOCKING|CLEAN)' <<<"$OUTPUT"; then
+  bad "Codex produced output but no VERDICT line — cannot confirm a real review ran."
+  printf '%s\n' "$OUTPUT" | tail -25 | sed 's/^/      /'
+  exit 2
+fi
+
+say ""
+printf '%s\n' "$OUTPUT" | sed 's/^/  /'
+say ""
+
+if grep -qE '^VERDICT: BLOCKING' <<<"$OUTPUT"; then
+  bad "Codex raised BLOCKING findings."
+  exit 1
+fi
+
+ok "Codex review CLEAN — cross-model verification genuinely ran."
+exit 0


### PR DESCRIPTION
## Root cause — the Codex CLI exits `0` when quota-blocked

```
$ echo "Reply OK" | codex exec --sandbox read-only -
ERROR: You've hit your usage limit ... try again at Aug 15th, 2026 11:44 PM.
$ echo $?
0
```

Verified 2026-08-02. **Any wrapper that trusts the exit code reads a refusal as a pass.** That is the silent-pass mechanism, and it sits deeper than the `codex-rescue` agent-spec behaviour previously suspected.

The consequence: the mandated adversarial pass did not run **once** between 2026-07-22 and 2026-08-02, and every build reported green. PRs **#18, #19, #22, #24, #112 and #113** all merged without cross-model review — #22 and #24 were data-exposure security fixes, and #112 changed RLS policies on 76 production tables.

## Two findings that contradict the rule as written

1. **Codex is not missing.** `codex-cli 0.145.0` is installed, authenticated (`chatgpt` mode, tokens stored), and reachable (handshake HTTP 101). Only quota was exhausted. The rule was never blocked by unavailability.
2. **The rule pointed at things that don't exist.** It instructed dispatching a `codex:codex-rescue` agent that is not installed in this environment, and claimed _"Enforcement = build-gate + this rule"_ — false: `/gate` had no Codex check and `grep -rl codex .github/` returned nothing.

## What this adds

### `scripts/verification/codex-review.sh`

Deliberately does **not** trust the exit code. Inspects output for refusal signatures — quota, auth, network, near-empty response, missing `VERDICT:` line — and distinguishes three states the old setup collapsed into one:

| Exit | Meaning                |
| ---- | ---------------------- |
| `0`  | ran, clean             |
| `1`  | ran, blocking findings |
| `2`  | **did not run**        |

Exit 2 prints the tier-2 fallback instructions. **Tested live against the current quota block: returns 2, not 0.**

### `/gate` check 15

Runs it. Exit 2 must be reported ⚠️ NOT RUN, never PASS.

### CI job `verification-gate`

Fails any PR whose body has neither a `## Verification` section nor an explicit `Verification-waiver: <reason>` line.

This does not prove a review happened — it makes an **absent** one visible in GitHub instead of buried in a session log, which is the actual failure mode here. Zero-cost: no checkout, no install, pure API read on `github.event.pull_request.body`. Modeled on the existing `table-ownership` job.

### `.claude/rules/verification.md`

Rewritten to be true. Documents the exit-0 trap, the real enforcement surface, and the 3-lens same-model fallback — including the explicit instruction to **stop calling the rule "cross-model" while the fallback is active**, since same-model review shares the original author's blind spots.

## Verification

- [x] `bash -n` clean on the new script
- [x] Live run against the current quota block returns **exit 2**, not 0
- [x] `ci.yml` parses (pyyaml); 6 jobs including `verification-gate`
- [x] CI matcher unit-tested across 6 cases — `## Verification`, `### Verification`, valid waiver all pass; empty waiver, missing section, and the word used inline-only all fail
- [x] gitleaks clean
- [ ] **Codex cross-model pass — NOT RUN.** Quota-blocked until 2026-08-15. This PR _is_ the fix for that being invisible, so per the new rule it is recorded here rather than omitted.

## Note on this PR's own gate

The `verification-gate` job will run against this body and should pass on the `## Verification` section above — a live self-test of the check being introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
