### PR TITLE
feat(security): enforce the flip/privilege invariants that were only documented (#132, #126, #38)

### DIFF
--- a/docs/architecture/csharp-migration/ownership-flip-runbook.md
+++ b/docs/architecture/csharp-migration/ownership-flip-runbook.md
@@ -779,123 +779,140 @@ one of three drift sources — but only if the baseline is written to match prod
 Run all of these. Step 0 and steps 6-9 need a real DB (0, 6, 7 and 9 against prod, read-only;
 8 against a throwaway).
 
-0. **Schema drift, FIRST (#115).** Everything below compares the flip against an expected schema; this
-   proves the expected schema is still the real one.
-   ```bash
-   bash scripts/db/schema-baseline.sh check   # 0 = matches, 1 = drift, 2 = DID NOT RUN
-   ```
-   A flip PR normally changes **no** DDL, so this must be a clean exit 0 both before and after. If the
-   flip does move DDL (§4 option (a)/(b)), re-capture the baseline and commit it in the flip PR — the
-   baseline diff is then the reviewable record of exactly what the flip did to prod. **Exit 2 is not a
-   pass**; resolve it before continuing rather than proceeding on an unverified schema.
-1. **Ledger check, directly.**
-   ```bash
-   node scripts/table-ownership.mjs        # expect: "table-ownership check passed." exit 0
-   npx vitest run tests/governance/table-ownership.test.ts
-   ```
-2. **Prisma schema still validates and generates.** This is the real gate for missed back-relations.
-   ```bash
-   cd packages/db && npx prisma validate --schema=prisma/schema
-   npx prisma generate --schema=prisma/schema
-   ```
-3. **Both type checks.**
-   ```bash
-   pnpm --filter @tims/api exec tsc --noEmit
-   cd apps/web && npx tsc --noEmit
-   ```
-   This — not the ownership check — is what catches a surviving Prisma reader.
-4. **Full suite + build.** `npx vitest run` at root, then `/gate`. Remember §0 P6: a green suite is not
-   evidence the flip is clean, because the tripwires are static source greps.
-5. **Manual assertion the check cannot make — every `efcore[]` entry maps to a real EF `ToTable`:**
-   ```bash
-   # run from the repo root; the flag MUST precede -e
-   node --input-type=module -e "
-   import {parseLedger,parseEfCoreTables} from './scripts/table-ownership.mjs';
-   import fs from 'node:fs';
-   const l=parseLedger(fs.readFileSync('docs/architecture/table-ownership.md','utf8'));
-   const ef=new Set(parseEfCoreTables('services/Tims.Platform/src'));
-   console.log('ghost efcore[] entries:', l.efcore.filter(t=>!ef.has(t)));"
-   ```
-   Verified 2026-08-02 against the current repo: `ghost efcore[] entries: []` (all six pass). A typo in
-   step 4 of §1 shows up here and nowhere else.
-   _(Consider promoting this to a real rule in `checkOwnership()` — it is a ~3-line addition.)_
-6. **Live DB assertion — the table survived, unchanged.** Run against prod (read-only) before and after
-   the PR merges, and diff:
+0.  **Schema drift, FIRST (#115).** Everything below compares the flip against an expected schema; this
+    proves the expected schema is still the real one.
+    ```bash
+    bash scripts/db/schema-baseline.sh check   # 0 = matches, 1 = drift, 2 = DID NOT RUN
+    ```
+    A flip PR normally changes **no** DDL, so this must be a clean exit 0 both before and after. If the
+    flip does move DDL (§4 option (a)/(b)), re-capture the baseline and commit it in the flip PR — the
+    baseline diff is then the reviewable record of exactly what the flip did to prod. **Exit 2 is not a
+    pass**; resolve it before continuing rather than proceeding on an unverified schema.
+1.  **Ledger check, directly.**
+    ```bash
+    node scripts/table-ownership.mjs        # expect: "table-ownership check passed." exit 0
+    npx vitest run tests/governance/table-ownership.test.ts
+    ```
+2.  **Prisma schema still validates and generates.** This is the real gate for missed back-relations.
+    ```bash
+    cd packages/db && npx prisma validate --schema=prisma/schema
+    npx prisma generate --schema=prisma/schema
+    ```
+3.  **Both type checks.**
+    ```bash
+    pnpm --filter @tims/api exec tsc --noEmit
+    cd apps/web && npx tsc --noEmit
+    ```
+    This — not the ownership check — is what catches a surviving Prisma reader.
+4.  **Full suite + build.** `npx vitest run` at root, then `/gate`. Remember §0 P6: a green suite is not
+    evidence the flip is clean, because the tripwires are static source greps.
+5.  **Manual assertion the check cannot make — every `efcore[]` entry maps to a real EF `ToTable`:**
 
-   ```sql
-   SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity, pg_get_userbyid(c.relowner) AS owner
-   FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
-   WHERE n.nspname='public' AND c.relname IN ('<table>');
+    ```bash
+    # run from the repo root; the flag MUST precede -e
+    node --input-type=module -e "
+    import {parseLedger,parseEfCoreTables} from './scripts/table-ownership.mjs';
+    import fs from 'node:fs';
+    const l=parseLedger(fs.readFileSync('docs/architecture/table-ownership.md','utf8'));
+    const ef=new Set(parseEfCoreTables('services/Tims.Platform/src'));
+    console.log('ghost efcore[] entries:', l.efcore.filter(t=>!ef.has(t)));"
+    ```
 
-   SELECT polname, polpermissive, polcmd,
-          pg_get_expr(polqual, polrelid)      AS using_expr,
-          pg_get_expr(polwithcheck, polrelid) AS with_check_expr
-   FROM pg_policy WHERE polrelid = '<table>'::regclass;
+    Verified 2026-08-02 against the current repo: `ghost efcore[] entries: []` (all six pass). A typo in
+    step 4 of §1 shows up here and nowhere else.
+    _(Consider promoting this to a real rule in `checkOwnership()` — it is a ~3-line addition.)_
+    5b. **Database-side dependency scan — SCRIPTED as of #132.** Run this BEFORE deleting the model, not after:
 
-   SELECT grantee, privilege_type FROM information_schema.role_table_grants
-   WHERE table_schema='public' AND table_name='<table>' ORDER BY grantee, privilege_type;
+        ```bash
+        npx tsx scripts/db/pre-flip-scan.ts <table>...     # 0 = no blocker, 1 = blocker or could-not-run
+        ```
 
-   SELECT indexname FROM pg_indexes WHERE schemaname='public' AND tablename='<table>' ORDER BY 1;
+        It replaces four separate hand-run queries and covers what no repo grep can see: **views/matviews**
+        and **functions** referencing the table (both BLOCKERS — they keep working after the Prisma model is
+        deleted, and keep bypassing whatever scoping the TS stack applied), plus the §3(f) policy scan,
+        inbound FKs (flagging any from *outside* the flip set), `app_tenant` grants (#126), and RLS state.
 
-   SELECT to_regclass('public.<table>') IS NOT NULL AS exists,
-          pg_relation_size('public.<table>')        AS bytes;
+        Flip #2 ran these by hand and came back clean; the script exists so the next flip cannot forget one.
+        Its blocker paths are tested against a throwaway cluster with a real view and function.
 
-   -- Liveness / deletion probe. NOT an equality assertion — see below.
-   SELECT n_tup_ins, n_tup_del FROM pg_stat_user_tables WHERE relname='<table>';
-   SELECT max(<created_or_submitted_at>) FROM <table>;
-   ```
+6.  **Live DB assertion — the table survived, unchanged.** Run against prod (read-only) before and after
+    the PR merges, and diff. `pre-flip-scan.ts` above already reports existence, RLS, policies, grants and
+    FKs, so this step is the _before/after diff_ of that plus the row-liveness probes below:
 
-   **Split the invariant — "byte-identical" applies to _shape_, never to _rows_ (corrected 2026-08-02).**
-   - **Strict equality (any diff ⇒ stop and investigate):** `relrowsecurity`, `relforcerowsecurity`,
-     `relowner`, the full `pg_policy` row set, the `role_table_grants` set, the `pg_indexes` list, and
-     `to_regclass(...) IS NOT NULL`. The flip runs no DDL, so a diff here means something ran DDL that
-     should not have. This is a **DROP/DDL tripwire** and that is all it is.
-   - **NOT equality — monotonicity:** the row count. An earlier draft demanded "`SELECT count(*)` … must
-     be identical before and after"; in production that is **guaranteed to be violated**, because the
-     flip's entire premise is that C# is already the live sole writer.
-     `apps/web/lib/platform-api/engagement.ts:511-522` (`useEngagementSubmitSurveyResponse`) POSTs to
-     `/engagement/surveys/{surveyId}/responses` unconditionally, driven by
-     `apps/web/app/(admin)/dashboard/survey-take-modal.tsx:41` — every employee submission inserts a
-     `survey_responses` row while the before/after window is open. Following the old rule produces either
-     a **false rollback of a correct flip**, or an operator trained to ignore the one check that would
-     catch a real DROP. Assert instead: `count_after >= count_before`, the timestamp column advancing, and
-     `pg_stat_user_tables.n_tup_del` **not** jumping. `count(*)` is also a full sequential scan — at real
-     `survey_responses` volume it is the wrong probe to run twice against prod; prefer
-     `pg_relation_size > 0` plus the `n_tup_del` delta.
+    ```sql
+    SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity, pg_get_userbyid(c.relowner) AS owner
+    FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname IN ('<table>');
 
-7. **The C# writer still works.** `scripts/parity/cli.ts verify-write <surface>` against the live
-   surface. The flip does not change the write path, so this is a regression check, not a new proof.
+    SELECT polname, polpermissive, polcmd,
+           pg_get_expr(polqual, polrelid)      AS using_expr,
+           pg_get_expr(polwithcheck, polrelid) AS with_check_expr
+    FROM pg_policy WHERE polrelid = '<table>'::regclass;
 
-8. **Clean-checkout bootstrap still produces the table (§0 P8).** On a **scratch** DB, from a clean
-   checkout of the flip branch, run the documented bootstrap — `pnpm db:push` (which now routes through
-   `scripts/db/guard-prod-ddl.sh`) followed by the table's extracted DDL:
+    SELECT grantee, privilege_type FROM information_schema.role_table_grants
+    WHERE table_schema='public' AND table_name='<table>' ORDER BY grantee, privilege_type;
 
-   ```bash
-   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f services/Tims.Platform/db/flip-ddl/<name>.sql
-   ```
+    SELECT indexname FROM pg_indexes WHERE schemaname='public' AND tablename='<table>' ORDER BY 1;
 
-   Generate that file with `node scripts/db/extract-table-ddl.mjs` if it does not exist yet (#128 — it is
-   already committed for #64's and #66's tables). Then assert:
+    SELECT to_regclass('public.<table>') IS NOT NULL AS exists,
+           pg_relation_size('public.<table>')        AS bytes;
 
-   ```sql
-   SELECT to_regclass('public.<table>') IS NOT NULL;   -- must be true
-   ```
+    -- Liveness / deletion probe. NOT an equality assertion — see below.
+    SELECT n_tup_ins, n_tup_del FROM pg_stat_user_tables WHERE relname='<table>';
+    SELECT max(<created_or_submitted_at>) FROM <table>;
+    ```
 
-   and confirm `packages/db/prisma/seed-demo.ts` and `scripts/parity/seed.ts` still run green against it.
-   Deleting the Prisma model can remove the repo's **only** DDL definition of the table; this step is the
-   check that it did not.
+    **Split the invariant — "byte-identical" applies to _shape_, never to _rows_ (corrected 2026-08-02).**
+    - **Strict equality (any diff ⇒ stop and investigate):** `relrowsecurity`, `relforcerowsecurity`,
+      `relowner`, the full `pg_policy` row set, the `role_table_grants` set, the `pg_indexes` list, and
+      `to_regclass(...) IS NOT NULL`. The flip runs no DDL, so a diff here means something ran DDL that
+      should not have. This is a **DROP/DDL tripwire** and that is all it is.
+    - **NOT equality — monotonicity:** the row count. An earlier draft demanded "`SELECT count(*)` … must
+      be identical before and after"; in production that is **guaranteed to be violated**, because the
+      flip's entire premise is that C# is already the live sole writer.
+      `apps/web/lib/platform-api/engagement.ts:511-522` (`useEngagementSubmitSurveyResponse`) POSTs to
+      `/engagement/surveys/{surveyId}/responses` unconditionally, driven by
+      `apps/web/app/(admin)/dashboard/survey-take-modal.tsx:41` — every employee submission inserts a
+      `survey_responses` row while the before/after window is open. Following the old rule produces either
+      a **false rollback of a correct flip**, or an operator trained to ignore the one check that would
+      catch a real DROP. Assert instead: `count_after >= count_before`, the timestamp column advancing, and
+      `pg_stat_user_tables.n_tup_del` **not** jumping. `count(*)` is also a full sequential scan — at real
+      `survey_responses` volume it is the wrong probe to run twice against prod; prefer
+      `pg_relation_size > 0` plus the `n_tup_del` delta.
 
-9. **EF write-value compatibility against the live column types (§0 P10).** For the flipped table, diff
-   the EF property mappings against `information_schema.columns` on prod:
+7.  **The C# writer still works.** `scripts/parity/cli.ts verify-write <surface>` against the live
+    surface. The flip does not change the write path, so this is a regression check, not a new proof.
 
-   ```sql
-   SELECT column_name, data_type, datetime_precision, is_nullable, column_default
-   FROM information_schema.columns
-   WHERE table_schema='public' AND table_name='<table>' ORDER BY ordinal_position;
-   ```
+8.  **Clean-checkout bootstrap still produces the table (§0 P8).** On a **scratch** DB, from a clean
+    checkout of the flip branch, run the documented bootstrap — `pnpm db:push` (which now routes through
+    `scripts/db/guard-prod-ddl.sh`) followed by the table's extracted DDL:
 
-   Every EF property must pin a matching `HasColumnType(...)` or be `ValueGeneratedOnAdd`. This is what
-   makes §6's "same column shape" claim true — the absence of an EF migration does not.
+    ```bash
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f services/Tims.Platform/db/flip-ddl/<name>.sql
+    ```
+
+    Generate that file with `node scripts/db/extract-table-ddl.mjs` if it does not exist yet (#128 — it is
+    already committed for #64's and #66's tables). Then assert:
+
+    ```sql
+    SELECT to_regclass('public.<table>') IS NOT NULL;   -- must be true
+    ```
+
+    and confirm `packages/db/prisma/seed-demo.ts` and `scripts/parity/seed.ts` still run green against it.
+    Deleting the Prisma model can remove the repo's **only** DDL definition of the table; this step is the
+    check that it did not.
+
+9.  **EF write-value compatibility against the live column types (§0 P10).** For the flipped table, diff
+    the EF property mappings against `information_schema.columns` on prod:
+
+    ```sql
+    SELECT column_name, data_type, datetime_precision, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='<table>' ORDER BY ordinal_position;
+    ```
+
+    Every EF property must pin a matching `HasColumnType(...)` or be `ValueGeneratedOnAdd`. This is what
+    makes §6's "same column shape" claim true — the absence of an EF migration does not.
 
 ---
 

--- a/docs/architecture/csharp-migration/ownership-flip-runbook.md
+++ b/docs/architecture/csharp-migration/ownership-flip-runbook.md
@@ -833,7 +833,11 @@ Run all of these. Step 0 and steps 6-9 need a real DB (0, 6, 7 and 9 against pro
         inbound FKs (flagging any from *outside* the flip set), `app_tenant` grants (#126), and RLS state.
 
         Flip #2 ran these by hand and came back clean; the script exists so the next flip cannot forget one.
-        Its blocker paths are tested against a throwaway cluster with a real view and function.
+        Its blocker paths were exercised against a throwaway PG17 cluster carrying a deliberate view
+        and function over a target table (both correctly reported, exit 1). That run is not
+        committable — vitest has no database — so `tests/db/pre-flip-scan.test.ts` pins the
+        exit-code contract and the query-correctness properties offline instead, the same split as
+        `tests/db/schema-baseline-failure-paths.test.ts`.
 
 6.  **Live DB assertion — the table survived, unchanged.** Run against prod (read-only) before and after
     the PR merges, and diff. `pre-flip-scan.ts` above already reports existence, RLS, policies, grants and

--- a/docs/architecture/ddl-governance.md
+++ b/docs/architecture/ddl-governance.md
@@ -163,6 +163,67 @@ belong in 14; only 14 can carry them.
 baseline, and a client older than the server. Given #38, a gate whose did-not-run path is untested is
 not a gate. Exit 0 is not covered there (it needs live credentials); `/gate` check 16 covers it.
 
+### Check 17 — `app_tenant` least privilege (#126, added 2026-08-04)
+
+`scripts/security/verify-tenant-grants.ts`. Asserts that `app_tenant` holds `INSERT`/`UPDATE`/`DELETE`
+**only** on tables the Prisma schema declares. Exit 0 clean · 1 violation · 1 could-not-run (fail closed,
+same contract as 14 and 16 — an unrunnable privilege check is not a pass).
+
+It exists because production carries this default privilege, verified via `pg_default_acl`:
+
+```sql
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_tenant;   -- {app_tenant=arwd/postgres}
+```
+
+so **every** table `postgres` creates in `public` inherits tenant DML whether it needs it or not. Opt-out,
+not opt-in. On 2026-08-04 that was **20 tables** `app_tenant` has no business writing: the 3
+ownership-flipped ones, 5 EF-native (`fx_rates` + 4 `hris_*`), all 11 `qrtz_*`, and
+`__EFMigrationsHistory`. **13 of the 20 have RLS disabled entirely**, so for those the grant is the only
+guard.
+
+Two corrections this check encodes, both of which were wrong in #126's original framing:
+
+- **The grant is applied at `CREATE TABLE`, not at flip time.** An ownership flip does not re-grant, so a
+  `REVOKE` on a flipped table **is** durable. The earlier "every flip re-creates the condition" was wrong.
+- **The exposure is therefore not about flips at all** — it is every non-Prisma table in the schema, which
+  is how the 11 `qrtz_*` and `__EFMigrationsHistory` were sitting there unnoticed.
+
+Severity, stated honestly: `app_tenant` is `NOLOGIN` and `NOBYPASSRLS`, reachable only via
+`SET LOCAL ROLE app_tenant` from the app's own connection inside a transaction. Exploiting it needs
+app-level SQL injection or a compromised app process — **not remotely exploitable**. But containing exactly
+that is what `app_tenant` + RLS exist for.
+
+The default ACL is **deliberately left in place**: narrowing it means explicitly granting ~99 Prisma-owned
+tables, and one missed table breaks tenant writes at runtime. This check is the chosen alternative — it
+catches the next table that inherits the grant, instead of preventing the inheritance. Fix script:
+`packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql` (+ `.ROLLBACK.sql`).
+
+> **Grants are part of the baseline**, so applying that REVOKE **will** make check 16 report drift. Re-capture
+> in the same change, and read the diff — it should contain nothing but the expected `REVOKE`s.
+
+### Which of the flip/privilege controls are actually enforced, and where
+
+Being explicit, because "documented in the runbook" and "enforced" are not the same thing and this repo has
+been burned by the difference (#38):
+
+| Control                                          | Runs where                               | Enforced?                               |
+| ------------------------------------------------ | ---------------------------------------- | --------------------------------------- |
+| `tests/governance/scope-fixtures.test.ts` (#132) | `npx vitest run` → CI `Security Audit`   | ✅ **yes** — blocks CI                  |
+| `tests/governance/table-ownership.test.ts`       | `npx vitest run` + `dotnet-platform.yml` | ✅ yes                                  |
+| check 14 `verify-rls-isolation.ts`               | `/gate`, local (live DB)                 | ⚠️ ship-time only                       |
+| check 16 `schema-baseline.sh check`              | `/gate`, local (live DB)                 | ⚠️ ship-time only (#124)                |
+| **check 17 `verify-tenant-grants.ts`**           | `/gate`, local (live DB)                 | ⚠️ ship-time only — same credential gap |
+| `scripts/db/pre-flip-scan.ts` (#132)             | by hand, per flip (runbook §5)           | ❌ no — a documented step, not a gate   |
+
+`main` also has **no required status checks** (see the ownership-flip runbook §1), so even the ✅ rows are
+"CI goes red", not "the merge is blocked". `gh pr merge --admin` bypasses all of it.
+
+> **The `/gate` skill's own check list is defined outside this repository**, so adding "check 17" to it is a
+> separate edit that this change cannot make. Until that happens, check 17 must be run explicitly:
+> `npx tsx scripts/security/verify-tenant-grants.ts`. Treating it as automatically part of `/gate` would be
+> the same mistake as assuming the Codex gate ran (#38).
+
 ### CI, and what to do when check 16 cannot run
 
 Check 16 is local-only for now: it needs the direct connection (`:5432`) and a `pg_dump` ≥ 17, and

--- a/docs/architecture/ddl-governance.md
+++ b/docs/architecture/ddl-governance.md
@@ -177,12 +177,29 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
 ```
 
 so **every** table `postgres` creates in `public` inherits tenant DML whether it needs it or not. Opt-out,
-not opt-in. On 2026-08-04 that was **20 tables** `app_tenant` has no business writing: the 3
-ownership-flipped ones, 5 EF-native (`fx_rates` + 4 `hris_*`), all 11 `qrtz_*`, and
-`__EFMigrationsHistory`. **13 of the 20 have RLS disabled entirely**, so for those the grant is the only
-guard.
+not opt-in.
 
-Two corrections this check encodes, both of which were wrong in #126's original framing:
+**The discriminator is RLS, not ownership — and getting that wrong nearly caused an outage.** The first
+version of this check flagged all 20 non-Prisma tables, and the accompanying REVOKE script would have
+revoked all 20. A cross-model reviewer caught that the C# strangler writes its tables **as `app_tenant`**:
+`TenantScope.cs:46` issues `SET LOCAL ROLE app_tenant`, because that is *how* those writes are
+RLS-enforced. Revoking the 7 RLS-forced EF tables would have broken HRIS sync, access-review attestation
+and succession writes in production, detectable only by the failures themselves.
+
+So the rule is:
+
+| Table shape                | Meaning                                                    | app_tenant DML |
+| -------------------------- | ---------------------------------------------------------- | -------------- |
+| Prisma-owned               | the TS app writes it via `tenantDb`                        | required       |
+| EF-owned, RLS **forced**   | tenant-scoped; C# writes it as `app_tenant` under TenantScope | **required**   |
+| No RLS                     | not tenant-scoped ⇒ nothing writes it under TenantScope    | **dead → revoke** |
+
+That leaves **13 violations**: `fx_rates` (its writer runs on a plain connection as the owner role,
+explicitly not under TenantScope), all **11 `qrtz_*`** (no Quartz source file references TenantScope), and
+`__EFMigrationsHistory` (written by psql-applied scripts as `postgres`). All 13 have RLS disabled, so the
+grant is their only guard. Writer-verified per table, which is the step the first draft skipped.
+
+Two further corrections this check encodes, both wrong in #126's original framing:
 
 - **The grant is applied at `CREATE TABLE`, not at flip time.** An ownership flip does not re-grant, so a
   `REVOKE` on a flipped table **is** durable. The earlier "every flip re-creates the condition" was wrong.

--- a/packages/api/src/access/entity-policies.ts
+++ b/packages/api/src/access/entity-policies.ts
@@ -8,43 +8,45 @@ import type { AccessContext } from './types';
 // deploy-safety invariant: pre-seed prod grants are all org-equivalent, so this
 // slice is behavior-neutral until seed-access --apply runs.
 
-export type ScopedEntity =
-  | 'vacancy'
-  | 'candidate'
-  | 'application'
-  | 'interview'
-  | 'offer'
-  | 'assessmentAssignment'
-  | 'okr'
-  | 'coachingSession'
-  | 'feedback'
-  | 'onboardingPlan'
-  | 'enrollment'
-  | 'certificate'
-  | 'nineBoxEvaluation'
-  | 'successor'
-  | 'criticalRole'
-  | 'employeeCompensation'
-  | 'salaryAdjustment'
-  | 'team'
-  | 'actionPlan'
-  | 'leaderCommitment'
-  | 'commitment';
+// ONE source of truth (#132, 2026-08-04). This list previously existed THREE times — as a `ScopedEntity`
+// union, as this runtime `ENTITIES` set, and as the case labels below — with nothing keeping them in
+// agreement. Now the type is DERIVED from the array, so union/set drift is impossible by construction.
+// Verified behaviour-neutral at the point of the change: union, set and the
+// contracts/access-fixtures/scope-where.json entity set were all exactly these 21 names.
+//
+// Adding an entity here without a `case` below is a compile error (the switch is exhaustive over the
+// union). Adding one without a fixture case fails tests/governance/scope-fixtures.test.ts.
+export const SCOPED_ENTITIES = [
+  'vacancy',
+  'candidate',
+  'application',
+  'interview',
+  'offer',
+  'assessmentAssignment',
+  'okr',
+  'coachingSession',
+  'feedback',
+  'onboardingPlan',
+  'enrollment',
+  'certificate',
+  'nineBoxEvaluation',
+  'successor',
+  'criticalRole',
+  'employeeCompensation',
+  'salaryAdjustment',
+  'team',
+  'actionPlan',
+  'leaderCommitment',
+  'commitment',
+] as const;
+
+export type ScopedEntity = (typeof SCOPED_ENTITIES)[number];
 
 type Fragment = Record<string, unknown>;
 
-const ENTITIES: ReadonlySet<string> = new Set([
-  'vacancy', 'candidate', 'application', 'interview', 'offer', 'assessmentAssignment',
-  'okr', 'coachingSession', 'feedback', 'onboardingPlan', 'enrollment', 'certificate',
-  'nineBoxEvaluation', 'successor', 'criticalRole', 'employeeCompensation',
-  'salaryAdjustment', 'team', 'actionPlan', 'leaderCommitment', 'commitment',
-]);
+const ENTITIES: ReadonlySet<string> = new Set(SCOPED_ENTITIES);
 
-export async function scopeWhereFor(
-  entity: ScopedEntity,
-  access: AccessContext,
-  userId: string,
-): Promise<Fragment> {
+export async function scopeWhereFor(entity: ScopedEntity, access: AccessContext, userId: string): Promise<Fragment> {
   if (!ENTITIES.has(entity)) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Entidad sin politica de alcance: ${entity}` });
   }

--- a/packages/api/src/access/entity-policies.ts
+++ b/packages/api/src/access/entity-policies.ts
@@ -8,14 +8,20 @@ import type { AccessContext } from './types';
 // deploy-safety invariant: pre-seed prod grants are all org-equivalent, so this
 // slice is behavior-neutral until seed-access --apply runs.
 
-// ONE source of truth (#132, 2026-08-04). This list previously existed THREE times — as a `ScopedEntity`
-// union, as this runtime `ENTITIES` set, and as the case labels below — with nothing keeping them in
-// agreement. Now the type is DERIVED from the array, so union/set drift is impossible by construction.
+// ONE source of truth for the entity LIST (#132, 2026-08-04). It previously existed twice — as a
+// hand-written `ScopedEntity` union AND as this runtime `ENTITIES` set — with nothing keeping the two in
+// agreement. The type is now DERIVED from the array, so union/set drift is impossible by construction.
 // Verified behaviour-neutral at the point of the change: union, set and the
 // contracts/access-fixtures/scope-where.json entity set were all exactly these 21 names.
 //
-// Adding an entity here without a `case` below is a compile error (the switch is exhaustive over the
-// union). Adding one without a fixture case fails tests/governance/scope-fixtures.test.ts.
+// Being precise about what enforces what, since "one source of truth" alone would overstate it — the
+// names still appear in the switch below and in the fixture JSON, and those are pinned differently:
+//
+//   union ↔ this array   by CONSTRUCTION (the type is the array's element type)
+//   array ↔ switch below by the COMPILER: omit a case and `scopeWhereFor` has a code path returning
+//                        undefined against a declared `Promise<Fragment>` → TS2366. Verified empirically
+//                        by adding an entity without a case; no `assertNever` needed.
+//   array ↔ fixture JSON by tests/governance/scope-fixtures.test.ts (both directions).
 export const SCOPED_ENTITIES = [
   'vacancy',
   'candidate',

--- a/packages/api/src/access/scoped-probe.ts
+++ b/packages/api/src/access/scoped-probe.ts
@@ -92,12 +92,14 @@ export async function assertScoped(
   organizationId: string,
 ): Promise<void> {
   const fragment = await scopeWhereFor(entity, access, userId);
-  // BELT AND BRACES, and deliberately not redundant. The parameter type only constrains call sites TS
-  // can see: a caller holding a `string`, an `any`, or a cast-widened `ScopedEntity` compiles fine, and
-  // would then hit `DELEGATES[entity]()` with `undefined` and throw a bare
-  // `TypeError: ... is not a function` → an opaque 500. Worse, NOT_FOUND_MESSAGES still carries entries
-  // for the flipped entities (on purpose — those strings mirror ScopedNotFoundException.cs), so the code
-  // reads as though it supports them right up to this lookup. Fail with something that names the cause.
+  // BELT AND BRACES, and deliberately not redundant. The parameter type covers every call site the
+  // compiler can see — including one holding a widened `ScopedEntity`, which is correctly rejected. What
+  // it does NOT cover: an `any`, an explicit cast, or a JS caller. (A plain `string` IS rejected — an
+  // earlier version of this comment claimed otherwise.) Any of those reaches `DELEGATES[entity]()` with
+  // `undefined` and throws a bare `TypeError: ... is not a function` → an opaque 500. Worse,
+  // NOT_FOUND_MESSAGES still carries entries for the flipped entities (on purpose — those strings mirror
+  // ScopedNotFoundException.cs), so the code reads as though it supports them right up to this lookup.
+  // Fail with something that names the cause instead.
   const factory = DELEGATES[entity as ProbeableEntity] as (() => unknown) | undefined;
   if (typeof factory !== 'function') {
     throw new TRPCError({

--- a/packages/api/src/access/scoped-probe.ts
+++ b/packages/api/src/access/scoped-probe.ts
@@ -82,9 +82,9 @@ const DELEGATES: Record<ProbeableEntity, () => unknown> = {
 } as const;
 
 export async function assertScoped(
-  // ProbeableEntity, not ScopedEntity: a by-id probe needs a live Prisma delegate, so passing a
-  // flipped entity ('successor'/'criticalRole') is rejected at compile time instead of blowing up on an
-  // undefined delegate at runtime. Their probes live in C# now — see FlippedEntity above.
+  // ProbeableEntity, not ScopedEntity: a by-id probe needs a live Prisma delegate, so a flipped entity
+  // ('successor'/'criticalRole') is rejected at COMPILE time. Their probes live in C# now — see
+  // FlippedEntity above.
   entity: ProbeableEntity,
   id: string,
   access: AccessContext,
@@ -92,7 +92,22 @@ export async function assertScoped(
   organizationId: string,
 ): Promise<void> {
   const fragment = await scopeWhereFor(entity, access, userId);
-  const delegate = DELEGATES[entity]() as { findFirst: (args: unknown) => Promise<unknown> };
+  // BELT AND BRACES, and deliberately not redundant. The parameter type only constrains call sites TS
+  // can see: a caller holding a `string`, an `any`, or a cast-widened `ScopedEntity` compiles fine, and
+  // would then hit `DELEGATES[entity]()` with `undefined` and throw a bare
+  // `TypeError: ... is not a function` → an opaque 500. Worse, NOT_FOUND_MESSAGES still carries entries
+  // for the flipped entities (on purpose — those strings mirror ScopedNotFoundException.cs), so the code
+  // reads as though it supports them right up to this lookup. Fail with something that names the cause.
+  const factory = DELEGATES[entity as ProbeableEntity] as (() => unknown) | undefined;
+  if (typeof factory !== 'function') {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message:
+        `assertScoped('${String(entity)}') has no Prisma delegate: that table was ownership-flipped to ` +
+        `EF Core, so it cannot be probed from TypeScript. Probe it via the C# API instead.`,
+    });
+  }
+  const delegate = factory() as { findFirst: (args: unknown) => Promise<unknown> };
   const conditions: unknown[] = [{ id }, { organizationId }];
   if (SOFT_DELETABLE.has(entity)) conditions.push({ deletedAt: null });
   conditions.push(fragment);

--- a/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql
+++ b/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql
@@ -1,7 +1,7 @@
 -- ============================================================================================
 -- ROLLBACK for 2026-08-04-revoke-app-tenant-dml.sql (#126).
 --
--- Restores app_tenant's INSERT/UPDATE/DELETE on the 20 tables the forward script revoked, returning
+-- Restores app_tenant's INSERT/UPDATE/DELETE on the 13 tables the forward script revoked, returning
 -- them to the `{app_tenant=arwd/postgres}` ACL the default privilege had conferred.
 --
 -- WHEN TO RUN THIS. Only if revoking breaks something — i.e. if some path really does write one of
@@ -23,7 +23,9 @@
 
 BEGIN;
 
--- Part 1 (the 13 with no RLS).
+-- The 13 tables with no RLS. (An earlier draft also had a Part 2 for the 7 RLS-forced EF tables; that
+-- was removed from the forward script because revoking those would break C# writes, so there is
+-- nothing to restore for them here either.)
 GRANT INSERT, UPDATE, DELETE ON TABLE public."__EFMigrationsHistory" TO app_tenant;
 GRANT INSERT, UPDATE, DELETE ON TABLE public.fx_rates TO app_tenant;
 GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_blob_triggers TO app_tenant;
@@ -37,14 +39,5 @@ GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_scheduler_state TO app_tenant;
 GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_simple_triggers TO app_tenant;
 GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_simprop_triggers TO app_tenant;
 GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_triggers TO app_tenant;
-
--- Part 2 (the 7 EF-owned tables with forced RLS).
-GRANT INSERT, UPDATE, DELETE ON TABLE public.access_reviews TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.critical_roles TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.successors TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_connectors TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_external_employees TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_sync_record_errors TO app_tenant;
-GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_sync_runs TO app_tenant;
 
 COMMIT;

--- a/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql
+++ b/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql
@@ -1,0 +1,50 @@
+-- ============================================================================================
+-- ROLLBACK for 2026-08-04-revoke-app-tenant-dml.sql (#126).
+--
+-- Restores app_tenant's INSERT/UPDATE/DELETE on the 20 tables the forward script revoked, returning
+-- them to the `{app_tenant=arwd/postgres}` ACL the default privilege had conferred.
+--
+-- WHEN TO RUN THIS. Only if revoking breaks something — i.e. if some path really does write one of
+-- these tables as app_tenant, contradicting the analysis. If that happens, the finding is more
+-- interesting than the rollback: it means a TS path writes an EF-owned table, which is an ownership
+-- violation worth its own issue. Capture WHICH table and WHICH code path before reverting.
+--
+-- SELECT was never revoked by the forward script, so it is not re-granted here.
+--
+-- IDEMPOTENT: re-granting an existing privilege is a no-op.
+--
+-- APPLY:
+--   psql "$DIRECT_URL" -v ON_ERROR_STOP=1 -f packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql
+-- THEN re-capture the baseline, since grants are part of it:
+--   bash scripts/db/schema-baseline.sh capture
+-- NOTE: after rolling back, `/gate` check 17 (verify-tenant-grants) will FAIL again by design —
+-- that is the check correctly reporting the restored exposure, not a broken check.
+-- ============================================================================================
+
+BEGIN;
+
+-- Part 1 (the 13 with no RLS).
+GRANT INSERT, UPDATE, DELETE ON TABLE public."__EFMigrationsHistory" TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.fx_rates TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_blob_triggers TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_calendars TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_cron_triggers TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_fired_triggers TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_job_details TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_locks TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_paused_trigger_grps TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_scheduler_state TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_simple_triggers TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_simprop_triggers TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.qrtz_triggers TO app_tenant;
+
+-- Part 2 (the 7 EF-owned tables with forced RLS).
+GRANT INSERT, UPDATE, DELETE ON TABLE public.access_reviews TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.critical_roles TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.successors TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_connectors TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_external_employees TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_sync_record_errors TO app_tenant;
+GRANT INSERT, UPDATE, DELETE ON TABLE public.hris_sync_runs TO app_tenant;
+
+COMMIT;

--- a/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql
+++ b/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql
@@ -1,5 +1,5 @@
 -- ============================================================================================
--- #126 — REVOKE app_tenant's write privileges on the 20 tables it has no business writing.
+-- #126 — REVOKE app_tenant's write privileges on the 13 tables nothing writes as app_tenant.
 --
 -- WHY. Production carries this default privilege (pg_default_acl, verified 2026-08-04):
 --
@@ -7,20 +7,22 @@
 --     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_tenant;
 --
 -- so every table `postgres` creates in `public` inherits tenant DML whether it needs it or not.
--- 20 tables currently hold write privileges that no TS code path uses.
+-- 20 tables hold app_tenant DML without being Prisma-owned; 13 of those are genuinely dead (see below)
+-- and are what this script revokes. The other 7 are RLS-forced EF tables that C# writes AS app_tenant
+-- under TenantScope — revoking those would break production. See PART 2 below.
 --
 -- SEVERITY, STATED PLAINLY. `app_tenant` is NOLOGIN and NOBYPASSRLS: it is reachable only via
 -- `SET LOCAL ROLE app_tenant` from the app's own connection inside a transaction, so exploiting this
 -- needs app-level SQL injection or a compromised app process. It is NOT remotely exploitable. But
--- containing exactly that scenario is what `app_tenant` + RLS exist for, and 13 of the 20 have RLS
--- DISABLED entirely (0 policies), so for those the grant is the only thing in the way. Those 13 are
--- revoked first below, in their own transaction, for that reason.
+-- containing exactly that scenario is what `app_tenant` + RLS exist for, and every table revoked here has
+-- RLS DISABLED entirely (0 policies), so the grant is the only thing in the way. That is also precisely
+-- why they are safe to revoke: no RLS ⇒ not tenant-scoped ⇒ nothing writes them under TenantScope.
 --
 -- WHAT THIS DOES NOT DO. It does not touch the default ACL, so a NEWLY created table will still
 -- inherit tenant DML. That was a deliberate decision (#126): narrowing the default means explicitly
 -- granting ~99 Prisma-owned tables, and a table missed there breaks tenant writes at runtime. The
 -- regression guard instead is `scripts/security/verify-tenant-grants.ts` (`/gate` check 17), which
--- fails the moment any non-Prisma table holds app_tenant DML.
+-- fails the moment a table with NO RLS holds app_tenant DML.
 --
 -- SELECT IS DELIBERATELY RETAINED on every table here. Revoking reads is a separate, riskier change:
 -- `information_schema`/catalog reads and any diagnostic query would change behaviour, and no TS path
@@ -29,7 +31,12 @@
 -- SAFETY / PRE-FLIGHT (all verified 2026-08-04 against prod, read-only):
 --   * The §3(f) policy scan returns 0 rows — no RLS policy on ANY table references these tables, so
 --     no policy's USING/WITH CHECK clause depends on app_tenant being able to read or write them.
---   * Zero views, zero matviews and zero functions in `public` reference the flipped pair.
+--   * Zero views, zero matviews and zero functions in `public` reference these tables
+--     (scripts/db/pre-flip-scan.ts).
+--   * WRITER-VERIFIED, per table, which is the check the first draft of this script skipped:
+--     fx_rates → FxRateDbContext/FxRateWriteRepository run on a PLAIN connection as the owner role,
+--     explicitly NOT under TenantScope; qrtz_* → no Quartz source file references TenantScope at all;
+--     __EFMigrationsHistory → written by psql-applied idempotent scripts as `postgres`.
 --   * `audit_logs` and `data_access_logs` are NOT in this script: they are `efcoreAppendOnly` and the
 --     TS app genuinely appends to them. They already hold INSERT,SELECT only — the one pre-existing
 --     deliberate narrowing in the schema, and the precedent this script follows.
@@ -74,23 +81,21 @@ REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_triggers FROM app_tenant;
 
 COMMIT;
 
--- ── PART 2: the 7 EF-owned tables that DO have forced fail-closed RLS. ─────────────────────────
--- Lower risk (RLS bounds the damage to the caller's own org) but still dead privilege: C# owns every
--- one of these and no TS path writes them.
-BEGIN;
-
--- Ownership-flipped: EF Core is the sole writer.
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.access_reviews FROM app_tenant;   -- flip #1, #63/#65
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.critical_roles FROM app_tenant;   -- flip #2, #69
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.successors FROM app_tenant;       -- flip #2, #69
-
--- EF-native: created greenfield for the HRIS domain, never Prisma-owned, never had a TS writer.
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_connectors FROM app_tenant;
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_external_employees FROM app_tenant;
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_sync_record_errors FROM app_tenant;
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_sync_runs FROM app_tenant;
-
-COMMIT;
+-- ── PART 2: REMOVED. It would have caused a production write outage. ──────────────────────────
+-- An earlier draft of this script ALSO revoked DML on access_reviews, critical_roles, successors and
+-- the 4 hris_* tables, on the reasoning "C# owns them, so no TS path writes them". That reasoning was
+-- WRONG, and a cross-model reviewer caught it before this was applied.
+--
+-- The C# strangler writes its tables UNDER TenantScope, and TenantScope.cs:46 issues
+--   SET LOCAL ROLE app_tenant
+-- because that is HOW those writes become RLS-enforced. So for a tenant-scoped EF table the app_tenant
+-- grant is not dead privilege — it is load-bearing. Revoking it would have broken HRIS sync,
+-- access-review attestation and succession writes in production, and the only detection would have been
+-- the write failures themselves.
+--
+-- "EF owns the table" and "app_tenant never writes it" are different claims. Do not conflate them again.
+-- The discriminator is RLS: RLS-forced ⇒ tenant-scoped ⇒ possibly written as app_tenant ⇒ KEEP the grant.
+-- Every table in Part 1 has NO RLS, which is exactly why nothing writes it under TenantScope.
 
 -- ── POST-APPLY ASSERTION (run manually; not part of the transactions above). ───────────────────
 -- Must return zero rows.
@@ -100,9 +105,12 @@ COMMIT;
 --    WHERE g.table_schema='public' AND g.grantee='app_tenant'
 --      AND g.privilege_type IN ('INSERT','UPDATE','DELETE')
 --      AND g.table_name IN (
---        '__EFMigrationsHistory','fx_rates','access_reviews','critical_roles','successors',
---        'hris_connectors','hris_external_employees','hris_sync_record_errors','hris_sync_runs',
+--        '__EFMigrationsHistory','fx_rates',
 --        'qrtz_blob_triggers','qrtz_calendars','qrtz_cron_triggers','qrtz_fired_triggers',
 --        'qrtz_job_details','qrtz_locks','qrtz_paused_trigger_grps','qrtz_scheduler_state',
 --        'qrtz_simple_triggers','qrtz_simprop_triggers','qrtz_triggers')
 --    ORDER BY 1,2;
+--
+-- NOTE the 7 RLS-forced EF tables (access_reviews, critical_roles, successors, hris_*) are deliberately
+-- ABSENT from that list. They MUST still hold app_tenant DML. If they ever appear without it, something
+-- revoked them by mistake and C# writes are broken.

--- a/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql
+++ b/packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql
@@ -1,0 +1,108 @@
+-- ============================================================================================
+-- #126 — REVOKE app_tenant's write privileges on the 20 tables it has no business writing.
+--
+-- WHY. Production carries this default privilege (pg_default_acl, verified 2026-08-04):
+--
+--   ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_tenant;
+--
+-- so every table `postgres` creates in `public` inherits tenant DML whether it needs it or not.
+-- 20 tables currently hold write privileges that no TS code path uses.
+--
+-- SEVERITY, STATED PLAINLY. `app_tenant` is NOLOGIN and NOBYPASSRLS: it is reachable only via
+-- `SET LOCAL ROLE app_tenant` from the app's own connection inside a transaction, so exploiting this
+-- needs app-level SQL injection or a compromised app process. It is NOT remotely exploitable. But
+-- containing exactly that scenario is what `app_tenant` + RLS exist for, and 13 of the 20 have RLS
+-- DISABLED entirely (0 policies), so for those the grant is the only thing in the way. Those 13 are
+-- revoked first below, in their own transaction, for that reason.
+--
+-- WHAT THIS DOES NOT DO. It does not touch the default ACL, so a NEWLY created table will still
+-- inherit tenant DML. That was a deliberate decision (#126): narrowing the default means explicitly
+-- granting ~99 Prisma-owned tables, and a table missed there breaks tenant writes at runtime. The
+-- regression guard instead is `scripts/security/verify-tenant-grants.ts` (`/gate` check 17), which
+-- fails the moment any non-Prisma table holds app_tenant DML.
+--
+-- SELECT IS DELIBERATELY RETAINED on every table here. Revoking reads is a separate, riskier change:
+-- `information_schema`/catalog reads and any diagnostic query would change behaviour, and no TS path
+-- needs these reads either, so it buys little. Revoke DML, re-verify, then consider SELECT separately.
+--
+-- SAFETY / PRE-FLIGHT (all verified 2026-08-04 against prod, read-only):
+--   * The §3(f) policy scan returns 0 rows — no RLS policy on ANY table references these tables, so
+--     no policy's USING/WITH CHECK clause depends on app_tenant being able to read or write them.
+--   * Zero views, zero matviews and zero functions in `public` reference the flipped pair.
+--   * `audit_logs` and `data_access_logs` are NOT in this script: they are `efcoreAppendOnly` and the
+--     TS app genuinely appends to them. They already hold INSERT,SELECT only — the one pre-existing
+--     deliberate narrowing in the schema, and the precedent this script follows.
+--   * No Prisma-owned table appears below. `verify-tenant-grants.ts` derives that set from
+--     `packages/db/prisma/schema` via the ownership check's own parser.
+--
+-- IDEMPOTENT: `REVOKE` on a privilege that is already absent is a no-op, not an error.
+-- REVERSIBLE: 2026-08-04-revoke-app-tenant-dml.ROLLBACK.sql restores the exact prior grants.
+--
+-- APPLY (Federico — this is prod DCL):
+--   psql "$DIRECT_URL" -v ON_ERROR_STOP=1 -f packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql
+-- THEN, in the same session, re-capture the baseline and re-run the guards:
+--   bash scripts/db/schema-baseline.sh capture      # grants are IN the baseline — it WILL diff
+--   npx tsx scripts/security/verify-tenant-grants.ts   # must print ✓ and exit 0
+--   npx tsx scripts/security/verify-rls-isolation.ts   # must stay exit 0
+-- ============================================================================================
+
+-- ── PART 1: the 13 with NO RLS — the grant is their only guard, so these matter most. ──────────
+BEGIN;
+
+-- Migration history. A tenant-role write here could forge or delete applied-migration records,
+-- which is also what makes the EF path's self-recording property untrustworthy if abused.
+REVOKE INSERT, UPDATE, DELETE ON TABLE public."__EFMigrationsHistory" FROM app_tenant;
+
+-- FX rates feed compensation and DEI pay-equity maths for EVERY tenant. This table is global (no
+-- organization_id), so a write here is inherently cross-tenant.
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.fx_rates FROM app_tenant;
+
+-- Quartz scheduler internals. Writes here manipulate job schedules, triggers and locks for the whole
+-- platform. Quartz connects as its own principal and never as app_tenant.
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_blob_triggers FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_calendars FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_cron_triggers FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_fired_triggers FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_job_details FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_locks FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_paused_trigger_grps FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_scheduler_state FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_simple_triggers FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_simprop_triggers FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.qrtz_triggers FROM app_tenant;
+
+COMMIT;
+
+-- ── PART 2: the 7 EF-owned tables that DO have forced fail-closed RLS. ─────────────────────────
+-- Lower risk (RLS bounds the damage to the caller's own org) but still dead privilege: C# owns every
+-- one of these and no TS path writes them.
+BEGIN;
+
+-- Ownership-flipped: EF Core is the sole writer.
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.access_reviews FROM app_tenant;   -- flip #1, #63/#65
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.critical_roles FROM app_tenant;   -- flip #2, #69
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.successors FROM app_tenant;       -- flip #2, #69
+
+-- EF-native: created greenfield for the HRIS domain, never Prisma-owned, never had a TS writer.
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_connectors FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_external_employees FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_sync_record_errors FROM app_tenant;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.hris_sync_runs FROM app_tenant;
+
+COMMIT;
+
+-- ── POST-APPLY ASSERTION (run manually; not part of the transactions above). ───────────────────
+-- Must return zero rows.
+--
+--   SELECT g.table_name, g.privilege_type
+--     FROM information_schema.role_table_grants g
+--    WHERE g.table_schema='public' AND g.grantee='app_tenant'
+--      AND g.privilege_type IN ('INSERT','UPDATE','DELETE')
+--      AND g.table_name IN (
+--        '__EFMigrationsHistory','fx_rates','access_reviews','critical_roles','successors',
+--        'hris_connectors','hris_external_employees','hris_sync_record_errors','hris_sync_runs',
+--        'qrtz_blob_triggers','qrtz_calendars','qrtz_cron_triggers','qrtz_fired_triggers',
+--        'qrtz_job_details','qrtz_locks','qrtz_paused_trigger_grps','qrtz_scheduler_state',
+--        'qrtz_simple_triggers','qrtz_simprop_triggers','qrtz_triggers')
+--    ORDER BY 1,2;

--- a/scripts/db/pre-flip-scan.ts
+++ b/scripts/db/pre-flip-scan.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env npx tsx
+/**
+ * Pre-flip DATABASE-SIDE dependency scan — issue #132, for the ownership-flip runbook §5.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The runbook's P2 reader sweep is six `grep` strategies over the repo. All six share one blind spot:
+ * a dependency that lives in the DATABASE rather than in a file. A view, a materialized view or a
+ * `plpgsql` function over the table being flipped is a real reader that is invisible to
+ *
+ *   * `tsc`                     — it is not TypeScript,
+ *   * `scripts/table-ownership.mjs` — that only greps `@@map` / `ToTable`,
+ *   * every P2 grep             — the object is not in the repo at all.
+ *
+ * #111 is the standing proof that production contains objects no repo file describes, so "we would have
+ * noticed" is not an argument. Flip #2 (#69) ran these queries by hand, one at a time, and came back
+ * clean — this script exists so the next flip runs one command instead of remembering four, and so a
+ * non-clean result is impossible to skim past.
+ *
+ * WHAT IT CHECKS, per table
+ *   1. BLOCKER  views / matviews whose definition references the table
+ *   2. BLOCKER  functions whose body references the table
+ *   3. INFO     RLS policies on OTHER tables that reference this one (runbook §3(f) pre-REVOKE scan)
+ *   4. INFO     inbound foreign keys (a FK from outside the flip set means the flip is not self-contained)
+ *   5. INFO     app_tenant grants (#126 — dead DML after the flip)
+ *   6. INFO     existence, RLS enabled/forced, policy count, size
+ *
+ * BLOCKER vs INFO: a view or function must be dispositioned BEFORE the model is deleted, because
+ * deleting the model does not break them — they keep working against the table and keep bypassing
+ * whatever scoping the TS stack used to apply. Everything else is reported for the PR body.
+ *
+ * USAGE
+ *   npx tsx scripts/db/pre-flip-scan.ts critical_roles successors
+ *   npx tsx scripts/db/pre-flip-scan.ts --json surveys survey_responses
+ *
+ * Exits 0 if no BLOCKER found, 1 if any BLOCKER found, and 1 if it cannot run (fail closed — an
+ * unrunnable scan is not a clean scan). Read-only: every statement is a SELECT, safe against production.
+ */
+import { readFileSync } from 'node:fs';
+import { Client } from 'pg';
+
+function loadDbEnv(): void {
+  if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
+  for (const path of ['packages/db/.env', '.env']) {
+    try {
+      for (const line of readFileSync(path, 'utf8').split('\n')) {
+        const m = /^\s*(DIRECT_URL|DATABASE_URL)\s*=\s*(.*)$/.exec(line);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+      }
+    } catch {
+      /* file absent — try the next one */
+    }
+    if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
+  }
+}
+
+interface Report {
+  table: string;
+  exists: boolean;
+  rlsEnabled: boolean;
+  rlsForced: boolean;
+  policies: string[];
+  bytes: number | null;
+  dependentViews: string[];
+  dependentRoutines: string[];
+  policiesReferencing: string[];
+  inboundFks: string[];
+  appTenantPrivs: string[];
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const tables = args.filter((a) => !a.startsWith('--'));
+  if (tables.length === 0) {
+    console.error('usage: npx tsx scripts/db/pre-flip-scan.ts [--json] <table>...');
+    process.exit(1);
+  }
+
+  loadDbEnv();
+  const url = process.env.DIRECT_URL || process.env.DATABASE_URL;
+  if (!url) {
+    console.error('✖ pre-flip-scan: no DIRECT_URL or DATABASE_URL — scan DID NOT RUN (not a clean scan).');
+    process.exit(1);
+  }
+
+  // \y is a Postgres word boundary; without it `successors` would also match inside other identifiers.
+  const wordRe = (t: string) => `\\y${t}\\y`;
+  const db = new Client({ connectionString: url });
+  const reports: Report[] = [];
+
+  try {
+    await db.connect();
+    for (const table of tables) {
+      const re = wordRe(table);
+
+      const meta = await db.query<{
+        exists: boolean;
+        rls_enabled: boolean;
+        rls_forced: boolean;
+        bytes: string | null;
+      }>(
+        `SELECT to_regclass('public.'||$1) IS NOT NULL AS exists,
+                coalesce(c.relrowsecurity,false)      AS rls_enabled,
+                coalesce(c.relforcerowsecurity,false) AS rls_forced,
+                pg_relation_size(c.oid)               AS bytes
+           FROM pg_namespace n LEFT JOIN pg_class c ON c.relname=$1 AND c.relnamespace=n.oid
+          WHERE n.nspname='public'`,
+        [table],
+      );
+
+      const own = await db.query<{ polname: string }>(
+        `SELECT p.polname FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid
+           JOIN pg_namespace n ON n.oid=c.relnamespace
+          WHERE n.nspname='public' AND c.relname=$1 ORDER BY 1`,
+        [table],
+      );
+
+      const views = await db.query<{ name: string }>(
+        `SELECT n.nspname||'.'||c.relname AS name
+           FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+          WHERE c.relkind IN ('v','m') AND pg_get_viewdef(c.oid) ~* $1 ORDER BY 1`,
+        [re],
+      );
+
+      const routines = await db.query<{ name: string }>(
+        `SELECT n.nspname||'.'||p.proname AS name
+           FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+          WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+            AND p.prosrc ~* $1 ORDER BY 1`,
+        [re],
+      );
+
+      // §3(f): a policy on ANOTHER table whose USING/WITH CHECK references this one. Such a policy
+      // depends on the table remaining readable by whatever role evaluates it — so it must be
+      // dispositioned before revoking anything (#126) and before the flip.
+      const refPolicies = await db.query<{ name: string }>(
+        `SELECT c.relname||'.'||p.polname AS name
+           FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid
+          WHERE (coalesce(pg_get_expr(p.polqual,p.polrelid),'') ~* $1
+              OR coalesce(pg_get_expr(p.polwithcheck,p.polrelid),'') ~* $1)
+            AND c.relname <> $2
+          ORDER BY 1`,
+        [re, table],
+      );
+
+      const fks = await db.query<{ name: string }>(
+        `SELECT tc.table_name||'.'||kcu.column_name AS name
+           FROM information_schema.table_constraints tc
+           JOIN information_schema.key_column_usage kcu       ON tc.constraint_name=kcu.constraint_name
+           JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name=ccu.constraint_name
+          WHERE tc.constraint_type='FOREIGN KEY' AND tc.table_schema='public'
+            AND ccu.table_name=$1
+          ORDER BY 1`,
+        [table],
+      );
+
+      const grants = await db.query<{ privilege_type: string }>(
+        `SELECT DISTINCT privilege_type FROM information_schema.role_table_grants
+          WHERE table_schema='public' AND table_name=$1 AND grantee='app_tenant'
+          ORDER BY 1`,
+        [table],
+      );
+
+      reports.push({
+        table,
+        exists: meta.rows[0]?.exists ?? false,
+        rlsEnabled: meta.rows[0]?.rls_enabled ?? false,
+        rlsForced: meta.rows[0]?.rls_forced ?? false,
+        policies: own.rows.map((r) => r.polname),
+        bytes: meta.rows[0]?.bytes == null ? null : Number(meta.rows[0].bytes),
+        dependentViews: views.rows.map((r) => r.name),
+        dependentRoutines: routines.rows.map((r) => r.name),
+        policiesReferencing: refPolicies.rows.map((r) => r.name),
+        inboundFks: fks.rows.map((r) => r.name),
+        appTenantPrivs: grants.rows.map((r) => r.privilege_type),
+      });
+    }
+  } finally {
+    await db.end();
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ tables: reports }, null, 2));
+  }
+
+  const blockers: string[] = [];
+  const flipSet = new Set(tables);
+
+  for (const r of reports) {
+    if (!asJson) {
+      console.log(`\n── ${r.table} ──────────────────────────────────────────────`);
+      if (!r.exists) {
+        console.log('  ⚠ DOES NOT EXIST in public — check the name before flipping.');
+      } else {
+        console.log(
+          `  exists   yes   RLS ${r.rlsEnabled ? 'enabled' : 'DISABLED'}` +
+            `${r.rlsForced ? ' + forced' : ''}, ${r.policies.length} policy(ies)` +
+            `${r.policies.length ? ' [' + r.policies.join(', ') + ']' : ''}, ${r.bytes ?? '?'} bytes`,
+        );
+        console.log(`  app_tenant  ${r.appTenantPrivs.join(',') || '(none)'}`);
+      }
+      console.log(`  views/matviews referencing it   ${r.dependentViews.join(', ') || 'none'}`);
+      console.log(`  functions referencing it        ${r.dependentRoutines.join(', ') || 'none'}`);
+      console.log(`  policies elsewhere referencing  ${r.policiesReferencing.join(', ') || 'none'}`);
+      // A FK from a table also being flipped is fine — both sides move together.
+      const foreignFks = r.inboundFks.filter((f) => !flipSet.has(f.split('.')[0]));
+      console.log(
+        `  inbound FKs                     ${r.inboundFks.join(', ') || 'none'}` +
+          (foreignFks.length ? `  ← ${foreignFks.length} from OUTSIDE the flip set` : ''),
+      );
+    }
+
+    if (!r.exists) blockers.push(`${r.table}: does not exist in public`);
+    for (const v of r.dependentViews) blockers.push(`${r.table}: view/matview ${v} references it`);
+    for (const f of r.dependentRoutines) blockers.push(`${r.table}: function ${f} references it`);
+  }
+
+  if (blockers.length === 0) {
+    console.log(
+      `\n✓ No database-side blocker for ${tables.join(', ')}.` +
+        `\n  Reported items above still belong in the flip PR body — notably app_tenant grants (#126,` +
+        `\n  dead DML after the flip) and any inbound FK from outside the flip set.\n`,
+    );
+    process.exit(0);
+  }
+
+  console.error(`\n✖ ${blockers.length} database-side BLOCKER(s):\n`);
+  for (const b of blockers) console.error(`  ${b}`);
+  console.error(
+    '\nA view or function over the table keeps working after the Prisma model is deleted, and keeps' +
+      '\nbypassing whatever scoping the TS stack applied. Disposition each one BEFORE deleting the model' +
+      '\n(runbook §0 P2 / §5).\n',
+  );
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('✖ pre-flip-scan failed to run:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/db/pre-flip-scan.ts
+++ b/scripts/db/pre-flip-scan.ts
@@ -100,7 +100,7 @@ async function main(): Promise<void> {
         rls_forced: boolean;
         bytes: string | null;
       }>(
-        `SELECT to_regclass('public.'||$1) IS NOT NULL AS exists,
+        `SELECT to_regclass(format('public.%I', $1)) IS NOT NULL AS exists,
                 coalesce(c.relrowsecurity,false)      AS rls_enabled,
                 coalesce(c.relforcerowsecurity,false) AS rls_forced,
                 pg_relation_size(c.oid)               AS bytes
@@ -151,6 +151,10 @@ async function main(): Promise<void> {
            JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name=ccu.constraint_name
           WHERE tc.constraint_type='FOREIGN KEY' AND tc.table_schema='public'
             AND ccu.table_name=$1
+            -- constraint_name is NOT globally unique across schemas, so join on the schema too or a
+            -- same-named constraint elsewhere produces a phantom inbound FK.
+            AND kcu.constraint_schema = tc.constraint_schema
+            AND ccu.constraint_schema = tc.constraint_schema
           ORDER BY 1`,
         [table],
       );
@@ -177,7 +181,8 @@ async function main(): Promise<void> {
       });
     }
   } finally {
-    await db.end();
+    // A failed connect() makes end() throw too, which would replace the real error with a useless one.
+    await db.end().catch(() => undefined);
   }
 
   if (asJson) {
@@ -217,11 +222,15 @@ async function main(): Promise<void> {
   }
 
   if (blockers.length === 0) {
-    console.log(
-      `\n✓ No database-side blocker for ${tables.join(', ')}.` +
-        `\n  Reported items above still belong in the flip PR body — notably app_tenant grants (#126,` +
-        `\n  dead DML after the flip) and any inbound FK from outside the flip set.\n`,
-    );
+    // Gated on !asJson: in --json mode stdout must be the JSON document and NOTHING else, or a consumer
+    // piping to jq/JSON.parse breaks precisely in the success case.
+    if (!asJson) {
+      console.log(
+        `\n✓ No database-side blocker for ${tables.join(', ')}.` +
+          `\n  Reported items above still belong in the flip PR body — notably app_tenant grants (#126,` +
+          `\n  dead DML after the flip) and any inbound FK from outside the flip set.\n`,
+      );
+    }
     process.exit(0);
   }
 

--- a/scripts/security/verify-tenant-grants.ts
+++ b/scripts/security/verify-tenant-grants.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env npx tsx
+/**
+ * `app_tenant` least-privilege guard — issue #126.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Production carries this default privilege (verified 2026-08-04 via `pg_default_acl`):
+ *
+ *   ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+ *     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_tenant;   -- default_acl {app_tenant=arwd/postgres}
+ *
+ * So EVERY table `postgres` creates in `public` gets tenant DML automatically, whether or not
+ * `app_tenant` has any business writing it. That is opt-out, not opt-in, and nothing noticed.
+ *
+ * A CORRECTION TO THE ORIGINAL #126 FRAMING: the grant is applied at CREATE TABLE time, not at
+ * ownership-flip time. An ownership flip does NOT re-grant, so a REVOKE on a flipped table IS durable.
+ * The real exposure is broader than the flip process — it is every non-Prisma table in the schema.
+ *
+ * WHAT WAS ACTUALLY FOUND (2026-08-04, 20 tables)
+ * ----------------------------------------------
+ *   8  `efcore`            access_reviews, critical_roles, successors (flipped) + fx_rates,
+ *                          hris_connectors, hris_external_employees, hris_sync_runs,
+ *                          hris_sync_record_errors (EF-native, never Prisma-owned)
+ *   11 `quartzInfra`       every qrtz_* table — scheduler internals
+ *   1  uncategorised       __EFMigrationsHistory — migration history, forgeable/deletable
+ *
+ * SEVERITY, STATED HONESTLY. `app_tenant` is NOLOGIN and NOBYPASSRLS, so it is reachable only via
+ * `SET LOCAL ROLE app_tenant` from the app's own connection inside a transaction. Exploiting this needs
+ * app-level SQL injection or a compromised app process — it is NOT remotely exploitable. But that is
+ * exactly the scenario `app_tenant` + RLS exists to contain, and 13 of the 20 have **RLS disabled
+ * entirely** (fx_rates, all 11 qrtz_*, __EFMigrationsHistory — 0 policies each), so for those the grant
+ * is the only thing standing in the way. The other 7 are bounded by a forced fail-closed policy.
+ *
+ * WHY A LIVE CHECK RATHER THAN A UNIT TEST
+ * ----------------------------------------
+ * Same reason as check 14 (#111): grants live in the database, not the repo. No amount of migration
+ * reading finds a privilege that a default ACL conferred silently. And because the default ACL is
+ * deliberately left in place (see #126 — narrowing it means explicitly granting ~99 Prisma tables, a
+ * far larger blast radius), this check is what stops the next new table from quietly inheriting DML.
+ *
+ * USAGE
+ *   npx tsx scripts/security/verify-tenant-grants.ts            # uses DIRECT_URL, else DATABASE_URL
+ *   ALLOW_KNOWN_VIOLATIONS=1 npx tsx scripts/security/verify-tenant-grants.ts   # report, exit 0
+ *
+ * Exits 0 if `app_tenant` holds DML only on Prisma-owned tables, 1 on any violation, and 1 if it
+ * cannot run (fail closed — an unrunnable privilege check is not a pass). Read-only: every statement
+ * is a SELECT.
+ */
+import { readFileSync } from 'node:fs';
+import { Client } from 'pg';
+import { parsePrismaTables } from '../table-ownership.mjs';
+
+function loadDbEnv(): void {
+  if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
+  for (const path of ['packages/db/.env', '.env']) {
+    try {
+      for (const line of readFileSync(path, 'utf8').split('\n')) {
+        const m = /^\s*(DIRECT_URL|DATABASE_URL)\s*=\s*(.*)$/.exec(line);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+      }
+    } catch {
+      /* file absent — try the next one */
+    }
+    if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
+  }
+}
+
+const WRITE_PRIVS = ['INSERT', 'UPDATE', 'DELETE'] as const;
+
+/**
+ * Tables that legitimately keep NARROWED tenant DML despite not being a Prisma model.
+ * `audit_logs` / `data_access_logs` are `efcoreAppendOnly`: the TS app appends to them, so INSERT is
+ * required and UPDATE/DELETE must never be granted. Production already matches this (they are the only
+ * two tables in the schema with an `INSERT,SELECT`-only grant), so this is recording an existing
+ * deliberate narrowing, not creating an exemption.
+ */
+const APPEND_ONLY_ALLOWED: Readonly<Record<string, ReadonlySet<string>>> = {
+  audit_logs: new Set(['INSERT']),
+  data_access_logs: new Set(['INSERT']),
+};
+
+interface Violation {
+  table: string;
+  privs: string[];
+  rlsEnabled: boolean;
+  policies: number;
+}
+
+async function main(): Promise<void> {
+  loadDbEnv();
+  const url = process.env.DIRECT_URL || process.env.DATABASE_URL;
+  if (!url) {
+    console.error('✖ verify-tenant-grants: no DIRECT_URL or DATABASE_URL — check DID NOT RUN (not a pass).');
+    process.exit(1);
+  }
+
+  // The Prisma schema is the definition of "a table the TS app legitimately writes as app_tenant".
+  // Reusing the ownership check's own parser keeps the two from drifting.
+  const prismaOwned = new Set(parsePrismaTables('packages/db/prisma/schema'));
+  if (prismaOwned.size === 0) {
+    console.error('✖ verify-tenant-grants: parsed ZERO Prisma tables — refusing to run (would flag everything).');
+    process.exit(1);
+  }
+
+  const db = new Client({ connectionString: url });
+  const violations: Violation[] = [];
+  try {
+    await db.connect();
+    // `string_agg` + split rather than `array_agg`: the driver's text[] parsing is one more moving part
+    // in a check whose whole job is to be trustworthy, and privilege_type values are bare words.
+    // The pg_class lookup is scoped to `public` on the JOIN so a same-named table in another schema
+    // (e.g. storage.*) cannot supply the RLS flags.
+    const { rows } = await db.query<{
+      table_name: string;
+      privs: string;
+      rls_enabled: boolean;
+      policies: string;
+    }>(
+      `SELECT g.table_name,
+              string_agg(DISTINCT g.privilege_type, ',' ORDER BY g.privilege_type) AS privs,
+              coalesce(bool_or(c.relrowsecurity), false)                           AS rls_enabled,
+              coalesce(max((SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)), 0) AS policies
+         FROM information_schema.role_table_grants g
+         LEFT JOIN pg_namespace n ON n.nspname = 'public'
+         LEFT JOIN pg_class     c ON c.relname = g.table_name AND c.relnamespace = n.oid
+        WHERE g.table_schema = 'public'
+          AND g.grantee      = 'app_tenant'
+          AND g.privilege_type = ANY($1::text[])
+        GROUP BY g.table_name
+        ORDER BY g.table_name`,
+      [[...WRITE_PRIVS]],
+    );
+
+    for (const r of rows) {
+      if (prismaOwned.has(r.table_name)) continue; // Prisma-owned → tenant DML is the whole point
+      const privs = r.privs.split(',').filter(Boolean);
+      const allowed = APPEND_ONLY_ALLOWED[r.table_name];
+      const offending = allowed ? privs.filter((p) => !allowed.has(p)) : privs;
+      if (offending.length === 0) continue;
+      violations.push({
+        table: r.table_name,
+        privs: offending,
+        rlsEnabled: r.rls_enabled,
+        policies: Number(r.policies),
+      });
+    }
+  } finally {
+    await db.end();
+  }
+
+  if (violations.length === 0) {
+    console.log('✓ app_tenant holds write privileges only on Prisma-owned tables (least privilege intact).');
+    process.exit(0);
+  }
+
+  // Unbacked = no RLS at all, so the grant is the ONLY thing between a compromised tenant transaction
+  // and the table. Those are the ones to fix first.
+  const unbacked = violations.filter((v) => !v.rlsEnabled || v.policies === 0);
+  console.error(`\n✖ app_tenant has write privileges on ${violations.length} non-Prisma table(s) (#126):\n`);
+  for (const v of violations) {
+    const guard =
+      v.rlsEnabled && v.policies > 0 ? `RLS on, ${v.policies} policy(ies)` : 'NO RLS — grant is the only guard';
+    console.error(`  ${v.table.padEnd(28)} ${v.privs.join(',').padEnd(20)} [${guard}]`);
+  }
+  if (unbacked.length > 0) {
+    console.error(`\n  ${unbacked.length} of these have NO RLS: ${unbacked.map((v) => v.table).join(', ')}`);
+  }
+  console.error(
+    '\nFix: packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql (+ its .ROLLBACK.sql).' +
+      '\nThe default ACL that causes this is deliberately left in place — see #126 for why — so this' +
+      '\ncheck is what catches the next table that inherits it.\n',
+  );
+  if (process.env.ALLOW_KNOWN_VIOLATIONS === '1') {
+    console.error('ALLOW_KNOWN_VIOLATIONS=1 — reporting only, exiting 0.\n');
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('✖ verify-tenant-grants failed to run:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/security/verify-tenant-grants.ts
+++ b/scripts/security/verify-tenant-grants.ts
@@ -13,23 +13,39 @@
  * `app_tenant` has any business writing it. That is opt-out, not opt-in, and nothing noticed.
  *
  * A CORRECTION TO THE ORIGINAL #126 FRAMING: the grant is applied at CREATE TABLE time, not at
- * ownership-flip time. An ownership flip does NOT re-grant, so a REVOKE on a flipped table IS durable.
- * The real exposure is broader than the flip process — it is every non-Prisma table in the schema.
+ * ownership-flip time. An ownership flip does NOT re-grant, so a REVOKE is durable. The exposure is
+ * therefore not about flips at all — which is how 11 `qrtz_*` tables and `__EFMigrationsHistory` sat
+ * there unnoticed while the issue was scoped to "flipped tables".
  *
- * WHAT WAS ACTUALLY FOUND (2026-08-04, 20 tables)
- * ----------------------------------------------
- *   8  `efcore`            access_reviews, critical_roles, successors (flipped) + fx_rates,
- *                          hris_connectors, hris_external_employees, hris_sync_runs,
- *                          hris_sync_record_errors (EF-native, never Prisma-owned)
- *   11 `quartzInfra`       every qrtz_* table — scheduler internals
- *   1  uncategorised       __EFMigrationsHistory — migration history, forgeable/deletable
+ * WHAT COUNTS AS A VIOLATION — and the correction that shaped it
+ * --------------------------------------------------------------
+ * The first version of this check flagged every non-Prisma table: 20 of them. A cross-model reviewer
+ * pointed out that would have been a PRODUCTION WRITE OUTAGE if acted on, and it was right.
  *
- * SEVERITY, STATED HONESTLY. `app_tenant` is NOLOGIN and NOBYPASSRLS, so it is reachable only via
+ * The C# strangler writes its tables UNDER TenantScope, and `TenantScope.cs:46` issues
+ * `SET LOCAL ROLE app_tenant` — that is HOW those writes are RLS-enforced. So "EF owns it" does not
+ * mean "app_tenant never writes it"; for a tenant-scoped EF table the grant is REQUIRED.
+ *
+ * The discriminator is RLS, and it follows from the design rather than being a heuristic:
+ *
+ *   RLS enabled + forced  → tenant-scoped → an app path may write it as app_tenant → grant is LEGITIMATE
+ *   no RLS                → not tenant-scoped → nothing writes it under TenantScope → grant is DEAD
+ *
+ * Confirmed per writer for all 13 of the no-RLS tables:
+ *   fx_rates   FxRateDbContext / FxRateWriteRepository run on a PLAIN connection as the owner role,
+ *              explicitly NOT under TenantScope ("fx_rates is RLS-exempt").
+ *   qrtz_* ×11 no Quartz source file references TenantScope; the scheduler owns its own connection.
+ *   __EFMigrationsHistory  written by psql-applied idempotent scripts as `postgres`.
+ *
+ * So: 13 violations, not 20. The 7 excluded are access_reviews, critical_roles, successors (flipped)
+ * and the 4 hris_* — all RLS-forced, all written by C# as app_tenant, all legitimately granted.
+ *
+ * SEVERITY, STATED HONESTLY. `app_tenant` is NOLOGIN and NOBYPASSRLS, reachable only via
  * `SET LOCAL ROLE app_tenant` from the app's own connection inside a transaction. Exploiting this needs
- * app-level SQL injection or a compromised app process — it is NOT remotely exploitable. But that is
- * exactly the scenario `app_tenant` + RLS exists to contain, and 13 of the 20 have **RLS disabled
- * entirely** (fx_rates, all 11 qrtz_*, __EFMigrationsHistory — 0 policies each), so for those the grant
- * is the only thing standing in the way. The other 7 are bounded by a forced fail-closed policy.
+ * app-level SQL injection or a compromised app process — NOT remotely exploitable. But containing exactly
+ * that is what app_tenant + RLS exist for, and these 13 have no RLS, so the grant is the only guard.
+ * fx_rates is the sharpest case: global (no organization_id) and it feeds every tenant's compensation
+ * and pay-equity maths.
  *
  * WHY A LIVE CHECK RATHER THAN A UNIT TEST
  * ----------------------------------------
@@ -42,9 +58,9 @@
  *   npx tsx scripts/security/verify-tenant-grants.ts            # uses DIRECT_URL, else DATABASE_URL
  *   ALLOW_KNOWN_VIOLATIONS=1 npx tsx scripts/security/verify-tenant-grants.ts   # report, exit 0
  *
- * Exits 0 if `app_tenant` holds DML only on Prisma-owned tables, 1 on any violation, and 1 if it
- * cannot run (fail closed — an unrunnable privilege check is not a pass). Read-only: every statement
- * is a SELECT.
+ * Exits 0 if every table `app_tenant` can write is either Prisma-owned or RLS-protected, 1 on any
+ * violation, and 1 if it cannot run (fail closed — an unrunnable privilege check is not a pass).
+ * Read-only: every statement is a SELECT, safe against production.
  */
 import { readFileSync } from 'node:fs';
 import { Client } from 'pg';
@@ -133,6 +149,25 @@ async function main(): Promise<void> {
 
     for (const r of rows) {
       if (prismaOwned.has(r.table_name)) continue; // Prisma-owned → tenant DML is the whole point
+
+      // CORRECTED 2026-08-04 after a cross-model reviewer caught the original invariant being wrong.
+      //
+      // "Not Prisma-owned" does NOT imply "app_tenant never writes it". The C# strangler writes its
+      // tables UNDER TenantScope, and `TenantScope.cs:46` issues `SET LOCAL ROLE app_tenant` — that is
+      // precisely HOW those writes get RLS-enforced. So an EF-owned, tenant-scoped table legitimately
+      // NEEDS this grant, and revoking it would break live writes (HRIS sync, access-review attest,
+      // succession).
+      //
+      // The discriminator is RLS, and it is not a heuristic — it follows from the design. A table with
+      // RLS enabled + forced is tenant-scoped, so an app path may write it under TenantScope as
+      // app_tenant. A table with NO RLS is by definition not tenant-scoped, so nothing writes it under
+      // TenantScope, so app_tenant DML on it is dead. Confirmed per writer:
+      //   fx_rates  → FxRateDbContext/FxRateWriteRepository run on a PLAIN connection as the owner role,
+      //               explicitly NOT under TenantScope ("fx_rates is RLS-exempt").
+      //   qrtz_*    → no Quartz file references TenantScope at all; the scheduler owns its connection.
+      //   __EFMigrationsHistory → written by psql-applied idempotent scripts as `postgres`.
+      if (r.rls_enabled && Number(r.policies) > 0) continue;
+
       const privs = r.privs.split(',').filter(Boolean);
       const allowed = APPEND_ONLY_ALLOWED[r.table_name];
       const offending = allowed ? privs.filter((p) => !allowed.has(p)) : privs;
@@ -153,17 +188,14 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Unbacked = no RLS at all, so the grant is the ONLY thing between a compromised tenant transaction
-  // and the table. Those are the ones to fix first.
-  const unbacked = violations.filter((v) => !v.rlsEnabled || v.policies === 0);
-  console.error(`\n✖ app_tenant has write privileges on ${violations.length} non-Prisma table(s) (#126):\n`);
+  // Every surviving violation is a no-RLS table by definition (the RLS-forced ones are skipped above as
+  // legitimately written by C# under TenantScope), so the grant really is the only guard on each of them.
+  console.error(
+    `\n✖ app_tenant has write privileges on ${violations.length} table(s) that have NO RLS and that no` +
+      ` application path writes as app_tenant (#126):\n`,
+  );
   for (const v of violations) {
-    const guard =
-      v.rlsEnabled && v.policies > 0 ? `RLS on, ${v.policies} policy(ies)` : 'NO RLS — grant is the only guard';
-    console.error(`  ${v.table.padEnd(28)} ${v.privs.join(',').padEnd(20)} [${guard}]`);
-  }
-  if (unbacked.length > 0) {
-    console.error(`\n  ${unbacked.length} of these have NO RLS: ${unbacked.map((v) => v.table).join(', ')}`);
+    console.error(`  ${v.table.padEnd(28)} ${v.privs.join(',').padEnd(20)} [no RLS — grant is the only guard]`);
   }
   console.error(
     '\nFix: packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql (+ its .ROLLBACK.sql).' +

--- a/scripts/verification/crossmodel-review.sh
+++ b/scripts/verification/crossmodel-review.sh
@@ -219,7 +219,11 @@ PY
 # `-w %{http_code}` is captured so rc=22 becomes actionable: a 401/403 is a key problem, a 404 a wrong
 # model or URL, a 429 quota, a 5xx the upstream. The original script reported only the curl rc, which is
 # why four failures today produced no diagnosis.
+# Bounded to 5 even if an operator sets OMNIROUTE_ATTEMPTS higher: the delay formula grows with the
+# attempt number, so an unbounded value turns a gate into a multi-hour hang.
 OMNI_ATTEMPTS="${OMNIROUTE_ATTEMPTS:-3}"
+[[ "$OMNI_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || OMNI_ATTEMPTS=3
+(( OMNI_ATTEMPTS > 5 )) && { warn "OMNIROUTE_ATTEMPTS=$OMNI_ATTEMPTS capped to 5."; OMNI_ATTEMPTS=5; }
 CURL_RC=1
 HTTP_CODE=""
 for attempt in $(seq 1 "$OMNI_ATTEMPTS"); do
@@ -235,8 +239,24 @@ for attempt in $(seq 1 "$OMNI_ATTEMPTS"); do
   warn "OmniRoute attempt $attempt/$OMNI_ATTEMPTS failed (curl rc=$CURL_RC, HTTP ${HTTP_CODE:-none})."
   CURL_RC=${CURL_RC:-1}
   [[ $CURL_RC -eq 0 ]] && CURL_RC=1 # a non-2xx with rc=0 is still a failure
+
+  # Retrying a PERMANENT error just burns the backoff and delays the diagnosis. 401/403 = key problem,
+  # 404 = wrong model or URL, 400/422 = malformed request. Stop immediately and say which.
+  case "$HTTP_CODE" in
+    400|401|403|404)
+      case "$HTTP_CODE" in
+        401|403) warn "HTTP $HTTP_CODE is an AUTH failure — check OMNIROUTE_KEY. Not retrying." ;;
+        404)     warn "HTTP 404 — OMNIROUTE_MODEL='$MODEL' or OMNIROUTE_URL is wrong. Not retrying." ;;
+        400)     warn "HTTP 400 — the gateway rejected the request body. Not retrying." ;;
+      esac
+      break
+      ;;
+  esac
+  # 422 is deliberately NOT in that list: observed twice on 2026-08-04 as a TRANSIENT gateway response
+  # that succeeded on the very next attempt, which is the whole reason this loop exists.
+
   if [[ $attempt -lt $OMNI_ATTEMPTS ]]; then
-    delay=$((attempt * 10 - 5)) # 5s, 15s
+    delay=$((attempt * 10 - 5)) # 5s, 15s, 25s, 35s
     sleep "$delay"
   fi
 done

--- a/scripts/verification/crossmodel-review.sh
+++ b/scripts/verification/crossmodel-review.sh
@@ -205,13 +205,44 @@ json.dump({"model": model, "temperature": 0, "stream": False, "messages": [
 ]}, open(out, "w"))
 PY
 
-SYS="$SYS" DIFF="$DIFF" curl -fsS --max-time 300 "$URL/chat/completions" \
-  ${AUTH_HDR[@]+"${AUTH_HDR[@]}"} -H "Content-Type: application/json" \
-  --data-binary @"$REQ" -o "$RESP" 2>/dev/null
-CURL_RC=$?
+# RETRY WITH BACKOFF (#38, added 2026-08-04). A single attempt was the original behaviour and it made
+# tier 2 look far less usable than it is: on 2026-08-03 it served three full review rounds, then on
+# 2026-08-04 four consecutive single-shot attempts failed — twice rc=22 (HTTP >=400) and twice rc=28
+# (timeout) — which is provider/gateway flakiness, not prompt size (a 28k-char retry failed identically
+# to a 60k one). Without retry, a transient blip is indistinguishable from "tier 2 is unavailable" and
+# silently demotes every review to the weaker same-model tier 3.
+#
+# Bounded deliberately: 3 attempts, 5s then 15s backoff. The point is to ride out a blip, not to hang a
+# gate. Total worst case ~15min with --max-time 300 each, and every attempt is reported so a persistent
+# outage is still visible rather than papered over.
+#
+# `-w %{http_code}` is captured so rc=22 becomes actionable: a 401/403 is a key problem, a 404 a wrong
+# model or URL, a 429 quota, a 5xx the upstream. The original script reported only the curl rc, which is
+# why four failures today produced no diagnosis.
+OMNI_ATTEMPTS="${OMNIROUTE_ATTEMPTS:-3}"
+CURL_RC=1
+HTTP_CODE=""
+for attempt in $(seq 1 "$OMNI_ATTEMPTS"); do
+  HTTP_CODE="$(SYS="$SYS" DIFF="$DIFF" curl -sS --max-time 300 -w '%{http_code}' \
+    "$URL/chat/completions" \
+    ${AUTH_HDR[@]+"${AUTH_HDR[@]}"} -H "Content-Type: application/json" \
+    --data-binary @"$REQ" -o "$RESP" 2>/dev/null)"
+  CURL_RC=$?
+  if [[ $CURL_RC -eq 0 && -s "$RESP" && "$HTTP_CODE" =~ ^2 ]]; then
+    [[ $attempt -gt 1 ]] && warn "OmniRoute succeeded on attempt $attempt/$OMNI_ATTEMPTS."
+    break
+  fi
+  warn "OmniRoute attempt $attempt/$OMNI_ATTEMPTS failed (curl rc=$CURL_RC, HTTP ${HTTP_CODE:-none})."
+  CURL_RC=${CURL_RC:-1}
+  [[ $CURL_RC -eq 0 ]] && CURL_RC=1 # a non-2xx with rc=0 is still a failure
+  if [[ $attempt -lt $OMNI_ATTEMPTS ]]; then
+    delay=$((attempt * 10 - 5)) # 5s, 15s
+    sleep "$delay"
+  fi
+done
 
 if [[ $CURL_RC -ne 0 || ! -s "$RESP" ]]; then
-  bad "OmniRoute request failed (curl rc=$CURL_RC) — tier 2 did not produce a review."
+  bad "OmniRoute request failed after $OMNI_ATTEMPTS attempt(s) (last: curl rc=$CURL_RC, HTTP ${HTTP_CODE:-none}) — tier 2 did not produce a review."
   exit 2
 fi
 

--- a/services/Tims.Platform/db/flip-ddl/README.md
+++ b/services/Tims.Platform/db/flip-ddl/README.md
@@ -22,6 +22,29 @@ exist as DDL nowhere. See **#128**.
 `access_reviews` (flip #1) did not need this — it had a real migration file, which is part of why it was
 the right pilot.
 
+## ⚠ `pnpm push` on an EXISTING local DB will DROP a flipped table
+
+Because the Prisma model is gone, `prisma db push` sees the live table as something not in the schema and
+wants to remove it. On a **fresh** database that is invisible (the table is simply never created — which is
+why these files exist). On an **existing** local database that already has the table, `db push` will
+propose dropping it and, with `--accept-data-loss`, will.
+
+That is expected and is not a production risk: `pnpm push` / `pnpm migrate` route through
+`scripts/db/guard-prod-ddl.sh`, which refuses a non-local host; Prisma Migrate is formally unused against
+prod (no `_prisma_migrations` table there, verified #115); and `/gate` check 16 would catch it if anything
+did reach prod. It IS a local-dev footgun, so after a `pnpm push` that follows an ownership flip:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f services/Tims.Platform/db/flip-ddl/<name>.sql
+cd packages/db && npx tsx prisma/seed.ts && npx tsx prisma/seed-users.ts && npx tsx prisma/seed-demo.ts
+```
+
+(That seed order is required — `seed-demo.ts` bails out without the org and users the first two create.)
+
+Raised by the tier-2 cross-model reviewer against #131 as a claimed prod/CI risk. The CI half was wrong —
+nothing runs `prisma migrate deploy`, and `pnpm migrate` is the guarded local-only wrapper — but the
+local-dev half is real, and it applies to every flipped table, including `access_reviews` from flip #1.
+
 ## ⚠ Never apply these to production
 
 The tables already exist in prod. These are **bootstrap / dev-parity** artifacts. Production DDL goes

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * #132 — offline contract tests for `scripts/db/pre-flip-scan.ts`.
+ *
+ * WHY THESE ARE STATIC RATHER THAN EXECUTED. The script's real behaviour needs a live Postgres, and its
+ * blocker paths WERE exercised against a throwaway PG17 cluster carrying a deliberate view and function
+ * over a target table (both correctly reported as BLOCKERs, exit 1). That run cannot be committed —
+ * `vitest` here has no database — so the runbook must not claim an automated test covers it. What IS
+ * worth pinning automatically is the part that would rot silently: the exit-code contract and the
+ * queries' correctness properties, each of which was a real finding.
+ *
+ * Same reasoning as `tests/db/schema-baseline-failure-paths.test.ts`: given #38, the properties a gate
+ * depends on should fail loudly when edited away, even when the end-to-end path needs credentials.
+ */
+
+const ROOT = join(__dirname, '..', '..');
+const SRC = readFileSync(join(ROOT, 'scripts/db/pre-flip-scan.ts'), 'utf8');
+
+describe('pre-flip-scan — exit-code contract', () => {
+  it('fails closed when no connection string is available', () => {
+    // An unrunnable scan must never read as a clean scan (#38 doctrine, same as checks 14/16/17).
+    expect(SRC).toMatch(/scan DID NOT RUN \(not a clean scan\)/);
+    const idx = SRC.indexOf('scan DID NOT RUN');
+    expect(SRC.slice(idx, idx + 200)).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('exits 1 on a blocker and 0 only when the blocker list is empty', () => {
+    expect(SRC).toMatch(/if \(blockers\.length === 0\)[\s\S]{0,900}?process\.exit\(0\)/);
+    expect(SRC).toMatch(/database-side BLOCKER\(s\)[\s\S]{0,600}?process\.exit\(1\)/);
+  });
+
+  it('treats a missing table as a blocker rather than a clean result', () => {
+    expect(SRC).toMatch(/if \(!r\.exists\) blockers\.push/);
+  });
+
+  it('classifies views AND functions as blockers, not merely as info', () => {
+    expect(SRC).toMatch(/for \(const v of r\.dependentViews\) blockers\.push/);
+    expect(SRC).toMatch(/for \(const f of r\.dependentRoutines\) blockers\.push/);
+  });
+});
+
+describe('pre-flip-scan — query correctness properties (each was a real finding)', () => {
+  it('matches table names on a word boundary, so `successors` cannot match a longer identifier', () => {
+    expect(SRC).toMatch(/\\\\y\$\{t\}\\\\y/);
+  });
+
+  it('quotes the identifier in the existence probe, so a mixed-case table is not a false blocker', () => {
+    // to_regclass('public.'||$1) folds unquoted names to lowercase, which reported
+    // `__EFMigrationsHistory` as non-existent — a false BLOCKER. format('%I') quotes it.
+    expect(SRC).toMatch(/to_regclass\(format\('public\.%I', \$1\)\)/);
+    expect(SRC).not.toMatch(/to_regclass\('public\.'\|\|\$1\)/);
+  });
+
+  it('qualifies the FK join by constraint_schema, since constraint_name is not globally unique', () => {
+    expect(SRC).toMatch(/kcu\.constraint_schema = tc\.constraint_schema/);
+    expect(SRC).toMatch(/ccu\.constraint_schema = tc\.constraint_schema/);
+  });
+
+  it('excludes the scanned table itself from the "policies elsewhere referencing it" query', () => {
+    expect(SRC).toMatch(/AND c\.relname <> \$2/);
+  });
+
+  it('does not let a failed db.end() mask the original connection error', () => {
+    expect(SRC).toMatch(/db\.end\(\)\.catch\(\(\) => undefined\)/);
+  });
+});
+
+describe('pre-flip-scan — --json is a machine interface', () => {
+  it('emits nothing but JSON on stdout in --json mode, including on the clean path', () => {
+    // The success summary must be gated, or piping to jq breaks precisely when there is no blocker.
+    expect(SRC).toMatch(/if \(!asJson\) \{[\s\S]{0,400}?No database-side blocker/);
+  });
+
+  it('sends blocker output to stderr so it cannot corrupt the JSON payload', () => {
+    const idx = SRC.indexOf('database-side BLOCKER(s)');
+    expect(SRC.slice(Math.max(0, idx - 120), idx)).toMatch(/console\.error/);
+  });
+});

--- a/tests/governance/scope-fixtures.test.ts
+++ b/tests/governance/scope-fixtures.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { SCOPED_ENTITIES } from '../../packages/api/src/access/entity-policies';
+
+/**
+ * #132 — pin the CROSS-STACK scope fixture to the scope-policy registry.
+ *
+ * WHY THIS EXISTS. `contracts/access-fixtures/scope-where.json` is not an ordinary fixture: it is the
+ * shared contract that BOTH stacks are held to — `tests/access/scope-where-fixtures.test.ts` asserts the
+ * TS `scopeWhereFor` against it (calling itself "the production-TS oracle that pins the fixtures"), and
+ * `services/Tims.Platform/tests/Tims.UnitTests/Fixtures/ScopeWhereForFixtureTests.cs` asserts the C# port
+ * against the same file.
+ *
+ * The ownership flip in #69 removed two entities from `ScopedEntity` because the runbook said to. `tsc`
+ * stayed GREEN — a JSON file has no types — and the only signal was 6 opaque
+ * "Entidad sin politica de alcance" throws from a test that does not explain why. The tempting fix was to
+ * delete the failing fixture cases, which would have silently deleted the oracle pinning C#'s own
+ * implementation. See the ownership-flip-runbook §1 step 6 correction.
+ *
+ * None of the six P2 reader-sweep greps would have caught it either: all of them are `.ts`-scoped.
+ *
+ * So this file exists to turn that class of break into a NAMED failure that says what to do.
+ */
+
+const ROOT = join(__dirname, '..', '..');
+const FIXTURE_REL = 'contracts/access-fixtures/scope-where.json';
+
+interface ScopeCase {
+  name: string;
+  entity: string;
+}
+const fixture = JSON.parse(readFileSync(join(ROOT, FIXTURE_REL), 'utf8')) as {
+  description: string;
+  cases: ScopeCase[];
+};
+
+const fixtureEntities = [...new Set(fixture.cases.map((c) => c.entity))].sort();
+const registryEntities = [...SCOPED_ENTITIES].sort();
+
+describe('scope-where fixture ↔ ScopedEntity registry (cross-stack contract)', () => {
+  it('every entity named in the fixture is a real ScopedEntity', () => {
+    const unknown = fixtureEntities.filter((e) => !(SCOPED_ENTITIES as readonly string[]).includes(e));
+    expect(
+      unknown,
+      `${FIXTURE_REL} names ${unknown.length} entity/entities that are NOT in SCOPED_ENTITIES: ` +
+        `${unknown.join(', ')}.\n` +
+        `If an ownership flip just removed one from packages/api/src/access/entity-policies.ts: PUT IT BACK. ` +
+        `scopeWhereFor is a PURE function — it never touches the Prisma client — so a flip does NOT require ` +
+        `removing the entity, and this fixture is also asserted by Tims.UnitTests' ScopeWhereForFixtureTests, ` +
+        `so the C# owner still needs the policy. Only scoped-probe.ts's DELEGATES map (which dereferences a ` +
+        `live Prisma delegate) may drop a flipped entity — see its ProbeableEntity type.`,
+    ).toEqual([]);
+  });
+
+  it('every ScopedEntity has at least one fixture case pinning its fragment', () => {
+    const unpinned = registryEntities.filter((e) => !fixtureEntities.includes(e));
+    expect(
+      unpinned,
+      `${unpinned.length} ScopedEntity value(s) have NO case in ${FIXTURE_REL}: ${unpinned.join(', ')}.\n` +
+        `An unpinned entity is one whose scope fragment the C# port is not held to — add cases (at minimum ` +
+        `own/team/unit) so both stacks are constrained by the same expected output.`,
+    ).toEqual([]);
+  });
+
+  it('the two sets are exactly equal, in both directions', () => {
+    // Belt-and-braces over the two directional assertions above: this is the invariant in one line, and
+    // it is the one to read in a failure diff.
+    expect(fixtureEntities).toEqual(registryEntities);
+  });
+
+  it('SCOPED_ENTITIES has no duplicates (a dup would mask a missing entity in the counts)', () => {
+    expect(new Set(SCOPED_ENTITIES).size).toBe(SCOPED_ENTITIES.length);
+  });
+});

--- a/tests/governance/scope-fixtures.test.ts
+++ b/tests/governance/scope-fixtures.test.ts
@@ -72,4 +72,54 @@ describe('scope-where fixture ↔ ScopedEntity registry (cross-stack contract)',
   it('SCOPED_ENTITIES has no duplicates (a dup would mask a missing entity in the counts)', () => {
     expect(new Set(SCOPED_ENTITIES).size).toBe(SCOPED_ENTITIES.length);
   });
+
+  /**
+   * The three assertions above only catch ASYMMETRIC drift. A *coordinated* removal — deleting the
+   * fixture cases AND the SCOPED_ENTITIES member together — satisfies all of them while silently
+   * shrinking the oracle that the C# port is held to. That is not hypothetical: it is exactly the shape
+   * of the "tempting fix" a future ownership flip will reach for, and the one flip #2 nearly took.
+   *
+   * So the floor is pinned explicitly. Removing an entity now requires editing this list, which is a
+   * deliberate act with a comment attached rather than a silent side effect of making a flip compile.
+   *
+   * TO REMOVE AN ENTITY LEGITIMATELY: it must no longer be a scope root in EITHER stack. Check
+   * `Tims.Domain/Access/ScopedEntity.cs` and `ScopeProbeRegistry.cs` FIRST — if C# still probes it, it
+   * stays here regardless of what the Prisma side looks like. An ownership flip alone is NOT a reason:
+   * `scopeWhereFor` is pure and outlives the Prisma model.
+   */
+  const PINNED_SCOPE_ROOTS = [
+    'actionPlan',
+    'application',
+    'assessmentAssignment',
+    'candidate',
+    'certificate',
+    'coachingSession',
+    'commitment',
+    'criticalRole', // flipped to efcore in #69 — KEEP: C# still probes it
+    'employeeCompensation',
+    'enrollment',
+    'feedback',
+    'interview',
+    'leaderCommitment',
+    'nineBoxEvaluation',
+    'offer',
+    'okr',
+    'onboardingPlan',
+    'salaryAdjustment',
+    'successor', // flipped to efcore in #69 — KEEP: C# still probes it
+    'team',
+    'vacancy',
+  ] as const;
+
+  it('no scope root disappears from BOTH sides at once (coordinated-removal guard)', () => {
+    const missing = PINNED_SCOPE_ROOTS.filter((e) => !registryEntities.includes(e));
+    expect(
+      missing,
+      `${missing.length} pinned scope root(s) are gone from SCOPED_ENTITIES: ${missing.join(', ')}.\n` +
+        `Deleting an entity from BOTH the registry and the fixture passes every other assertion in this ` +
+        `file while shrinking the cross-stack oracle, so the list is pinned here on purpose. If the ` +
+        `removal is genuinely correct, verify Tims.Domain/Access/ScopedEntity.cs and ScopeProbeRegistry.cs ` +
+        `no longer reference it, then update PINNED_SCOPE_ROOTS in the same commit and say why.`,
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
Addresses #132, #126 and #38. Turns three invariants that existed only as prose into checks — and, in the
process, the gate caught a **production-breaking error in this PR's own first draft**.

## The headline: my REVOKE script would have broken production

I built `verify-tenant-grants.ts` on the rule _"app_tenant should only hold DML on Prisma-owned tables"_,
and a REVOKE script for all 20 tables that violated it. A tier-2 cross-model reviewer refuted the premise:

> **The C# strangler writes its tables AS `app_tenant`.** `TenantScope.cs:46` issues
> `SET LOCAL ROLE app_tenant` — that is _how_ those writes become RLS-enforced.

Revoking the 7 RLS-forced EF tables (`access_reviews`, `critical_roles`, `successors`, 4× `hris_*`) would
have broken **HRIS sync, access-review attestation and succession writes in prod**, detectable only by the
write failures. Part 2 of the script is deleted, and the file keeps a comment explaining why so nobody
re-derives it.

**The correct discriminator is RLS, and it follows from the design rather than being a heuristic:**

| Table shape                  | Meaning                                                       | app_tenant DML              |
| ---------------------------- | ------------------------------------------------------------- | --------------------------- |
| Prisma-owned (99)            | TS writes it via `tenantDb`                                   | required                    |
| EF-owned, RLS **forced** (7) | tenant-scoped; C# writes it as `app_tenant` under TenantScope | **required — never revoke** |
| **No RLS (13)**              | not tenant-scoped ⇒ nothing writes it under TenantScope       | **dead → revoke**           |

The 13 safe-to-revoke tables are _exactly_ the no-RLS set. Not a coincidence — the same fact stated twice.
Writer-verified per table, which is the step the first draft skipped: `fx_rates`' repository runs on a
**plain connection as the owner role**, explicitly not under TenantScope; **no Quartz source file
references TenantScope**; `__EFMigrationsHistory` is written by psql-applied scripts as `postgres`.

## #126 — two corrections to the issue's own framing

1. **The grant is applied at `CREATE TABLE`, not at flip time.** A flip does not re-grant, so a REVOKE
   **is** durable. My earlier comment claiming "every flip re-creates the condition" was wrong.
2. **So the exposure is not about flips at all** — it is every non-Prisma table. Which is precisely how
   11 `qrtz_*` tables and `__EFMigrationsHistory` sat there unnoticed while the issue was scoped to
   "flipped tables".

Severity, unchanged and still honest: `app_tenant` is `NOLOGIN` + `NOBYPASSRLS`, reachable only via
`SET LOCAL ROLE` from the app's own connection, so this needs app-level SQL injection or a compromised app
process — **not remotely exploitable**. But containing exactly that is what `app_tenant` + RLS exist for,
and these 13 have no RLS, so the grant is the only guard. `fx_rates` is the sharpest case: global, no
`organization_id`, and it feeds every tenant's compensation and pay-equity maths.

**Ships as a reviewed script, not applied** — `packages/db/prisma/manual/2026-08-04-revoke-app-tenant-dml.sql`
(+ `.ROLLBACK.sql`), 13 statements each, `SELECT` retained, idempotent. Prod DCL is Federico-only.
⚠️ Applying it **will** make check 16 report drift, because grants are in the baseline — re-capture in the
same change and read the diff.

## #132 — the two scan gaps

**Gap 1, data-driven consumers — now CI-enforced.** `tests/governance/scope-fixtures.test.ts` pins
`contracts/access-fixtures/scope-where.json` to the registry both ways. Failure path verified by
re-introducing flip #2's exact mistake; the message says PUT IT BACK and explains why.

Also collapsed the registry to one source of truth. Being precise about what enforces what:

| pairing                         | enforced by                                                                                                                                                 |
| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
| union ↔ `SCOPED_ENTITIES` array | **construction** — the type is the array's element type                                                                                                     |
| array ↔ `switch`                | **the compiler** — omit a case and `scopeWhereFor` returns undefined against `Promise<Fragment>` → `TS2366`. Verified empirically; no `assertNever` needed. |
| array ↔ fixture JSON            | the new governance test, both directions                                                                                                                    |

**Gap 2, database-side readers — scripted.** `scripts/db/pre-flip-scan.ts` replaces four hand-run queries.
Views/matviews and functions are BLOCKERS; §3(f) policies, inbound FKs (flagging any from _outside_ the flip
set), grants and RLS are reported. Reproduces flip #2's hand result on the flipped pair, and blocks correctly
on a throwaway PG17 cluster seeded with a real view + function. Runbook §5 gains step 5b, placed **before**
the model deletion.

## #38 — retry/backoff, and it paid for itself immediately

Tier 2 was single-shot. It served 3 rounds on 2026-08-03, then failed **4 consecutive attempts** on
2026-08-04 (rc=22 ×2, rc=28 ×2) — indistinguishable, without retry, from "tier 2 is unavailable", silently
demoting every review to the weaker same-model tier 3.

Now 3 attempts with 5s/15s backoff and `-w %{http_code}` so `rc=22` is diagnosable. Permanent errors
(400/401/403/404) stop immediately with a specific diagnosis rather than burning the backoff; **422 stays
retryable because it is what actually recovered on attempt 2, twice**. `OMNIROUTE_ATTEMPTS` capped at 5 —
the delay formula grows with attempt count, so an unbounded value turns a gate into a multi-hour hang.

Effect: the retroactive review of the #131 flip — impossible an hour earlier — **ran**, and produced the
finding at the top of this PR.

## Everything else the reviewer found

Acted on:

- `pre-flip-scan --json` printed the human summary _after_ the JSON on the **clean** path, breaking `jq`
  consumers exactly when there was no blocker.
- FK query joined on `constraint_name` alone — not globally unique, so a same-named constraint in another
  schema produced a phantom inbound FK. Now schema-qualified.
- `to_regclass('public.'||$1)` folds unquoted identifiers to lowercase, reporting `__EFMigrationsHistory`
  as nonexistent — a **false BLOCKER**. Now `format('%I')`.
- `db.end()` in a `finally` could throw over the real connection error.
- `assertScoped`'s comment claimed a plain `string` compiles against `ProbeableEntity`. It does not — only
  `any`, a cast, or a JS caller. The runtime guard is still warranted for those; the justification is now
  accurate.
- **`scope-fixtures.test.ts` only caught _asymmetric_ drift.** Deleting the fixture cases _and_ the registry
  entry together passed everything while shrinking the C# oracle — the exact "tempting fix" shape.
  `PINNED_SCOPE_ROOTS` makes removal a deliberate edit.
- **The runbook claimed pre-flip-scan's blocker paths were "tested"; no test was committed.**
  `tests/db/pre-flip-scan.test.ts` now pins the exit-code contract and every query property above, and the
  runbook says plainly that the cluster run is not committable and what covers it instead.

Refuted with evidence:

- _"`prisma migrate deploy` will apply a DROP TABLE in CI."_ Nothing runs `migrate deploy`/`dev`;
  `pnpm migrate` is the guarded local-only wrapper; prod has no `_prisma_migrations`. The **local** half is
  real though — `pnpm push` on an existing dev DB drops a flipped table — so `flip-ddl/README.md` documents
  it with recovery steps.
- _"A missing switch case is not a compile error without `assertNever`."_ It is — `TS2366`, verified.
- _"DELEGATES re-typing breaks the body."_ The cast handles it; api `tsc` clean.
- _"Raw-SQL readers of the flipped tables."_ Zero in `packages/api` and `workers`.

## Honest scorecard — what is actually enforced

This is in `ddl-governance.md` verbatim, because "documented" and "enforced" are not the same thing and #38
is what happens when they get conflated:

| Control                    | Runs where                       | Enforced?                      |
| -------------------------- | -------------------------------- | ------------------------------ |
| `scope-fixtures.test.ts`   | `vitest` → CI `Security Audit`   | ✅ blocks CI                   |
| `table-ownership.test.ts`  | `vitest` + `dotnet-platform.yml` | ✅                             |
| check 14 RLS isolation     | `/gate`, local (live DB)         | ⚠️ ship-time only              |
| check 16 schema drift      | `/gate`, local (live DB)         | ⚠️ ship-time only (#124)       |
| **check 17 tenant grants** | `/gate`, local (live DB)         | ⚠️ ship-time only              |
| `pre-flip-scan.ts`         | by hand, per flip                | ❌ documented step, not a gate |

And `main` has **no required status checks**, so even ✅ means "CI goes red", not "the merge is blocked".

**Two things this PR does NOT do, stated plainly:**

1. The `/gate` skill's check list lives **outside this repository**, so "check 17" is not automatically part
   of `/gate` yet. Until that edit happens it must be run explicitly. Assuming otherwise would repeat #38.
2. `pre-flip-scan.ts` is wired to nothing. Making it a gate needs the same live-DB credentials as #124.

## Verification

| Check                       | Result                                                                          |
| --------------------------- | ------------------------------------------------------------------------------- |
| 1 `@tims/api` tsc           | ✅ exit 0                                                                       |
| 2 `apps/web` tsc            | ✅ exit 0                                                                       |
| — root tsc                  | ✅ exit 0                                                                       |
| 3 vitest                    | ✅ **284 files / 2680 tests** (+16)                                             |
| 4–10, 13 greps              | ✅ all empty                                                                    |
| 11 build                    | ✅ exit 0                                                                       |
| 12 gitleaks                 | ✅ no leaks                                                                     |
| 14 RLS isolation (live)     | ✅ exit 0                                                                       |
| 16 schema drift (live)      | ✅ exit 0 — no DDL in this PR                                                   |
| **17 tenant grants (live)** | ⚠️ **exit 1 by design** — reports the 13; goes green when the REVOKE is applied |
| ledger check                | ✅ passed                                                                       |
| 15 cross-model | ✅ **RAN (tier 2)** — raised 7 findings, all triaged in this PR (5 fixed, 4 refuted). See note below. |

Check 17 failing is the intended state of this PR: the check ships before the fix, so the exposure is
visible rather than asserted.

### Note on check 15

Tier 1 Codex remains quota-blocked to 2026-08-15. **Tier 2 RAN, and it is the source of every finding in
the "Everything else the reviewer found" section above** — including the production-breaking one that
deleted Part 2 of the REVOKE script. That is the review of record for this PR.

A confirmation re-run against these corrections was started and was still cycling through retries when the
PR was opened. It re-checks fixes already made rather than being an outstanding gate. Anyone re-running it
should do so **in the background**: 3 attempts × `--max-time 300` plus backoff can exceed a 10-minute
foreground timeout — a direct and slightly ironic consequence of the retry this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
