### PR TITLE
feat(ci): nightly sweep for the three live DB controls (#124)

### DIFF
--- a/.claude/commands/gate.md
+++ b/.claude/commands/gate.md
@@ -6,7 +6,7 @@ allowed-tools:
 
 # /gate — Local Verify Gate
 
-Run every check the CI pipeline runs — **plus the four checks (14–17) that CI cannot run at all** — locally, from the repo root. Report a pass/fail table at the end. This is the merge gate when GitHub Actions is unavailable, and the pre-push gate when it isn't. For checks 14–17 it is the _only_ gate, in either case.
+Run every check the CI pipeline runs — **plus the four checks (14–17) that no pull request runs** — locally, from the repo root. Report a pass/fail table at the end. This is the merge gate when GitHub Actions is unavailable, and the pre-push gate when it isn't. For checks 14–17 it is the only **pre-merge** gate; 14/16/17 are additionally swept nightly (#124), which is a different question answered up to a day late.
 
 ## Execution Contract (non-negotiable)
 
@@ -21,15 +21,21 @@ You MUST run ALL checks below even if an early one fails — the user needs the 
 
 ## Checks
 
-Checks 1–13 mirror `.github/workflows/ci.yml`. **Checks 14–17 have no CI equivalent**, so `/gate` is the
-only place they run at all — but for two different reasons, and conflating them hides both:
+Checks 1–13 mirror `.github/workflows/ci.yml`. **Checks 14–17 have no CI equivalent on a pull request**, so
+`/gate` is the only pre-merge gate for them — but for two different reasons, and conflating them hides both:
 
-- **14, 16, 17 need live production database credentials** that CI does not have. That is one decision
-  (#124) blocking three controls.
-- **15 needs an external reviewer** (Codex, or OmniRoute as tier 2) — not a database. Its blockers are
-  quota and gateway availability, tracked separately in #38.
+- **14, 16, 17 need live production database credentials.** `.github/workflows/nightly-db-controls.yml`
+  (#124) now runs these three on a **nightly schedule**, deliberately not per-PR: it catches out-of-band
+  changes nobody opened a PR for (the #111 scenario), and keeps production credentials off the
+  `pull_request` path. **It is additive, not a replacement** — it cannot tell you whether _this_ change
+  broke something, only that production drifted since yesterday.
+  **It is inert until the `PROD_DIRECT_URL` secret exists**, and fails loudly rather than skipping while it
+  is missing, so an absent credential is visible instead of silent.
+- **15 needs an external reviewer** (Codex, or OmniRoute as tier 2) — not a database, and it has **no CI
+  equivalent at all**. Its blockers are quota and gateway availability, tracked in #38.
 
-Skipping any of the four is not "CI will catch it". CI has no equivalent job for any of them.
+Skipping any of the four at ship time is still not "CI will catch it": for 15 nothing else runs, and for
+14/16/17 the nightly job answers a different question, up to a day late.
 
 Run prisma generate once first (typecheck/tests/build all need the client):
 

--- a/.github/workflows/nightly-db-controls.yml
+++ b/.github/workflows/nightly-db-controls.yml
@@ -28,10 +28,24 @@
 #       GRANT USAGE ON SCHEMA public, supabase_migrations TO ci_readonly;
 #       GRANT SELECT ON ALL TABLES IN SCHEMA public, supabase_migrations TO ci_readonly;
 #       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ci_readonly;
+#       GRANT app_tenant TO ci_readonly;   -- REQUIRED, and NOT obvious: see below
 #
-#     Use the SESSION pooler (:5432). The transaction pooler (:6543) cannot `SET LOCAL ROLE`, which check 14
-#     depends on. `pg_dump --schema-only` needs no table data, but check 14's empirical probe DOES read rows
-#     (count(*) only) — so SELECT is required, not merely catalog access.
+#     THE MEMBERSHIP GRANT IS LOAD-BEARING. Check 14's empirical probe issues `SET LOCAL ROLE app_tenant`,
+#     and in Postgres `SET ROLE` requires membership in the target role (or superuser). Without that last
+#     line the role connects fine, reads fine, and then check 14 dies with
+#     `permission denied to set role "app_tenant"` — i.e. exit 2, every night, forever. Verified on a
+#     throwaway PG17 cluster: without it the probe fails, with it `SET LOCAL ROLE app_tenant` succeeds.
+#
+#     `NOINHERIT` is what keeps that safe: the role can ASSUME app_tenant explicitly (which is all check 14
+#     needs) but does not passively hold its privileges — verified, `current_user` stays `ci_readonly`
+#     until it opts in. Do not drop NOINHERIT to "simplify" this.
+#
+#     Use the SESSION pooler (:5432). The transaction pooler (:6543) cannot `SET LOCAL ROLE` at all, which
+#     check 14 also depends on. `pg_dump --schema-only` needs no table data, but check 14's probe DOES read
+#     rows (`count(*)` only) — so SELECT is required, not merely catalog access.
+#
+#     The whole block above was executed against a throwaway PostgreSQL 17 cluster before being written
+#     here. It is not SQL composed from memory and handed to someone to run against production.
 
 name: Nightly DB Controls
 

--- a/.github/workflows/nightly-db-controls.yml
+++ b/.github/workflows/nightly-db-controls.yml
@@ -1,0 +1,141 @@
+# Nightly live-database controls — /gate checks 14, 16 and 17 (#124).
+#
+# WHY A SCHEDULED JOB AND NOT A PR CHECK
+# --------------------------------------
+# These three controls are the only things in this repo that assert anything about PRODUCTION rather than
+# about the repository. Until now they ran only when a human ran `/gate`, which is the same
+# "someone must remember" mechanism that let #111 sit in production for ~14 months.
+#
+# A schedule, rather than per-PR, is a deliberate trade recorded on #124:
+#   - it catches the OUT-OF-BAND change — a Supabase dashboard edit, a hand-applied GRANT — which is the
+#     #111 scenario and the one no PR check can ever see, because there is no PR;
+#   - it keeps production credentials off the pull_request path entirely, where a fork PR could reach them.
+# It is weaker at "this PR changed the schema". `/gate` still covers that at ship time, and always will —
+# CI here is additive, never a replacement (#124 acceptance criteria).
+#
+# THE EXIT-CODE CONTRACT IS THE WHOLE POINT
+# -----------------------------------------
+#   0 = ran, clean · 1 = ran, FOUND something · 2 = COULD NOT RUN
+# Exit 2 must fail this job as loudly as exit 1. A control that cannot run and reports green is the #38
+# failure mode, which cost this repo six unreviewed PRs. All three scripts only gained a distinguishable
+# exit 2 in #136 and #138 — before that this job was literally unbuildable to its own acceptance criteria.
+#
+# ⚠️  REQUIRES the `PROD_DIRECT_URL` secret. This is the FIRST GitHub secret in this repository, so the
+#     read-only role behind it is an access-register entry — see #40. Grants it needs, and nothing more:
+#
+#       CREATE ROLE ci_readonly LOGIN PASSWORD '…' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+#       GRANT CONNECT ON DATABASE postgres TO ci_readonly;
+#       GRANT USAGE ON SCHEMA public, supabase_migrations TO ci_readonly;
+#       GRANT SELECT ON ALL TABLES IN SCHEMA public, supabase_migrations TO ci_readonly;
+#       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ci_readonly;
+#
+#     Use the SESSION pooler (:5432). The transaction pooler (:6543) cannot `SET LOCAL ROLE`, which check 14
+#     depends on. `pg_dump --schema-only` needs no table data, but check 14's empirical probe DOES read rows
+#     (count(*) only) — so SELECT is required, not merely catalog access.
+
+name: Nightly DB Controls
+
+on:
+  schedule:
+    # 07:00 UTC daily — after any overnight deploy, before European working hours.
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+# Never let two runs race the same database.
+concurrency:
+  group: nightly-db-controls
+  cancel-in-progress: false
+
+jobs:
+  live-checks:
+    name: Live DB controls (14, 16, 17)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # No `prisma generate`: none of these three need the Prisma CLIENT. Check 17 parses the .prisma
+      # schema files as TEXT (scripts/table-ownership.mjs), and 14/16 talk to Postgres directly. Skipping it
+      # removes a whole failure mode from a job whose job is to be trustworthy.
+
+      - name: Fail fast if the credential is absent
+        env:
+          PROD_DIRECT_URL: ${{ secrets.PROD_DIRECT_URL }}
+        run: |
+          if [ -z "$PROD_DIRECT_URL" ]; then
+            echo "::error title=Nightly DB controls did not run::PROD_DIRECT_URL is not set."
+            echo "This job verifies nothing without it. Failing rather than passing vacuously — see #124." >&2
+            exit 1
+          fi
+
+      - name: Install PostgreSQL 17 client (check 16 needs pg_dump >= server)
+        run: |
+          # Production is PostgreSQL 17.x and pg_dump refuses to dump a server newer than itself. Ubuntu
+          # runners ship an older client, so take it from PGDG.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+          pg_dump --version
+
+      - name: Run checks 14, 16 and 17
+        id: checks
+        env:
+          # Both names: check 14 prefers DIRECT_URL, check 16's script reads DIRECT_URL, check 17 accepts
+          # either. Setting both avoids a check silently falling back to something unintended.
+          DIRECT_URL: ${{ secrets.PROD_DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.PROD_DIRECT_URL }}
+          PG_DUMP: /usr/lib/postgresql/17/bin/pg_dump
+        run: |
+          # NOT `set -e`. Every check must run even if an earlier one fails — the same contract /gate has,
+          # for the same reason: one failure must not hide the state of the other two.
+          set +e
+          fail=0
+
+          run_check () {
+            local num="$1" name="$2"; shift 2
+            echo "::group::Check $num — $name"
+            "$@"
+            local rc=$?
+            echo "::endgroup::"
+            case $rc in
+              0) echo "✅ check $num ($name): PASS" | tee -a "$GITHUB_STEP_SUMMARY" ;;
+              1) echo "❌ check $num ($name): **FOUND A VIOLATION** (exit 1)" | tee -a "$GITHUB_STEP_SUMMARY"
+                 echo "::error title=check $num found a violation::$name reported a finding — see the log group above."
+                 fail=1 ;;
+              2) echo "⚠️ check $num ($name): **DID NOT RUN** (exit 2) — this is NOT a pass" | tee -a "$GITHUB_STEP_SUMMARY"
+                 echo "::error title=check $num DID NOT RUN::$name could not execute. Nothing was verified. Treating as failure (#38)."
+                 fail=1 ;;
+              *) echo "⚠️ check $num ($name): unexpected exit $rc — treating as DID NOT RUN" | tee -a "$GITHUB_STEP_SUMMARY"
+                 echo "::error title=check $num exited $rc::Unexpected exit code. Treated as did-not-run, never as a pass."
+                 fail=1 ;;
+            esac
+          }
+
+          echo "## Nightly DB controls" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          run_check 14 "RLS tenant isolation"   npx tsx scripts/security/verify-rls-isolation.ts
+          run_check 16 "schema drift vs baseline" bash scripts/db/schema-baseline.sh check
+          run_check 17 "app_tenant least privilege" npx tsx scripts/security/verify-tenant-grants.ts
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_Exit 1 = found something · exit 2 = could not run. Both fail this job; only 0 is a pass._" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+          exit $fail
+
+# NOT RUN HERE, deliberately:
+#   scripts/db/pre-flip-scan.ts — takes table names as arguments and answers "is THIS table safe to flip".
+#   There is no meaningful nightly form of that question, so folding it in (as #132's residual suggested)
+#   would produce a check with nothing to assert. It stays a documented per-flip step in the runbook.

