### PR TITLE
chore(db): re-capture the baseline after applying the #126 REVOKE

### DIFF
--- a/packages/db/baseline/prod-public-schema.sql
+++ b/packages/db/baseline/prod-public-schema.sql
@@ -1,6 +1,6 @@
 -- TIMS ATS — production schema baseline (issue #115)
 --
--- Captured:        2026-08-03T18:13:55Z
+-- Captured:        2026-08-04T17:30:30Z
 -- Server version:  17.6
 -- Schemas:         public, supabase_migrations
 -- Command:         bash scripts/db/schema-baseline.sh capture
@@ -8045,7 +8045,7 @@ GRANT USAGE ON SCHEMA public TO app_tenant;
 -- Name: TABLE "__EFMigrationsHistory"; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public."__EFMigrationsHistory" TO app_tenant;
+GRANT SELECT ON TABLE public."__EFMigrationsHistory" TO app_tenant;
 
 --
 -- Name: TABLE access_reviews; Type: ACL; Schema: public; Owner: postgres
@@ -8309,7 +8309,7 @@ GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.fit_scores TO app_tenant;
 -- Name: TABLE fx_rates; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.fx_rates TO app_tenant;
+GRANT SELECT ON TABLE public.fx_rates TO app_tenant;
 
 --
 -- Name: TABLE hire_predictions; Type: ACL; Schema: public; Owner: postgres
@@ -8549,67 +8549,67 @@ GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.publication_channels TO app_te
 -- Name: TABLE qrtz_blob_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_blob_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_blob_triggers TO app_tenant;
 
 --
 -- Name: TABLE qrtz_calendars; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_calendars TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_calendars TO app_tenant;
 
 --
 -- Name: TABLE qrtz_cron_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_cron_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_cron_triggers TO app_tenant;
 
 --
 -- Name: TABLE qrtz_fired_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_fired_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_fired_triggers TO app_tenant;
 
 --
 -- Name: TABLE qrtz_job_details; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_job_details TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_job_details TO app_tenant;
 
 --
 -- Name: TABLE qrtz_locks; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_locks TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_locks TO app_tenant;
 
 --
 -- Name: TABLE qrtz_paused_trigger_grps; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_paused_trigger_grps TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_paused_trigger_grps TO app_tenant;
 
 --
 -- Name: TABLE qrtz_scheduler_state; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_scheduler_state TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_scheduler_state TO app_tenant;
 
 --
 -- Name: TABLE qrtz_simple_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_simple_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_simple_triggers TO app_tenant;
 
 --
 -- Name: TABLE qrtz_simprop_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_simprop_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_simprop_triggers TO app_tenant;
 
 --
 -- Name: TABLE qrtz_triggers; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.qrtz_triggers TO app_tenant;
+GRANT SELECT ON TABLE public.qrtz_triggers TO app_tenant;
 
 --
 -- Name: TABLE rater_assignments; Type: ACL; Schema: public; Owner: postgres

--- a/services/Tims.Platform/db/flip-ddl/compensation.sql
+++ b/services/Tims.Platform/db/flip-ddl/compensation.sql
@@ -2,7 +2,7 @@
 -- Regenerate: node scripts/db/extract-table-ddl.mjs salary_adjustments employee_compensations
 --
 -- Tables: employee_compensations, salary_adjustments
--- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-03T18:13:55Z, server 17.6)
+-- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-04T17:30:30Z, server 17.6)
 --
 -- WHY THIS FILE EXISTS (issue #128, runbook §0 P8)
 -- Deleting a Prisma model during an ownership flip can remove the only executable definition of a

--- a/services/Tims.Platform/db/flip-ddl/succession.sql
+++ b/services/Tims.Platform/db/flip-ddl/succession.sql
@@ -2,7 +2,7 @@
 -- Regenerate: node scripts/db/extract-table-ddl.mjs critical_roles successors
 --
 -- Tables: critical_roles, successors
--- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-03T18:13:55Z, server 17.6)
+-- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-04T17:30:30Z, server 17.6)
 --
 -- WHY THIS FILE EXISTS (issue #128, runbook §0 P8)
 -- Deleting a Prisma model during an ownership flip can remove the only executable definition of a

--- a/services/Tims.Platform/db/flip-ddl/surveys.sql
+++ b/services/Tims.Platform/db/flip-ddl/surveys.sql
@@ -2,7 +2,7 @@
 -- Regenerate: node scripts/db/extract-table-ddl.mjs surveys survey_responses
 --
 -- Tables: survey_responses, surveys
--- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-03T18:13:55Z, server 17.6)
+-- Source: packages/db/baseline/prod-public-schema.sql (captured 2026-08-04T17:30:30Z, server 17.6)
 --
 -- WHY THIS FILE EXISTS (issue #128, runbook §0 P8)
 -- Deleting a Prisma model during an ownership flip can remove the only executable definition of a


### PR DESCRIPTION
The #126 REVOKE is **applied to production** (2026-08-04). Grants are part of the committed baseline, so
check 16 correctly reported drift — this records it.

## The diff, read rather than rubber-stamped

`ddl-governance.md` §7 is explicit that re-capturing without reading the hunk turns check 16 into a rubber
stamp, so: the baseline changes by **exactly 14 lines each way — 13 grant narrowings plus the `-- Captured:`
timestamp.** Nothing else.

```
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.<t> TO app_tenant;
+GRANT SELECT                      ON TABLE public.<t> TO app_tenant;
```

for `__EFMigrationsHistory`, `fx_rates`, and all 11 `qrtz_*`. Verified by grep that **no changed line is
anything other than an `app_tenant` GRANT** — no table, column, constraint, index, policy or RLS change.
`SELECT` is retained on all 13, exactly as the script intended.

## Post-apply state, verified against prod

| Assertion | Result |
| --- | --- |
| The 13 targets hold **zero** INSERT/UPDATE/DELETE for `app_tenant` | ✅ script's own assertion returns no rows |
| The **7 RLS-forced EF tables still hold DML** | ✅ all 7 present |

That second row is the one worth having in writing. `access_reviews`, `critical_roles`, `successors` and the
4 `hris_*` **must** keep the grant — C# writes them as `app_tenant` under `TenantScope`, which is how those
writes get RLS-enforced. Revoking them is exactly the mistake the first draft of the script made and the
cross-model reviewer caught, so it is asserted rather than assumed.

## Flip-DDL artifacts regenerated

All three embed the baseline's capture metadata, so `tests/db/extract-table-ddl.test.ts` failed — the
staleness guard doing its job. Their DDL bodies are byte-identical apart from `-- Captured:`/`-- Source:`,
which independently confirms none of those 6 tables was touched by the REVOKE.

## Verification

| Check | Result |
| --- | --- |
| **17 tenant grants** | ✅ **1 → 0** — "app_tenant holds write privileges only on Prisma-owned tables" |
| 14 RLS isolation | ✅ exit 0, unchanged — tenant isolation undisturbed |
| 16 schema drift | ✅ exit 0 after re-capture (was 1 before, correctly) |
| vitest | ✅ 286 files / 2680 tests |
| gitleaks | ✅ clean |

## What #126 still leaves open

The default ACL is **unchanged**, so a newly created table still inherits `app_tenant` DML. Check 17 now
catches that on the next run rather than preventing it — that was the recorded decision on #126, taken over
narrowing the default because the alternative means explicitly granting ~99 Prisma tables where one miss
breaks tenant writes at runtime.

Also unchanged: **check 17 is not in the `/gate` check list**, which lives outside this repo. It must be run
explicitly until that edit happens.

Verification-waiver: baseline re-capture recording an already-applied, already-reviewed production DCL change; the diff is 13 grant lines plus a timestamp and is reproduced in full above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)