--- a/docs/architecture/ddl-governance.md
+++ b/docs/architecture/ddl-governance.md
@@ -303,10 +303,16 @@ been burned by the difference (#38):
 | ------------------------------------------------ | ---------------------------------------- | --------------------------------------- |
 | `tests/governance/scope-fixtures.test.ts` (#132) | `npx vitest run` → CI `Security Audit`   | ✅ **yes** — blocks CI                  |
 | `tests/governance/table-ownership.test.ts`       | `npx vitest run` + `dotnet-platform.yml` | ✅ yes                                  |
-| check 14 `verify-rls-isolation.ts`               | `/gate` **check 14**, local (live DB)    | ⚠️ ship-time only                       |
-| check 16 `schema-baseline.sh check`              | `/gate`, local (live DB)                 | ⚠️ ship-time only (#124)                |
-| **check 17 `verify-tenant-grants.ts`**           | `/gate` **check 17**, local (live DB)    | ⚠️ ship-time only — same credential gap |
+| check 14 `verify-rls-isolation.ts`               | `/gate` check 14 + **nightly CI** (#124) | ⚠️ ship-time + nightly sweep            |
+| check 16 `schema-baseline.sh check`              | `/gate` check 16 + **nightly CI** (#124) | ⚠️ ship-time + nightly sweep            |
+| **check 17 `verify-tenant-grants.ts`**           | `/gate` check 17 + **nightly CI** (#124) | ⚠️ ship-time + nightly sweep            |
 | `scripts/db/pre-flip-scan.ts` (#132)             | by hand, per flip (runbook §5)           | ❌ no — a documented step, not a gate   |
+
+> **The nightly job is inert until the `PROD_DIRECT_URL` secret exists**, and fails loudly rather than
+> skipping while it is absent — so "not yet configured" is visible in the Actions tab instead of silently
+> reading as "nothing to report". It is **additive**: it answers *did production drift since yesterday*,
+> never *did this change break something*. `/gate` remains the pre-merge control and the nightly sweep must
+> not be treated as having replaced it.
 
 `main` also has **no required status checks** (see the ownership-flip runbook §1), so even the ✅ rows are
 "CI goes red", not "the merge is blocked". `gh pr merge --admin` bypasses all of it.

--- a/tests/governance/gate-wiring.test.ts
+++ b/tests/governance/gate-wiring.test.ts
@@ -163,17 +163,29 @@ describe('/gate check list ↔ the scripts it must run', () => {
     expect(sorted, `check numbers must run 1..${sorted.length} with no gaps`).toEqual(expected);
   });
 
-  it('states in so many words that the live-DB checks have no CI equivalent', () => {
-    // The trap this closes: reading a skipped check 14/16/17 as "CI will catch it". It will not.
+  it('states that no pull request runs the live-DB checks, and that the nightly job is additive', () => {
+    // The trap this closes: reading a skipped check 14/16/17 as "CI will catch it".
     //
-    // Tier-2 finding 2 on PR #135: this was `/no CI equivalent|#124/`, and that alternation defeated it —
-    // `#124` already appears twice in the file for other reasons, so the actual sentence could be deleted
-    // outright and the test still passed. Require the phrase itself. An alternation in a governance
-    // assertion is almost always a hole: it passes on the weakest branch.
+    // REWRITTEN TWICE, and the second rewrite is the interesting one:
+    //   - #135: was `/no CI equivalent|#124/`. The alternation defeated it — `#124` appears elsewhere in
+    //     the file, so the sentence it demanded could be deleted outright and this still passed.
+    //   - #124: "no CI equivalent" became FALSE for 14/16/17 once the nightly job landed. A test pinning a
+    //     doc against yesterday's reality starts enforcing yesterday's reality. Third time this file has
+    //     had to be inverted for that reason — pin the invariant, not the era.
+    //
+    // The durable invariant is not "CI never runs these". It is: **no pull request runs them, and the
+    // nightly sweep does not substitute for running them before you merge.**
     expect(
-      /no CI equivalent/.test(gate),
-      `${GATE_REL} must state that checks ${LIVE_DB_CHECKS.join('/')} have no CI equivalent, so that ` +
-        'skipping one is a visible decision rather than an assumption that CI covers it.',
+      /no CI equivalent on a pull request/.test(gate),
+      `${GATE_REL} must state that checks ${LIVE_DB_CHECKS.join('/')} have no CI equivalent ON A PULL ` +
+        'REQUEST, so skipping one at ship time stays a visible decision.',
+    ).toBe(true);
+
+    expect(
+      /additive, not a replacement/.test(gate),
+      `${GATE_REL} must say the nightly job (#124) is additive. It answers "did production drift since ` +
+        'yesterday", never "did this change break something" — treating it as the latter is how a ' +
+        'ship-time control quietly stops being run.',
     ).toBe(true);
   });
 
@@ -186,8 +198,12 @@ describe('/gate check list ↔ the scripts it must run', () => {
     //
     // Pin the correct statement positively instead. Positive pins fail when the text stops saying the right
     // thing; negative pins fail when someone phrases the right thing an unanticipated way.
+    // Tolerant of surrounding punctuation/emphasis, strict about the CLAIM: these three numbers, and the
+    // credential requirement, in one statement. The first version demanded an exact bolded phrase and
+    // broke when a full stop moved inside the `**` — a pin that fails on innocuous rewording gets deleted
+    // by whoever hits it, which is how a governance assertion dies.
     expect(
-      /\*\*14, 16, 17 need live production database credentials\*\*/.test(gate),
+      /14, 16, 17 need live production database credentials/.test(gate),
       `${GATE_REL} must attribute the live-database credential gap to checks 14, 16 and 17 specifically. ` +
         'Check 15 is the cross-model review — it needs an external reviewer (Codex/OmniRoute), not a ' +
         "database. Lumping 15 in makes #124 look bigger than it is and hides check 15's real blocker (#38).",


### PR DESCRIPTION
The credential half of **#124**, per your decision: a scheduled job with a minimal read-only role, not a per-PR check.

> ## ⚠️ Add the secret BEFORE merging
>
> Reversed, the schedule goes red every night until it exists — which trains people to ignore CI, the exact cry-wolf failure this issue is about.

## Why this is only buildable now

#124's own acceptance criterion — *"the job must distinguish exit 1 from exit 2 and fail loudly on 2"* — was **unsatisfiable** until #136 and #138, because checks 14 and 17 returned `1` for both "found something" and "never ran". All three now have a branchable `0/1/2` contract, so the job can finally tell a tenant-isolation breach from a network blip.

## Scheduled, not per-PR

Two distinct reasons, both recorded on the issue:

- it catches the **out-of-band change nobody opened a PR for** — the #111 scenario, and the one no PR check can ever see, because there is no PR;
- it keeps production credentials **off the `pull_request` path**, where a fork PR could reach them.

**It is additive.** It answers *did production drift since yesterday*, never *did this change break something*. `/gate` remains the pre-merge control. A governance test now pins the word "additive", because a nightly sweep is exactly the kind of thing that quietly becomes an excuse to stop running the ship-time check.

## Fail-loud behaviour — the entire point

| Condition | Result |
|---|---|
| exit 1 (violation) | ❌ job fails, `::error` says *found a violation* |
| exit 2 (could not run) | ❌ job fails, `::error` says *DID NOT RUN* |
| unexpected exit code | ❌ treated as did-not-run, never a pass |
| an earlier check fails | the other two **still run** — same contract as `/gate` |
| secret missing | ❌ **fails**, rather than skipping |

That last row matters: "not configured yet" must be visible in the Actions tab, not read as "nothing to report". The dispatch logic was tested locally against stubs returning 0/1/2/127.

## The setup SQL — and the bug in my first version of it

```sql
CREATE ROLE ci_readonly LOGIN PASSWORD '…' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
GRANT CONNECT ON DATABASE postgres TO ci_readonly;
GRANT USAGE ON SCHEMA public, supabase_migrations TO ci_readonly;
GRANT SELECT ON ALL TABLES IN SCHEMA public, supabase_migrations TO ci_readonly;
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ci_readonly;
GRANT app_tenant TO ci_readonly;   -- REQUIRED, and not obvious
```

**The last line was missing from my first draft, and without it this job fails every single night.** Check 14's probe issues `SET LOCAL ROLE app_tenant`, and Postgres requires *membership* in the target role for `SET ROLE`. Verified against a throwaway PG17 cluster:

```
ERROR:  permission denied to set role "app_tenant"
```

So the grants I was about to hand you would have produced exit 2 in perpetuity — the precise cry-wolf failure this issue exists to prevent, caused by my own setup instructions, and it would have looked like a broken check rather than a missing grant.

`NOINHERIT` is what keeps the membership grant safe: the role can **assume** `app_tenant` explicitly (all check 14 needs) without passively holding its privileges — verified, `current_user` stays `ci_readonly` until it opts in. Don't drop `NOINHERIT` to simplify.

**The whole block now runs clean end-to-end on a throwaway cluster before being handed over.** Composing DCL from memory and asking someone to run it against production isn't something to do twice.

Then add it as **`PROD_DIRECT_URL`** — **session pooler (`:5432`)**, since the transaction pooler can't `SET LOCAL ROLE` at all. `SELECT` is genuinely required, not just catalog access: check 14's probe reads row counts.

This is the **first GitHub secret in this repository**, which makes the role an access-register entry — see **#40**.

## Scope notes

- **No `prisma generate`**: none of the three need the Prisma client (17 parses `.prisma` files as text; 14/16 talk to Postgres directly), so that failure mode is simply absent.
- **`pre-flip-scan.ts` deliberately excluded**, despite #132's residual suggesting it be folded in: it takes table names and answers *is THIS table safe to flip*. There is no meaningful nightly form of that question, and a check with nothing to assert is worse than no check.
- `gate.md` and `ddl-governance.md` updated — "checks 14–17 have no CI equivalent" is now false for three of them, and leaving that claim standing would be its own small governance defect.

## Verification

Local gate: tsc api+web ✅ · vitest **290 files / 2726 tests** ✅ · greps ✅ · build ✅ · gitleaks ✅ · checks 14/16/17 against prod ✅.

**Check 15: ⚠️ NOT RUN (exit 2), four consecutive attempts**, all `3× curl rc=28`. OmniRoute has been down since mid-afternoon and has stopped recovering, so this is no longer per-run flakiness. Tier 1 remains quota-blocked to 2026-08-15.

Per `.claude/rules/verification.md`, the **tier-3 3-lens panel** ran instead:

- **Security** — the workflow has no `pull_request` trigger, so the secret is unreachable from fork PRs; actions match those already used in `ci.yml`; the PGDG key is fetched over HTTPS and pinned via `signed-by`; no step echoes the credential.
- **Claim auditor** — this is the lens that found the missing `GRANT app_tenant`. It went to *test* the SQL rather than re-read it, which is the only reason the defect surfaced.
- **Coverage** — the workflow itself can't be unit-tested; the dispatch logic was exercised against stub exit codes instead, and that limitation is stated rather than implied.

**Do not read this as cross-model-verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
