### PR TITLE
fix(db): pre-flip-scan could reach prod from vitest, and missed SQL-standard function bodies (#132)

### DIFF
--- a/.claude/commands/gate.md
+++ b/.claude/commands/gate.md
@@ -6,7 +6,7 @@ allowed-tools:
 
 # /gate — Local Verify Gate
 
-Run every check the CI pipeline runs — **plus the four checks (14–17) that CI cannot run at all** — locally, from the repo root. Report a pass/fail table at the end. This is the merge gate when GitHub Actions is unavailable, and the pre-push gate when it isn't. For checks 14–17 it is the _only_ gate, in either case.
+Run every check the CI pipeline runs — **plus the five checks (14–18) that CI cannot run at all** — locally, from the repo root. Report a pass/fail table at the end. This is the merge gate when GitHub Actions is unavailable, and the pre-push gate when it isn't. For checks 14–18 it is the _only_ gate, in either case.
 
 ## Execution Contract (non-negotiable)
 
@@ -21,15 +21,19 @@ You MUST run ALL checks below even if an early one fails — the user needs the 
 
 ## Checks
 
-Checks 1–13 mirror `.github/workflows/ci.yml`. **Checks 14–17 have no CI equivalent**, so `/gate` is the
-only place they run at all — but for two different reasons, and conflating them hides both:
+Checks 1–13 mirror `.github/workflows/ci.yml`. **Checks 14–18 have no CI equivalent**, so `/gate` is the
+only place they run at all — but for three different reasons, and conflating them hides all three:
 
 - **14, 16, 17 need live production database credentials** that CI does not have. That is one decision
   (#124) blocking three controls.
 - **15 needs an external reviewer** (Codex, or OmniRoute as tier 2) — not a database. Its blockers are
   quota and gateway availability, tracked separately in #38.
+- **18 needs a database only on a branch that actually flips a table's owner.** It derives its table list
+  from the ownership ledger's `efcore[]` diff, so on every other branch it is a no-op that still states
+  what it compared. A nightly job is the wrong home for it (#139 covers 14/16/17): run from `main` the
+  ledger diff is empty by construction, so it would report "nothing to scan" every night forever.
 
-Skipping any of the four is not "CI will catch it". CI has no equivalent job for any of them.
+Skipping any of the five is not "CI will catch it". CI has no equivalent job for any of them.
 
 Run prisma generate once first (typecheck/tests/build all need the client):
 
@@ -56,6 +60,7 @@ pnpm --filter @tims/db exec prisma generate --schema prisma/schema
 | 15  | Cross-model review             | `bash scripts/verification/crossmodel-review.sh` → exit 0. Tries Codex, then OmniRoute (tier 2). **Exit 2 = NO reviewer ran** — report ⚠️ NOT RUN, never PASS, then use the same-model 3-lens panel in `.claude/rules/verification.md`. Codex is quota-blocked until 2026-08-15; set `OMNIROUTE_KEY` to make tier 2 live.                                                                                                                                                                                                                                                                           |
 | 16  | Schema drift (live DB)         | `bash scripts/db/schema-baseline.sh check` → exit 0. Diffs the live schema against `packages/db/baseline/prod-public-schema.sql`. Needs the direct connection (:5432) and `pg_dump` ≥ 17 (`brew install postgresql@17`). **Exit 1 = drift, exit 2 = COULD NOT RUN** — report ⚠️ NOT RUN, never PASS. If the PR intentionally changes the schema, re-run `capture` and commit the new baseline **in that PR**.                                                                                                                                                                                       |
 | 17  | `app_tenant` grants (live DB)  | `npx tsx scripts/security/verify-tenant-grants.ts` → exit 0. Asserts `app_tenant` holds INSERT/UPDATE/DELETE only where the table is Prisma-owned **or** has RLS enabled with ≥1 policy. Needs the direct connection (:5432). **Exit 1 = violation, exit 2 = COULD NOT RUN** — report ⚠️ NOT RUN, never PASS. (Aligned with check 16's contract in #124; it previously returned 1 for both.)                                                                                                                                                                                                        |
+| 18  | Pre-flip dependency scan       | `npx tsx scripts/db/pre-flip-scan.ts --flip-diff` → exit 0. Derives its table list from the ownership ledger's `efcore[]` diff vs `origin/main`: on a branch that flips nothing it scans nothing, **states what it compared**, and needs no database. On a flip PR it needs the direct connection (:5432) and covers what no repo grep can — views/matviews (by text **and** by `pg_depend`), functions, triggers, other `pg_depend` dependents, §3(f) policies, inbound FKs, `app_tenant` grants — plus the data-file readers `tsc` cannot see. Needs `origin/main` to exist locally (`git fetch origin` first, or pass `--base <ref>`) — an unresolvable base is exit 2, deliberately, because guessing "nothing flipped" would be a silent pass on exactly the PR this exists for. **Exit 1 = blocker, exit 2 = COULD NOT RUN** — report ⚠️ NOT RUN, never PASS (#132). |
 
 Notes:
 
@@ -100,6 +105,16 @@ Notes:
   "the checks could not run" — npx would fetch and run them. An earlier draft of this note said that and
   overstated it.) If `npx tsx` ever resolves to something unexpected, prefer `node_modules/.bin/tsx` — which
   is what the failure-path tests invoke, deliberately.
+- **Check 18 reports the POPULATION each of its arms searched, and a "0" without a population is not a
+  result.** It was rewritten under #132 because the equivalent hand-run queries came back empty against
+  production for the calibration flip and one arm had, on inspection, examined nothing worth the name:
+  the view/matview arm returned 0 across the whole `public` schema, which proves nothing on its own,
+  because `public` holds 119 ordinary tables and **zero** views, matviews or foreign tables. Each
+  text-matching arm now re-runs its own query against a row it MUST match before its result is believed
+  (exit 2 if that fails), and the run as a whole is fingerprinted against the Prisma schema, so an empty
+  or wrong database exits 2 rather than printing a tick. If a summary line says an arm was **NOT
+  EXERCISED**, that is a statement about the database, not a clean bill of health for the tables — put it
+  in the PR body verbatim.
 - **Check 17's invariant is "Prisma-owned OR RLS-protected" — do not "simplify" it to "Prisma-owned only".**
   The C# strangler writes its own tables **as `app_tenant`** (`TenantScope.cs:46` issues
   `SET LOCAL ROLE app_tenant`), because that is _how_ those writes get RLS-enforced. A narrower check

--- a/docs/architecture/csharp-migration/ownership-flip-runbook.md
+++ b/docs/architecture/csharp-migration/ownership-flip-runbook.md
@@ -877,8 +877,12 @@ Run all of these. Step 0 and steps 6-9 need a real DB (0, 6, 7 and 9 against pro
 
         - **views/matviews** referencing the table, found BOTH by text over `pg_get_viewdef` AND through
           `pg_depend`. Neither method subsumes the other — measured on PG 17.10, a `plpgsql` function body
-          produces **no `pg_depend` row at all**, so functions can only ever be a text match, while
-          `pg_depend` catches relations the text arm cannot see.
+          (and equally a dollar-quoted `LANGUAGE sql` body) produces **no `pg_depend` row at all**, so
+          those can only ever be a text match, while `pg_depend` catches relations the text arm cannot see.
+          **The converse also holds, and it bit us:** a SQL-standard body (`BEGIN ATOMIC … END` or the
+          `RETURN` form, PG14+) is stored PARSED in `pg_proc.prosqlbody` with `prosrc = ''`, so it is
+          invisible to the text arm and visible ONLY through `pg_depend`. The text arm therefore searches
+          `prosrc || pg_get_function_sqlbody(oid)`, not `prosrc` alone. Do not "simplify" that back.
         - **functions**, **triggers**, and any other `pg_depend` dependent (`deptype = 'n'`) — a default
           expression or a generated column can depend on a table too. All BLOCKERS: they keep working
           after the Prisma model is deleted, and keep bypassing whatever scoping the TS stack applied.

--- a/docs/architecture/csharp-migration/ownership-flip-runbook.md
+++ b/docs/architecture/csharp-migration/ownership-flip-runbook.md
@@ -860,23 +860,49 @@ Run all of these. Step 0 and steps 6-9 need a real DB (0, 6, 7 and 9 against pro
     Verified 2026-08-02 against the current repo: `ghost efcore[] entries: []` (all six pass). A typo in
     step 4 of §1 shows up here and nowhere else.
     _(Consider promoting this to a real rule in `checkOwnership()` — it is a ~3-line addition.)_
-    5b. **Database-side dependency scan — SCRIPTED as of #132.** Run this BEFORE deleting the model, not after:
+    5b. **Pre-flip dependency scan — SCRIPTED as of #132, and WIRED as `/gate` check 18.** Run this
+    BEFORE deleting the model, not after:
 
         ```bash
-        npx tsx scripts/db/pre-flip-scan.ts <table>...     # 0 = no blocker, 1 = blocker or could-not-run
+        npx tsx scripts/db/pre-flip-scan.ts <table>...   # 0 = no blocker · 1 = blocker · 2 = DID NOT RUN
+        npx tsx scripts/db/pre-flip-scan.ts --flip-diff  # same, tables derived from the ledger diff
         ```
 
-        It replaces four separate hand-run queries and covers what no repo grep can see: **views/matviews**
-        and **functions** referencing the table (both BLOCKERS — they keep working after the Prisma model is
-        deleted, and keep bypassing whatever scoping the TS stack applied), plus the §3(f) policy scan,
-        inbound FKs (flagging any from *outside* the flip set), `app_tenant` grants (#126), and RLS state.
+        **Exit 2 is not a pass** — same contract as checks 14, 16 and 17. `--flip-diff` is the form
+        `/gate` runs: it takes the tables from the ownership ledger's `efcore[]` diff against
+        `origin/main`, so nobody has to remember to type the names, and on a branch that flips nothing it
+        scans nothing and says what it compared.
 
-        Flip #2 ran these by hand and came back clean; the script exists so the next flip cannot forget one.
-        Its blocker paths were exercised against a throwaway PG17 cluster carrying a deliberate view
-        and function over a target table (both correctly reported, exit 1). That run is not
-        committable — vitest has no database — so `tests/db/pre-flip-scan.test.ts` pins the
-        exit-code contract and the query-correctness properties offline instead, the same split as
-        `tests/db/schema-baseline-failure-paths.test.ts`.
+        It replaces four separate hand-run queries and covers what no repo grep can see:
+
+        - **views/matviews** referencing the table, found BOTH by text over `pg_get_viewdef` AND through
+          `pg_depend`. Neither method subsumes the other — measured on PG 17.10, a `plpgsql` function body
+          produces **no `pg_depend` row at all**, so functions can only ever be a text match, while
+          `pg_depend` catches relations the text arm cannot see.
+        - **functions**, **triggers**, and any other `pg_depend` dependent (`deptype = 'n'`) — a default
+          expression or a generated column can depend on a table too. All BLOCKERS: they keep working
+          after the Prisma model is deleted, and keep bypassing whatever scoping the TS stack applied.
+        - the §3(f) policy scan, inbound FKs (flagging any from *outside* the flip set, resolved by OID so
+          a same-named constraint in another schema cannot become a phantom), `app_tenant` grants (#126),
+          and RLS state.
+        - **data-file readers** — the class flip #2 actually hit. `contracts/access-fixtures/scope-where.json`
+          named `'successor'` / `'criticalRole'`, `tsc` stayed green, and all six P2 greps are `.ts`-scoped.
+          Hits there and in `packages/db/prisma/seed*.ts` are BLOCKERS; DDL and parity references are INFO.
+
+        **Every arm reports the population it searched, and a hit count without one is not a result.**
+        Flip #3's hand-run queries came back empty for the calibration tables, and the view arm had in fact
+        examined nothing worth the name — 0 across a `public` schema that contains 119 tables and **zero**
+        views. Each text arm now re-runs its own query against a row it MUST match before its result is
+        believed (exit 2 if that fails), and the whole run is fingerprinted against the Prisma schema, so
+        an empty or wrong database exits 2 rather than printing a tick. An arm reported **NOT EXERCISED**
+        is a statement about the database — copy it into the PR body rather than writing "clean scan".
+
+        Coverage split, stated plainly: the could-not-run paths are EXECUTED in
+        `tests/db/pre-flip-scan.test.ts` and the data-file arm is unit-tested for real in
+        `tests/db/pre-flip-repo-scan.test.ts`. Exit 0 and exit 1 need a database, so they were proved on a
+        throwaway PostgreSQL 17.10 cluster (transcript in the test header, including the mutation that
+        turns the functions arm blind and the exit 2 that catches it) and are pinned offline as properties
+        — the same split, and the same reason, as `tests/db/schema-baseline-failure-paths.test.ts`.
 
 6.  **Live DB assertion — the table survived, unchanged.** Run against prod (read-only) before and after
     the PR merges, and diff. `pre-flip-scan.ts` above already reports existence, RLS, policies, grants and
@@ -1499,6 +1525,13 @@ Federico-only:
 - **§5 step 5b — `pre-flip-scan.ts`.** The important gap: **views, matviews and functions** referencing
   the three tables are raw-SQL readers that survive model deletion and are invisible to `tsc`, to the
   ownership check and to every P2 grep. Flip #2 found zero; that is not evidence about these tables.
+  > **Since #132 this step is `/gate` check 18** (`npx tsx scripts/db/pre-flip-scan.ts --flip-diff`), and
+  > the note above understates what running it would have to show. The hand-run version of these queries
+  > returned empty for the calibration tables, but the view/matview arm searched a `public` schema
+  > containing **zero** views — a correct answer that no control had established. The script now reports
+  > every arm's population, proves each text matcher against a row it must match, and exits **2** rather
+  > than 0 when it cannot. Re-running it for these three tables is therefore still outstanding, and a
+  > result that says an arm was NOT EXERCISED must be recorded as such, not as "clean".
 - **§5 step 6 — the live before/after shape diff** (RLS flags, policy set, grants, indexes, `n_tup_del`).
   The DROP-TABLE tripwire.
   Run all three before merging. Steps 0 and 5b are the two that could still turn up a blocker.

--- a/docs/architecture/ddl-governance.md
+++ b/docs/architecture/ddl-governance.md
@@ -306,10 +306,22 @@ been burned by the difference (#38):
 | check 14 `verify-rls-isolation.ts`               | `/gate` **check 14**, local (live DB)    | ⚠️ ship-time only                       |
 | check 16 `schema-baseline.sh check`              | `/gate`, local (live DB)                 | ⚠️ ship-time only (#124)                |
 | **check 17 `verify-tenant-grants.ts`**           | `/gate` **check 17**, local (live DB)    | ⚠️ ship-time only — same credential gap |
-| `scripts/db/pre-flip-scan.ts` (#132)             | by hand, per flip (runbook §5)           | ❌ no — a documented step, not a gate   |
+| `scripts/db/pre-flip-scan.ts` (#132)             | `/gate` **check 18**, local              | ⚠️ ship-time only — see below           |
 
 `main` also has **no required status checks** (see the ownership-flip runbook §1), so even the ✅ rows are
 "CI goes red", not "the merge is blocked". `gh pr merge --admin` bypasses all of it.
+
+> **Check 18 (`pre-flip-scan.ts`) — wired 2026-08-06 (#132).** It was previously "by hand, per flip", which
+> in practice meant it had **never run**: flip #3 shipped with §5 step 5b unexecuted. It now derives its
+> table list from the ownership ledger's `efcore[]` diff (`--flip-diff`), so `/gate` can run it on every
+> branch without anyone typing table names, and it is a no-op that still states what it compared when the
+> branch flips nothing. Contract: **0 clean · 1 blocker · 2 could-not-run**, the same as 14/16/17.
+>
+> Its residual gap is NOT #124's. It needs a database only on a branch that actually flips a table, and a
+> nightly job (#139) is the wrong home for it — run from `main`, the ledger diff is empty by construction,
+> so it would report "nothing to scan" every night and prove nothing. What is genuinely unenforced is the
+> case where a flip PR is merged without `/gate` having been run at all, which is the same gap every ⚠️ row
+> in this table has.
 
 > **CORRECTED 2026-08-05.** The paragraph here previously said "the `/gate` skill's own check list is
 > defined outside this repository", so check 17 could not be added to it. **That was false.** The check list

--- a/scripts/db/pre-flip-repo-scan.mjs
+++ b/scripts/db/pre-flip-repo-scan.mjs
@@ -1,0 +1,258 @@
+// Data-driven reader sweep for the ownership-flip pre-flip scan — issue #132.
+//
+// WHY THIS EXISTS
+// ---------------
+// All six of the runbook's P2 reader-sweep greps are `.ts`-scoped, and `tsc` cannot see a model name
+// that lives inside a JSON file. Flip #2 (#69) removed `'successor'` / `'criticalRole'` from
+// `ScopedEntity`, got a GREEN `tsc`, and only found out via 6 opaque failures in
+// `contracts/access-fixtures/scope-where.json` — a file that is not an ordinary fixture but a
+// CROSS-STACK contract, asserted by `tests/access/scope-where-fixtures.test.ts` AND by
+// `Tims.UnitTests/Fixtures/ScopeWhereForFixtureTests.cs`. Deleting the failing cases (the tempting fix)
+// would have silently removed the oracle pinning the C# implementation.
+//
+// Pure, dependency-free (Node stdlib only) and separated from `pre-flip-scan.ts` on purpose: the
+// database arms of that script cannot run under `npx vitest run`, but THIS arm can, so it is unit-tested
+// for real against the real repository rather than pinned by a source-text grep. Same split, and the same
+// reason, as `scripts/table-ownership.mjs`.
+//
+// NON-VACUITY IS THE WHOLE POINT. `scanDataFiles` reports the population it searched — roots, file count,
+// and every root it could NOT find. A caller that ignores `missingRoots` is back to a scan that examined
+// nothing and reported clean, which is the defect class this repo keeps re-finding (#38, checks 14/16/17).
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/**
+ * The data roots that are searched, PINNED BY NAME rather than discovered.
+ *
+ * Auto-discovery (e.g. "every *.json under the repo") would make deleting a fixture directory a green
+ * change, and would drag in `node_modules`, lockfiles and the 2 MB schema baseline — which names every
+ * table in the database and would therefore match every scan, i.e. pure noise that gets the check
+ * switched off. Naming the roots makes REMOVING one a diff someone has to justify.
+ *
+ * `kind` is the classification of a hit, not of the root:
+ *   blocker — the hit must be dispositioned before the Prisma model is deleted
+ *   info    — the hit is expected for some tables (a `CREATE TABLE` in the DDL that defines them) and is
+ *             reported for the PR body rather than failing the scan
+ */
+export const DATA_ROOTS = Object.freeze([
+  Object.freeze({
+    path: 'contracts',
+    exts: Object.freeze(['.json', '.yaml', '.yml', '.csv']),
+    why: 'cross-stack contract fixtures — asserted by BOTH the TS suite and Tims.UnitTests',
+  }),
+  Object.freeze({
+    path: 'packages/db/prisma',
+    exts: Object.freeze(['.ts', '.json', '.sql']),
+    why: 'seeds (§8 Q9 post-flip seed hazard) and hand-applied SQL',
+  }),
+  Object.freeze({
+    path: 'scripts/parity',
+    exts: Object.freeze(['.ts', '.json']),
+    why: 'the parity harness writes/reads through RAW SQL, so it survives model deletion mechanically',
+  }),
+  Object.freeze({
+    path: 'services/Tims.Platform/db',
+    exts: Object.freeze(['.sql', '.json']),
+    why: 'flip-DDL and hand-applied EF scripts',
+  }),
+]);
+
+/**
+ * Path prefixes whose hits are BLOCKERS. Everything else found in a root above is INFO.
+ *
+ *  - `contracts/access-fixtures/` is the proven case: it pins the C# port of `scopeWhereFor`, so an
+ *    entity named there must SURVIVE the flip. The right response to a hit is NOT to delete the case.
+ *  - a `seed*` file under `packages/db/prisma/` is the §8 Q9 hazard: a seed that still writes a deleted
+ *    model breaks `prisma db seed`, and a seed that writes it through raw SQL is invisible to `tsc`.
+ */
+const BLOCKER_MATCHERS = Object.freeze([
+  Object.freeze({
+    test: (rel) => rel.startsWith('contracts/access-fixtures/'),
+    why:
+      'CROSS-STACK CONTRACT. This file is asserted by tests/access/scope-where-fixtures.test.ts AND by ' +
+      "Tims.UnitTests' ScopeWhereForFixtureTests, so the entity must SURVIVE the flip — scopeWhereFor is " +
+      'a PURE function and never touches Prisma. Do NOT delete the case to make it pass: that removes the ' +
+      "oracle pinning C#'s own implementation (runbook §1 step 6).",
+  }),
+  Object.freeze({
+    test: (rel) => /^packages\/db\/prisma\/[^/]*seed[^/]*\.ts$/.test(rel),
+    why:
+      'SEED (§8 Q9). A seed still writing this model breaks `prisma db seed` after the model is deleted, ' +
+      'and one that writes it through raw SQL is invisible to `tsc` — port or remove it in the flip PR.',
+  }),
+]);
+
+/** Directory names never descended into, at any depth. */
+const SKIP_DIRS = Object.freeze(new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']));
+
+/** Capitalise the first letter only; the rest of a snake segment is already lower-case. */
+const cap = (w) => (w ? w[0].toUpperCase() + w.slice(1) : w);
+
+/**
+ * English-plural → singular for the LAST segment of a table name. Deliberately small: the inputs are
+ * this repo's table names, not arbitrary English.
+ */
+function singularize(word) {
+  if (/ies$/i.test(word) && word.length > 3) return `${word.slice(0, -3)}y`;
+  if (/(ses|xes|zes|ches|shes)$/i.test(word)) return word.slice(0, -2);
+  if (/ss$/i.test(word)) return word;
+  if (/s$/i.test(word) && word.length > 1) return word.slice(0, -1);
+  return word;
+}
+
+/**
+ * Every spelling a data file might use for a table.
+ *
+ * A JSON fixture names the MODEL, not the table: flip #2's break was the string `"criticalRole"` in a
+ * file whose table is `critical_roles`. Searching only the snake-case table name would have found
+ * nothing — which is precisely how the whole P2 sweep missed it.
+ *
+ * Returned lower-cased and de-duplicated; matching is case-insensitive.
+ */
+export function nameVariants(table) {
+  const parts = String(table)
+    .split('_')
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) return [];
+  const singularParts = [...parts.slice(0, -1), singularize(parts[parts.length - 1])];
+
+  const snakePlural = parts.join('_');
+  const snakeSingular = singularParts.join('_');
+  const pascalPlural = parts.map(cap).join('');
+  const pascalSingular = singularParts.map(cap).join('');
+  const camelPlural = parts[0] + parts.slice(1).map(cap).join('');
+  const camelSingular = singularParts[0] + singularParts.slice(1).map(cap).join('');
+
+  return [
+    ...new Set(
+      [snakePlural, snakeSingular, pascalPlural, pascalSingular, camelPlural, camelSingular].map((v) =>
+        v.toLowerCase(),
+      ),
+    ),
+  ].sort();
+}
+
+/**
+ * Word-boundary matching, so `calibration_sessions_pkey` (an index name) is not reported as a reference
+ * to `calibration_sessions`. Without a boundary the migration files alone would contribute a hit per
+ * index per table, and a report nobody reads enforces nothing.
+ *
+ * The character classes are written out rather than using `\b`. In JavaScript the two are equivalent —
+ * `\w` is `[A-Za-z0-9_]`, so `\b` already treats the underscore as a word character; this was checked by
+ * mutation rather than assumed, and the `\b` version passed every test here. They are spelled out
+ * because the SQL side of this scan CANNOT use `\b`: in a Postgres advanced regular expression `\b` is a
+ * BACKSPACE, so `'critical_roles_pkey' ~* '\bcritical_roles\b'` and `'x critical_roles y' ~* '…'` both
+ * return false — a `\b` matcher there finds nothing at all and reports every scan clean. Keeping both
+ * sides visibly boundary-explicit is what stops one being "simplified" into the other.
+ */
+function variantRegex(variant) {
+  const escaped = variant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`, 'i');
+}
+
+/** Recursively list files under `dir` whose extension is in `exts`. Returns repo-relative POSIX paths. */
+function listFiles(root, dir, exts, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out; // unreadable subdirectory — the caller's missingRoots covers a missing ROOT
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      listFiles(root, full, exts, out);
+    } else if (entry.isFile() && exts.some((e) => entry.name.toLowerCase().endsWith(e))) {
+      out.push(relative(root, full).split(sep).join('/'));
+    }
+  }
+  return out;
+}
+
+function classify(rel) {
+  for (const m of BLOCKER_MATCHERS) if (m.test(rel)) return { kind: 'blocker', why: m.why };
+  return { kind: 'info', why: '' };
+}
+
+/**
+ * Scan the pinned data roots for any spelling of any of `tables`.
+ *
+ * @param {string[]} tables      table names being flipped
+ * @param {string}   repoRoot    directory the roots are resolved against (cwd for the CLI, a sandbox in tests)
+ * @returns {{
+ *   hits: { file: string, line: number, variant: string, table: string, kind: 'blocker'|'info', why: string, text: string }[],
+ *   filesScanned: number,
+ *   perRoot: { path: string, files: number, present: boolean }[],
+ *   missingRoots: string[],
+ *   variants: Record<string, string[]>,
+ * }}
+ *
+ * `missingRoots` is the non-vacuity control and the caller MUST fail on it: a renamed or deleted root
+ * silently shrinks the searched population to zero while the result still reads "no hits".
+ */
+export function scanDataFiles(tables, repoRoot) {
+  const perRoot = [];
+  const missingRoots = [];
+  const files = [];
+
+  for (const root of DATA_ROOTS) {
+    const abs = join(repoRoot, root.path);
+    let present = false;
+    try {
+      present = statSync(abs).isDirectory();
+    } catch {
+      present = false;
+    }
+    if (!present) {
+      missingRoots.push(root.path);
+      perRoot.push({ path: root.path, files: 0, present: false });
+      continue;
+    }
+    const found = listFiles(repoRoot, abs, [...root.exts], []);
+    files.push(...found);
+    perRoot.push({ path: root.path, files: found.length, present: true });
+  }
+
+  const variants = {};
+  for (const table of tables) variants[table] = nameVariants(table);
+
+  const hits = [];
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(join(repoRoot, file), 'utf8');
+    } catch {
+      continue;
+    }
+    // Cheap pre-filter: skip the line-by-line walk unless some variant appears at all.
+    const lower = content.toLowerCase();
+    const candidates = tables.filter((t) => variants[t].some((v) => lower.includes(v)));
+    if (candidates.length === 0) continue;
+
+    const lines = content.split('\n');
+    const { kind, why } = classify(file);
+    for (const table of candidates) {
+      for (const variant of variants[table]) {
+        const re = variantRegex(variant);
+        for (let i = 0; i < lines.length; i++) {
+          if (!re.test(lines[i])) continue;
+          hits.push({
+            file,
+            line: i + 1,
+            variant,
+            table,
+            kind,
+            why,
+            text: lines[i].trim().slice(0, 160),
+          });
+          break; // one hit per file per variant is enough to demand a look
+        }
+      }
+    }
+  }
+
+  hits.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.variant.localeCompare(b.variant));
+  return { hits, filesScanned: files.length, perRoot, missingRoots, variants };
+}

--- a/scripts/db/pre-flip-scan.ts
+++ b/scripts/db/pre-flip-scan.ts
@@ -104,6 +104,23 @@ function die2(reason: string): never {
   process.exit(2);
 }
 
+/**
+ * stdout, written SYNCHRONOUSLY — the same reason die2 uses writeSync(2, …).
+ *
+ * Node's stdout is ASYNC when it is a pipe, and `process.exit()` discards pending writes. Every stdout
+ * path in this file is immediately followed by an exit, so `console.log` truncates at the ~64KB pipe
+ * buffer. Reproduced on darwin/node v25: `out(400KB); process.exit(0)` piped yields 65536
+ * bytes; redirected to a file it yields all 400014. On Linux pipes are synchronous, so this is a local
+ * `/gate` exposure rather than a CI one — but a control whose output silently truncates is exactly the
+ * class of defect this script exists to eliminate.
+ *
+ * NOT fixed by dropping the explicit `process.exit()` in favour of `process.exitCode`: a lingering
+ * handle would then turn a fail-closed control into a HANG, which is worse than the defect.
+ */
+function out(line = ''): void {
+  writeSync(1, `${line}\n`);
+}
+
 function loadDbEnv(): void {
   if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
   for (const path of ['packages/db/.env', '.env']) {
@@ -156,6 +173,7 @@ interface TableReport {
   dependentViews: string[];
   /** Views found through `pg_depend` — text-free, authoritative, and an independent oracle. */
   dependentViewsByDepend: string[];
+  dependentRoutinesByDepend: string[];
   dependentRoutines: string[];
   triggers: string[];
   otherDependents: string[];
@@ -245,13 +263,13 @@ async function main(): Promise<void> {
     if (tables.length === 0) {
       // A real, stated finding — with its population — not an empty result dressed up as a pass.
       const line = `✓ pre-flip scan: no ownership flip in this diff (${diffNote}). Nothing to scan.`;
-      console.log(asJson ? JSON.stringify({ flipDiff: true, tables: [], note: diffNote }, null, 2) : line);
+      out(asJson ? JSON.stringify({ flipDiff: true, tables: [], note: diffNote }, null, 2) : line);
       process.exit(0);
     }
     // Say what was derived BEFORE anything can fail. If this only printed in the final report, then a
     // credentials problem — the most likely failure — would leave nobody able to tell "the diff found
     // nothing" from "the diff found something and we never got to it". They are opposite situations.
-    if (!asJson) console.log(`\n${diffNote}: ${tables.join(', ')}`);
+    if (!asJson) out(`\n${diffNote}: ${tables.join(', ')}`);
   } else if (tables.length === 0) {
     die2(
       'no tables given. usage: npx tsx scripts/db/pre-flip-scan.ts [--json] [--flip-diff [--base <ref>]] <table>...',
@@ -271,6 +289,28 @@ async function main(): Promise<void> {
   }
   if (repo.filesScanned === 0) {
     die2(`the ${DATA_ROOTS.length} pinned data roots exist but contain ZERO matching files — nothing was searched.`);
+  }
+  // Per-ROOT, not just repo-wide. `scanDataFiles` pushes to missingRoots only when statSync().isDirectory()
+  // fails, so an existing-but-EMPTY root yields {present: true, files: 0} and trips neither guard above:
+  // the directory is there, and the other roots keep filesScanned comfortably non-zero. The reachable
+  // drift is scripts/parity converting its .ts files to .mjs (the house pattern for scripts) — the
+  // directory survives, that root drops to 0 files, and the scan silently stops searching the reader
+  // class whose entire rationale is that the parity harness reads and WRITES through raw SQL and so
+  // survives model deletion mechanically. Same vacuity as filesScanned === 0, one root at a time.
+  // KNOWN future trigger, called out so it is a one-line fix and not a mystery mid-runbook:
+  // `services/Tims.Platform/db` holds only ~7 consumable flip-DDL artifacts and is expected to be
+  // ARCHIVED once the flips finish. When that happens this guard fires, and exit 2 would block a
+  // production flip for a non-safety reason. The remedy is to DROP that root from DATA_ROOTS in the same
+  // PR that archives it — deliberately, so a shrinking search population is a reviewed decision rather
+  // than a silent one. That is the point of failing closed here instead of printing a warning nobody reads.
+  const emptyRoots = repo.perRoot.filter((r) => r.files === 0);
+  if (emptyRoots.length > 0) {
+    die2(
+      `pinned data root(s) present but EMPTY: ${emptyRoots.map((r) => r.path).join(', ')}. ` +
+        'That root contributed nothing to the search, so a "no hits" result does not cover it. ' +
+        'Fix the root, or update DATA_ROOTS/EXTS in scripts/db/pre-flip-repo-scan.mjs if the harness ' +
+        'legitimately changed shape.',
+    );
   }
 
   loadDbEnv();
@@ -611,6 +651,27 @@ async function main(): Promise<void> {
         .map((d) => d.what.replace(/^view\/rule /, ''))
         .filter((v) => v !== '?');
 
+      // Routines get a SECOND blocking oracle, for the same reason views do. The text arm reads
+      // prosrc || pg_get_function_sqlbody; this reads pg_depend. `pg_proc` stays in NAMED (so the print
+      // is unchanged) but its edge is no longer blocker-suppressed — see the blocker loop below.
+      //
+      // The two are DISJOINT by construction, not overlapping: a plpgsql or dollar-quoted `LANGUAGE sql`
+      // body records no pg_depend edge and is found only by text, while a SQL-standard body (BEGIN
+      // ATOMIC / RETURN) is found by both. That is exactly why they are unioned into `blockers` but
+      // deliberately NOT fed to `oracleSplits`: a routine split line would fire for every function ever
+      // found, in both directions, forever — and a check that cries wolf gets switched off.
+      //
+      // This also covers `proveArm`'s short-circuit: it returns proven on the FIRST re-findable sample,
+      // so only one of the two routine text sources is ever exercised, and a matcher regression that
+      // dropped pg_get_function_sqlbody would still report `population > 0, proven, 0 hits`. The naive
+      // fix (require one sample of each) is wrong — prod plausibly has zero prosqlbody routines, which
+      // would make the arm a permanent NOT EXERCISED, i.e. the vacuity this control exists to kill.
+      // A second independent oracle is the guard that does not have that failure mode.
+      const routinesByDepend = deps.rows
+        .filter((d) => d.cls === 'pg_proc')
+        .map((d) => d.what.replace(/^function /, ''))
+        .filter((f) => f !== '?');
+
       reports.push({
         table,
         exists: Boolean(row),
@@ -622,6 +683,7 @@ async function main(): Promise<void> {
         dependentViews: viewsByText,
         dependentViewsByDepend: [...new Set(viewsByDepend)].sort(),
         dependentRoutines: await routinesQuery(re),
+        dependentRoutinesByDepend: [...new Set(routinesByDepend)].sort(),
         triggers: trigs.rows.map((r) => r.name),
         namedDependents: deps.rows.filter((d) => NAMED.has(d.cls)).map((d) => d.what),
         otherDependents: deps.rows.filter((d) => !NAMED.has(d.cls)).map((d) => d.what),
@@ -663,6 +725,15 @@ async function main(): Promise<void> {
       blockers.push(`${r.table}: view/matview ${v} references it`);
     }
     for (const f of r.dependentRoutines) blockers.push(`${r.table}: function ${f} references it`);
+    // pg_proc's pg_depend edge, as a BLOCKER rather than the INFO line it used to be. Before this, the
+    // text arm was the ONLY blocking path for a routine: a SQL-standard-bodied function was found by
+    // pg_depend, printed under "pg_depend (named classes)", and the scan then exited 0 having NAMED the
+    // reader. The two oracles spell names differently on purpose — `public.foo` from the text arm,
+    // `foo(uuid)` (argument-typed) from regprocedure — so one function can produce two blocker lines.
+    // That is accepted: over-reporting a blocker is safe, under-reporting is the defect being fixed.
+    for (const f of r.dependentRoutinesByDepend) {
+      blockers.push(`${r.table}: function ${f} references it (pg_depend)`);
+    }
     for (const t of r.triggers) blockers.push(`${r.table}: trigger ${t}`);
     for (const d of r.otherDependents) blockers.push(`${r.table}: pg_depend dependent ${d}`);
   }
@@ -685,7 +756,7 @@ async function main(): Promise<void> {
   }
 
   if (asJson) {
-    console.log(
+    out(
       JSON.stringify(
         {
           tables,
@@ -708,16 +779,16 @@ async function main(): Promise<void> {
   if (blockers.length === 0) {
     if (!asJson) {
       const unexercised = arms.filter((a) => a.population === 0);
-      console.log(`\n✓ No blocker for ${tables.join(', ')}.`);
+      out(`\n✓ No blocker for ${tables.join(', ')}.`);
       if (unexercised.length > 0) {
-        console.log(
+        out(
           `  ⚠ ${unexercised.length} arm(s) searched an EMPTY population and therefore proved nothing on ` +
             `their own: ${unexercised.map((a) => `${a.key} (0 ${a.populationLabel})`).join('; ')}.\n` +
             `    That is a statement about the database, not about these tables — say so in the PR body ` +
             'rather than reporting a clean scan.',
         );
       }
-      console.log(
+      out(
         '  Reported INFO items still belong in the flip PR body — notably app_tenant grants (#126, dead\n' +
           '  DML after the flip), any inbound FK from outside the flip set, and every data-file reference.\n',
       );
@@ -781,56 +852,57 @@ function printHuman(
   flipSet: Set<string>,
   oracleSplits: string[],
 ): void {
-  console.log(
+  out(
     `\nschema census (public): ${census.tables} tables, ${census.views} views, ${census.matviews} matviews, ` +
       `${census.foreignTables} foreign tables`,
   );
-  console.log('\npopulation each arm searched — a hit count is meaningless without it:');
+  out('\npopulation each arm searched — a hit count is meaningless without it:');
   for (const a of arms) {
-    console.log(`  ${a.key.padEnd(10)} ${String(a.population).padStart(5)} ${a.populationLabel.padEnd(58)} ${a.note}`);
+    out(`  ${a.key.padEnd(10)} ${String(a.population).padStart(5)} ${a.populationLabel.padEnd(58)} ${a.note}`);
   }
-  console.log(
+  out(
     `  ${'datafiles'.padEnd(10)} ${String(repo.filesScanned).padStart(5)} files across ${repo.perRoot.length} pinned roots` +
       `${' '.repeat(30)}${repo.perRoot.map((r) => `${r.path}=${r.files}`).join(' ')}`,
   );
 
   for (const r of reports) {
-    console.log(`\n── ${r.table} ──────────────────────────────────────────────`);
+    out(`\n── ${r.table} ──────────────────────────────────────────────`);
     if (!r.exists) {
-      console.log('  ⚠ DOES NOT EXIST in public — check the name before flipping.');
+      out('  ⚠ DOES NOT EXIST in public — check the name before flipping.');
     } else {
-      console.log(
+      out(
         `  exists   yes (relkind ${r.relkind})   RLS ${r.rlsEnabled ? 'enabled' : 'DISABLED'}` +
           `${r.rlsForced ? ' + forced' : ''}, ${r.policies.length} policy(ies)` +
           `${r.policies.length ? ' [' + r.policies.join(', ') + ']' : ''}, ${r.bytes ?? '?'} bytes`,
       );
-      console.log(`  app_tenant                      ${r.appTenantPrivs.join(',') || '(none)'}`);
+      out(`  app_tenant                      ${r.appTenantPrivs.join(',') || '(none)'}`);
     }
-    console.log(`  views/matviews (text matcher)   ${r.dependentViews.join(', ') || 'none'}`);
-    console.log(`  views/matviews (pg_depend)      ${r.dependentViewsByDepend.join(', ') || 'none'}`);
-    console.log(`  functions referencing it        ${r.dependentRoutines.join(', ') || 'none'}`);
-    console.log(`  triggers on it                  ${r.triggers.join(', ') || 'none'}`);
-    console.log(`  policies elsewhere referencing  ${r.policiesReferencing.join(', ') || 'none'}`);
+    out(`  views/matviews (text matcher)   ${r.dependentViews.join(', ') || 'none'}`);
+    out(`  views/matviews (pg_depend)      ${r.dependentViewsByDepend.join(', ') || 'none'}`);
+    out(`  functions (text matcher)        ${r.dependentRoutines.join(', ') || 'none'}`);
+    out(`  functions (pg_depend)           ${r.dependentRoutinesByDepend.join(', ') || 'none'}`);
+    out(`  triggers on it                  ${r.triggers.join(', ') || 'none'}`);
+    out(`  policies elsewhere referencing  ${r.policiesReferencing.join(', ') || 'none'}`);
     const foreignFks = r.inboundFks.filter((f) => !flipSet.has(f.split('.')[0]));
-    console.log(
+    out(
       `  inbound FKs                     ${r.inboundFks.join(', ') || 'none'}` +
         (foreignFks.length ? `  ← ${foreignFks.length} from OUTSIDE the flip set` : ''),
     );
-    console.log(`  pg_depend (named classes)       ${r.namedDependents.join(', ') || 'none'}`);
-    console.log(`  pg_depend (OTHER)               ${r.otherDependents.join(', ') || 'none'}`);
+    out(`  pg_depend (named classes)       ${r.namedDependents.join(', ') || 'none'}`);
+    out(`  pg_depend (OTHER)               ${r.otherDependents.join(', ') || 'none'}`);
   }
 
   if (oracleSplits.length > 0) {
-    console.log('\n⚠ the two view oracles do not agree — read each one before believing either:');
-    for (const s of oracleSplits) console.log(`    ${s}`);
+    out('\n⚠ the two view oracles do not agree — read each one before believing either:');
+    for (const s of oracleSplits) out(`    ${s}`);
   }
 
-  console.log('\n── data files ──────────────────────────────────────────────');
+  out('\n── data files ──────────────────────────────────────────────');
   if (repo.hits.length === 0) {
-    console.log(`  no reference to ${tables.join(', ')} in ${repo.filesScanned} files across the pinned roots`);
+    out(`  no reference to ${tables.join(', ')} in ${repo.filesScanned} files across the pinned roots`);
   }
   for (const h of repo.hits) {
-    console.log(`  ${h.kind === 'blocker' ? 'BLOCK' : 'info '} ${h.file}:${h.line}  ${h.variant}  ${h.text}`);
+    out(`  ${h.kind === 'blocker' ? 'BLOCK' : 'info '} ${h.file}:${h.line}  ${h.variant}  ${h.text}`);
   }
 }
 

--- a/scripts/db/pre-flip-scan.ts
+++ b/scripts/db/pre-flip-scan.ts
@@ -1,43 +1,108 @@
 #!/usr/bin/env npx tsx
 /**
- * Pre-flip DATABASE-SIDE dependency scan — issue #132, for the ownership-flip runbook §5.
+ * Pre-flip dependency scan — issue #132, the ownership-flip runbook's §5 step 5b control.
  *
  * WHY THIS EXISTS
  * ---------------
- * The runbook's P2 reader sweep is six `grep` strategies over the repo. All six share one blind spot:
- * a dependency that lives in the DATABASE rather than in a file. A view, a materialized view or a
- * `plpgsql` function over the table being flipped is a real reader that is invisible to
+ * The runbook's P2 reader sweep is six `grep` strategies over the repo. They share two blind spots:
  *
- *   * `tsc`                     — it is not TypeScript,
- *   * `scripts/table-ownership.mjs` — that only greps `@@map` / `ToTable`,
- *   * every P2 grep             — the object is not in the repo at all.
+ *   1. DATA-DRIVEN readers. All six are `.ts`-scoped, and `tsc` cannot see a model name inside a JSON
+ *      file. Flip #2 removed two entities from `ScopedEntity`, got a GREEN `tsc`, and broke
+ *      `contracts/access-fixtures/scope-where.json` — a CROSS-STACK contract that also pins the C#
+ *      port. Handled by `./pre-flip-repo-scan.mjs`, which is unit-tested for real.
+ *   2. DATABASE-SIDE readers. A view, matview, function, trigger or policy over the table is a raw-SQL
+ *      reader that is invisible to `tsc`, to `scripts/table-ownership.mjs` (it only greps `@@map` /
+ *      `ToTable`), and to every P2 grep — because the object is not in the repo at all. #111 is the
+ *      standing proof that production contains objects no repo file describes.
  *
- * #111 is the standing proof that production contains objects no repo file describes, so "we would have
- * noticed" is not an argument. Flip #2 (#69) ran these queries by hand, one at a time, and came back
- * clean — this script exists so the next flip runs one command instead of remembering four, and so a
- * non-clean result is impossible to skim past.
+ * WHY EVERY ARM CARRIES A NON-VACUITY CONTROL
+ * -------------------------------------------
+ * On 2026-08-05 the equivalent queries were run against production by hand and returned EMPTY for the
+ * calibration tables. An empty result is indistinguishable from a query that examined nothing, and one
+ * of the arms had in fact examined nothing worth the name: the view/matview arm returned 0 across the
+ * whole `public` schema, which proves nothing on its own, because `public` contains 119 ordinary tables
+ * and ZERO views, matviews or foreign tables. It took a separate census to learn that its 0 was
+ * correct-but-untested. Checks 14, 16 and 17 each shipped with exactly this defect and each had to be
+ * fixed afterwards.
+ *
+ * So every arm here reports the POPULATION it searched, and every text-matching arm proves its matcher
+ * end-to-end before its result is believed:
+ *
+ *   population unknown / query threw → exit 2. Never a pass.
+ *   population > 0, matcher unproven → exit 2. A matcher that finds nothing when pointed at a row it
+ *                                      MUST match makes every clean result from that arm worthless.
+ *   population = 0                   → reported as NOT EXERCISED, loudly, in the summary and the JSON.
+ *
+ * And the run as a whole is fingerprinted against the Prisma schema, so an empty or wrong database
+ * cannot produce a tick: against an EMPTY database this exits 2, not 0.
+ *
+ * TWO INDEPENDENT VIEW ORACLES, AND WHY NEITHER IS ENOUGH ALONE
+ * -------------------------------------------------------------
+ * Views are found BOTH by matching the table name in `pg_get_viewdef` AND through `pg_depend`. The two
+ * are not redundant, and neither subsumes the other — measured on a throwaway PostgreSQL 17.10 cluster:
+ *
+ *   - `pg_depend` is authoritative for views and matviews but records NOTHING for a `plpgsql` function
+ *     body. A `plpgsql` function whose body reads the table produced exactly 0 `pg_proc` rows in
+ *     `pg_depend`, so the FUNCTION arm can only ever be a text match.
+ *   - The text arm cannot see a dependency that renders no table name, and `pg_get_viewdef` is not the
+ *     only way a relation can depend on a table.
+ *
+ * So both run, both are printed separately, blockers are their union, and a disagreement is reported.
+ * `pg_depend` is filtered to `deptype = 'n'` — the explicit "this object needs that one" edge. The
+ * table's OWN internals (its indexes, constraints, defaults, extended statistics, triggers) come back as
+ * `'a'`/`'i'` and would be pure noise; that classification was checked against the catalog, not assumed.
  *
  * WHAT IT CHECKS, per table
- *   1. BLOCKER  views / matviews whose definition references the table
- *   2. BLOCKER  functions whose body references the table
- *   3. INFO     RLS policies on OTHER tables that reference this one (runbook §3(f) pre-REVOKE scan)
- *   4. INFO     inbound foreign keys (a FK from outside the flip set means the flip is not self-contained)
- *   5. INFO     app_tenant grants (#126 — dead DML after the flip)
- *   6. INFO     existence, RLS enabled/forced, policy count, size
+ *   BLOCKER  views / matviews referencing the table, by text AND by `pg_depend`
+ *   BLOCKER  functions whose body references the table
+ *   BLOCKER  triggers on the table
+ *   BLOCKER  any other `pg_depend` dependent — the classes above are named and reported as such, so
+ *            this bucket is whatever this script does not model, which is exactly the case for a human
+ *   BLOCKER  data-file readers under `contracts/access-fixtures/` and `packages/db/prisma/seed*.ts`
+ *   INFO     RLS policies on OTHER tables referencing it (runbook §3(f) pre-REVOKE scan)
+ *   INFO     inbound foreign keys (one from outside the flip set means the flip is not self-contained)
+ *   INFO     `app_tenant` grants (#126 — dead DML after the flip)
+ *   INFO     every other data-file reference, for the PR body
+ *   INFO     existence, relkind, RLS enabled/forced, policy count, size
  *
- * BLOCKER vs INFO: a view or function must be dispositioned BEFORE the model is deleted, because
- * deleting the model does not break them — they keep working against the table and keep bypassing
- * whatever scoping the TS stack used to apply. Everything else is reported for the PR body.
+ * BLOCKER vs INFO: a database object or a fixture over the table must be dispositioned BEFORE the model
+ * is deleted, because deleting the model does not break it — it keeps working, and keeps bypassing
+ * whatever scoping the TS stack used to apply.
  *
  * USAGE
  *   npx tsx scripts/db/pre-flip-scan.ts critical_roles successors
  *   npx tsx scripts/db/pre-flip-scan.ts --json surveys survey_responses
+ *   npx tsx scripts/db/pre-flip-scan.ts --flip-diff            # tables this branch moves into efcore[]
+ *   npx tsx scripts/db/pre-flip-scan.ts --flip-diff --base origin/main
  *
- * Exits 0 if no BLOCKER found, 1 if any BLOCKER found, and 1 if it cannot run (fail closed — an
- * unrunnable scan is not a clean scan). Read-only: every statement is a SELECT, safe against production.
+ * EXIT CODES — the contract shared with `/gate` checks 14, 16 and 17
+ *   0  ran, and found no blocker
+ *   1  ran, and found a blocker
+ *   2  COULD NOT RUN — no connection URL; a pinned data root missing; the Prisma schema parsed to zero
+ *      tables; the target database does not look like ours; an arm's population unknown or its matcher
+ *      unproven; or any query threw. Exit 2 is NOT a pass and must be reported ⚠️ NOT RUN.
+ *
+ * Read-only: every statement is a SELECT, safe against production.
  */
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeSync } from 'node:fs';
 import { Client } from 'pg';
+import { parseLedger, parsePrismaTables } from '../table-ownership.mjs';
+import { DATA_ROOTS, scanDataFiles } from './pre-flip-repo-scan.mjs';
+
+const LEDGER_REL = 'docs/architecture/table-ownership.md';
+const PRISMA_SCHEMA_REL = 'packages/db/prisma/schema';
+
+/**
+ * Exit 2 — could not run. Written with `writeSync(2, …)` rather than `console.error` because Node's
+ * stderr is ASYNC when it is a pipe and `process.exit()` does not flush pending writes: the one thing
+ * exit 2 exists to communicate is WHY nothing was verified, and every automated caller pipes stderr.
+ * Copied deliberately from `verify-tenant-grants.ts`, which learned it the same way.
+ */
+function die2(reason: string): never {
+  writeSync(2, `⚠ PRE-FLIP SCAN DID NOT RUN — ${reason}\n  This is exit 2, not a pass. Nothing was scanned.\n`);
+  process.exit(2);
+}
 
 function loadDbEnv(): void {
   if (process.env.DIRECT_URL || process.env.DATABASE_URL) return;
@@ -54,128 +119,496 @@ function loadDbEnv(): void {
   }
 }
 
-interface Report {
+/**
+ * `\y` is Postgres's word boundary. Do NOT "modernise" it to `\b`: in a Postgres advanced regular
+ * expression `\b` is a BACKSPACE, not a boundary. Measured on PG 17.10 — both
+ * `'critical_roles_pkey' ~* '\bcritical_roles\b'` and `'x critical_roles y' ~* '\bcritical_roles\b'`
+ * return false, so a `\b` matcher finds NOTHING and every scan comes back clean. That is the exact shape
+ * of failure this whole rewrite exists to make impossible, and it is why the arms carry matcher proofs.
+ */
+const wordRe = (t: string): string => `\\y${t.replace(/([\\^$.|?*+()[\]{}])/g, '\\$1')}\\y`;
+
+/** An identifier that must not exist, used to disable the "exclude the table itself" clause in a self-test. */
+const SENTINEL_TABLE = '__preflip_sentinel_no_such_table__';
+
+interface Arm {
+  key: string;
+  label: string;
+  /** How many candidate objects the arm's own predicate could have matched. */
+  population: number;
+  /** What the population counts, in words — printed so "0 hits" is never read as "0 out of 0". */
+  populationLabel: string;
+  /** Whether the arm's matcher was demonstrated against a row it MUST match. */
+  proven: boolean;
+  /** Why it is unproven, when it is. */
+  note: string;
+}
+
+interface TableReport {
   table: string;
   exists: boolean;
+  relkind: string | null;
   rlsEnabled: boolean;
   rlsForced: boolean;
   policies: string[];
   bytes: number | null;
+  /** Views found by matching the table name in `pg_get_viewdef`. */
   dependentViews: string[];
+  /** Views found through `pg_depend` — text-free, authoritative, and an independent oracle. */
+  dependentViewsByDepend: string[];
   dependentRoutines: string[];
+  triggers: string[];
+  otherDependents: string[];
+  namedDependents: string[];
   policiesReferencing: string[];
   inboundFks: string[];
   appTenantPrivs: string[];
 }
 
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Table selection
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `--flip-diff`: the tables this working tree moves INTO the ledger's `efcore[]` relative to `base`.
+ *
+ * This is what makes the scan wireable as a `/gate` row: a gate cannot hard-code table names, and a
+ * per-flip control nobody remembers to run is the state #132 was filed about. On a branch that flips
+ * nothing it scans nothing and says so — while still reporting the population it compared, so "no
+ * tables" is a stated finding rather than an empty result.
+ */
+function tablesFromLedgerDiff(base: string): { tables: string[]; headCount: number; baseCount: number } {
+  let headLedger: { efcore: string[] };
+  try {
+    headLedger = parseLedger(readFileSync(LEDGER_REL, 'utf8')) as { efcore: string[] };
+  } catch (e) {
+    die2(`could not parse ${LEDGER_REL} in the working tree (${e instanceof Error ? e.message : e}).`);
+  }
+
+  let baseText: string;
+  try {
+    baseText = execFileSync('git', ['show', `${base}:${LEDGER_REL}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    die2(
+      `could not read ${LEDGER_REL} at \`${base}\` (${e instanceof Error ? e.message : e}). ` +
+        'Run `git fetch origin`, or pass --base <ref>. Without both sides of the diff there is no way to ' +
+        'know which tables this branch flips, and guessing "none" would be a silent pass.',
+    );
+  }
+  let baseLedger: { efcore: string[] };
+  try {
+    baseLedger = parseLedger(baseText) as { efcore: string[] };
+  } catch (e) {
+    die2(`could not parse ${LEDGER_REL} at \`${base}\` (${e instanceof Error ? e.message : e}).`);
+  }
+
+  // Non-vacuity: an empty efcore[] on either side means the ledger did not parse the way we think it
+  // did, and every table would then look either newly-flipped or not-flipped for the wrong reason.
+  if (headLedger.efcore.length === 0) die2(`${LEDGER_REL} in the working tree lists ZERO efcore[] tables.`);
+  if (baseLedger.efcore.length === 0) die2(`${LEDGER_REL} at \`${base}\` lists ZERO efcore[] tables.`);
+
+  const before = new Set(baseLedger.efcore);
+  return {
+    tables: headLedger.efcore.filter((t) => !before.has(t)).sort(),
+    headCount: headLedger.efcore.length,
+    baseCount: baseLedger.efcore.length,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const asJson = args.includes('--json');
-  const tables = args.filter((a) => !a.startsWith('--'));
-  if (tables.length === 0) {
-    console.error('usage: npx tsx scripts/db/pre-flip-scan.ts [--json] <table>...');
-    process.exit(1);
+  const argv = process.argv.slice(2);
+  const asJson = argv.includes('--json');
+  const flipDiff = argv.includes('--flip-diff');
+  const baseIdx = argv.indexOf('--base');
+  const base = baseIdx >= 0 ? argv[baseIdx + 1] : 'origin/main';
+  if (baseIdx >= 0 && !base) die2('--base was given without a ref.');
+  const positional = argv.filter((a, i) => !a.startsWith('--') && !(baseIdx >= 0 && i === baseIdx + 1));
+
+  let tables = positional;
+  let diffNote = '';
+  if (flipDiff) {
+    if (positional.length > 0) {
+      die2('--flip-diff derives the table list from the ledger; do not also pass table names.');
+    }
+    const d = tablesFromLedgerDiff(base);
+    tables = d.tables;
+    diffNote =
+      `ledger diff vs \`${base}\`: ${d.baseCount} efcore[] tables there, ${d.headCount} here, ` +
+      `${d.tables.length} newly efcore-owned`;
+    if (tables.length === 0) {
+      // A real, stated finding — with its population — not an empty result dressed up as a pass.
+      const line = `✓ pre-flip scan: no ownership flip in this diff (${diffNote}). Nothing to scan.`;
+      console.log(asJson ? JSON.stringify({ flipDiff: true, tables: [], note: diffNote }, null, 2) : line);
+      process.exit(0);
+    }
+    // Say what was derived BEFORE anything can fail. If this only printed in the final report, then a
+    // credentials problem — the most likely failure — would leave nobody able to tell "the diff found
+    // nothing" from "the diff found something and we never got to it". They are opposite situations.
+    if (!asJson) console.log(`\n${diffNote}: ${tables.join(', ')}`);
+  } else if (tables.length === 0) {
+    die2(
+      'no tables given. usage: npx tsx scripts/db/pre-flip-scan.ts [--json] [--flip-diff [--base <ref>]] <table>...',
+    );
+  }
+
+  // ── Arm 0: the repo's data files. Runs first because it needs no database, so a credentials problem
+  //    cannot hide a fixture break that is visible from the working tree alone.
+  const repo = scanDataFiles(tables, process.cwd());
+  if (repo.missingRoots.length > 0) {
+    die2(
+      `pinned data root(s) missing from the working tree: ${repo.missingRoots.join(', ')}. ` +
+        'The data-driven arm would have searched a smaller population and still reported "no hits" — ' +
+        'which is the vacuous pass this scan exists to make impossible. Run from the repo root, or fix ' +
+        'DATA_ROOTS in scripts/db/pre-flip-repo-scan.mjs if a directory really was renamed.',
+    );
+  }
+  if (repo.filesScanned === 0) {
+    die2(`the ${DATA_ROOTS.length} pinned data roots exist but contain ZERO matching files — nothing was searched.`);
   }
 
   loadDbEnv();
   const url = process.env.DIRECT_URL || process.env.DATABASE_URL;
   if (!url) {
-    console.error('✖ pre-flip-scan: no DIRECT_URL or DATABASE_URL — scan DID NOT RUN (not a clean scan).');
-    process.exit(1);
+    die2('no DIRECT_URL or DATABASE_URL in the environment or packages/db/.env.');
   }
 
-  // \y is a Postgres word boundary; without it `successors` would also match inside other identifiers.
-  const wordRe = (t: string) => `\\y${t}\\y`;
+  // The Prisma schema is this database's fingerprint: it is how we tell "our application's database"
+  // from an empty one, a restored copy, or a sibling in the same cluster. Same guard, and the same
+  // reason, as verify-tenant-grants.ts (#124).
+  let prismaTables: string[];
+  try {
+    prismaTables = [...parsePrismaTables(PRISMA_SCHEMA_REL)];
+  } catch (e) {
+    die2(`could not read ${PRISMA_SCHEMA_REL} (${e instanceof Error ? e.message : e}) — run from the repo root.`);
+  }
+  if (prismaTables.length === 0)
+    die2(`parsed ZERO tables from ${PRISMA_SCHEMA_REL} — refusing to fingerprint against nothing.`);
+
   const db = new Client({ connectionString: url });
-  const reports: Report[] = [];
+  const arms: Arm[] = [];
+  const reports: TableReport[] = [];
+  let census = { tables: 0, views: 0, matviews: 0, foreignTables: 0 };
 
   try {
     await db.connect();
+
+    // ── Census + wrong-database guard ────────────────────────────────────────────────────────────
+    const censusRow = await db.query<{ tables: string; views: string; matviews: string; foreign_tables: string }>(
+      `SELECT count(*) FILTER (WHERE c.relkind IN ('r','p'))::text AS tables,
+              count(*) FILTER (WHERE c.relkind = 'v')::text        AS views,
+              count(*) FILTER (WHERE c.relkind = 'm')::text        AS matviews,
+              count(*) FILTER (WHERE c.relkind = 'f')::text        AS foreign_tables
+         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'`,
+    );
+    census = {
+      tables: Number(censusRow.rows[0]?.tables ?? 0),
+      views: Number(censusRow.rows[0]?.views ?? 0),
+      matviews: Number(censusRow.rows[0]?.matviews ?? 0),
+      foreignTables: Number(censusRow.rows[0]?.foreign_tables ?? 0),
+    };
+
+    const presentRow = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind IN ('r','p') AND c.relname = ANY($1::text[])`,
+      [prismaTables],
+    );
+    const present = Number(presentRow.rows[0]?.n ?? 0);
+    if (present * 2 < prismaTables.length) {
+      die2(
+        `only ${present} of the ${prismaTables.length} tables declared by the Prisma schema exist in this ` +
+          `database (public holds ${census.tables} ordinary tables in total). This is an empty database, a ` +
+          'restored copy or the wrong target — a clean scan against it would certify nothing. Check which ' +
+          'database DIRECT_URL/DATABASE_URL points at.',
+      );
+    }
+
+    // ── Arm populations + matcher proofs, once per database ──────────────────────────────────────
+    // Every text-matching arm is proved by taking a row it MUST match, extracting a word from the very
+    // text the arm searches, and re-running the ARM'S OWN query with that word. That catches a wrong
+    // schema filter, a wrong column, a regex the server rejects, and permission-filtered rows — none of
+    // which a source-code review of the SQL reliably catches, and all of which look like "clean".
+    const scopedSchemas = `n.nspname NOT IN ('pg_catalog','information_schema')`;
+
+    const viewsQuery = async (re: string): Promise<string[]> => {
+      const r = await db.query<{ name: string }>(
+        `SELECT n.nspname||'.'||c.relname AS name
+           FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relkind IN ('v','m') AND ${scopedSchemas} AND pg_get_viewdef(c.oid) ~* $1
+          ORDER BY 1`,
+        [re],
+      );
+      return r.rows.map((x) => x.name);
+    };
+    const viewPop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('v','m') AND ${scopedSchemas}`,
+    );
+    const viewSamples = await db.query<{ name: string; text: string }>(
+      `SELECT n.nspname||'.'||c.relname AS name, pg_get_viewdef(c.oid) AS text
+         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('v','m') AND ${scopedSchemas}
+        ORDER BY c.oid LIMIT 5`,
+    );
+    arms.push(
+      await proveArm(
+        'views',
+        'views/matviews referencing it',
+        Number(viewPop.rows[0].n),
+        'views + matviews outside pg_catalog/information_schema',
+        viewSamples.rows,
+        viewsQuery,
+      ),
+    );
+
+    const routinesQuery = async (re: string): Promise<string[]> => {
+      const r = await db.query<{ name: string }>(
+        `SELECT n.nspname||'.'||p.proname AS name
+           FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE ${scopedSchemas} AND p.prosrc ~* $1
+          ORDER BY 1`,
+        [re],
+      );
+      return r.rows.map((x) => x.name);
+    };
+    const routinePop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE ${scopedSchemas} AND p.prosrc IS NOT NULL AND p.prosrc <> ''`,
+    );
+    const routineSamples = await db.query<{ name: string; text: string }>(
+      `SELECT n.nspname||'.'||p.proname AS name, p.prosrc AS text
+         FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE ${scopedSchemas} AND length(p.prosrc) > 3
+        ORDER BY p.oid LIMIT 8`,
+    );
+    arms.push(
+      await proveArm(
+        'functions',
+        'functions referencing it',
+        Number(routinePop.rows[0].n),
+        'functions with a body outside pg_catalog/information_schema',
+        routineSamples.rows,
+        routinesQuery,
+      ),
+    );
+
+    // §3(f): a policy on ANOTHER table whose USING/WITH CHECK references this one. Such a policy is
+    // evaluated AS THE QUERYING ROLE, so it depends on the table staying readable by that role — it must
+    // be dispositioned before revoking anything (#126) and before the flip.
+    const policiesQuery = async (re: string, exclude = SENTINEL_TABLE): Promise<string[]> => {
+      const r = await db.query<{ name: string }>(
+        `SELECT n.nspname||'.'||c.relname||'.'||p.polname AS name
+           FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE ${scopedSchemas}
+            AND (coalesce(pg_get_expr(p.polqual, p.polrelid), '') ~* $1
+              OR coalesce(pg_get_expr(p.polwithcheck, p.polrelid), '') ~* $1)
+            AND c.relname <> $2
+          ORDER BY 1`,
+        [re, exclude],
+      );
+      return r.rows.map((x) => x.name);
+    };
+    const policyPop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE ${scopedSchemas} AND (p.polqual IS NOT NULL OR p.polwithcheck IS NOT NULL)`,
+    );
+    const policySamples = await db.query<{ name: string; text: string }>(
+      `SELECT n.nspname||'.'||c.relname||'.'||p.polname AS name,
+              coalesce(pg_get_expr(p.polqual, p.polrelid), '') || ' ' ||
+              coalesce(pg_get_expr(p.polwithcheck, p.polrelid), '') AS text
+         FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE ${scopedSchemas} AND (p.polqual IS NOT NULL OR p.polwithcheck IS NOT NULL)
+        ORDER BY p.oid LIMIT 5`,
+    );
+    arms.push(
+      await proveArm(
+        'policies',
+        'policies elsewhere referencing it',
+        Number(policyPop.rows[0].n),
+        'policies carrying a USING or WITH CHECK expression',
+        policySamples.rows,
+        (re) => policiesQuery(re),
+      ),
+    );
+
+    // The FK, trigger and pg_depend arms resolve the table by OID, so they match no text and need no
+    // matcher proof — but they still report their population, because "0 inbound FKs" in a database
+    // with no foreign keys at all is not the same statement as "0 inbound FKs" in ours.
+    const fkPop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_constraint con JOIN pg_class c ON c.oid = con.conrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE con.contype = 'f' AND n.nspname = 'public'`,
+    );
+    arms.push({
+      key: 'fks',
+      label: 'inbound foreign keys',
+      population: Number(fkPop.rows[0].n),
+      populationLabel: 'foreign-key constraints in public',
+      proven: true,
+      note: 'resolved by OID — no text matching',
+    });
+
+    const trigPop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE NOT t.tgisinternal AND n.nspname = 'public'`,
+    );
+    arms.push({
+      key: 'triggers',
+      label: 'triggers on it',
+      population: Number(trigPop.rows[0].n),
+      populationLabel: 'user triggers in public',
+      proven: true,
+      note: 'resolved by OID — no text matching',
+    });
+
+    const dependPop = await db.query<{ n: string }>(
+      `SELECT count(DISTINCT d.refobjid)::text AS n FROM pg_depend d
+         JOIN pg_class c ON c.oid = d.refobjid JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE d.refclassid = 'pg_class'::regclass AND d.deptype = 'n' AND n.nspname = 'public'`,
+    );
+    arms.push({
+      key: 'depend',
+      label: 'pg_depend dependents',
+      population: Number(dependPop.rows[0].n),
+      populationLabel: 'public relations carrying at least one normal dependency',
+      proven: true,
+      note: 'resolved by OID — no text matching',
+    });
+
+    const grantPop = await db.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM information_schema.role_table_grants
+        WHERE table_schema = 'public' AND grantee = 'app_tenant'`,
+    );
+    arms.push({
+      key: 'grants',
+      label: 'app_tenant grants',
+      population: Number(grantPop.rows[0].n),
+      populationLabel: 'app_tenant grants in public',
+      proven: true,
+      note: 'exact grantee match — no text matching',
+    });
+
+    // ── Per-table scan ──────────────────────────────────────────────────────────────────────────
     for (const table of tables) {
       const re = wordRe(table);
 
       const meta = await db.query<{
-        exists: boolean;
+        oid: string;
+        relkind: string;
         rls_enabled: boolean;
         rls_forced: boolean;
         bytes: string | null;
       }>(
-        `SELECT to_regclass(format('public.%I', $1)) IS NOT NULL AS exists,
+        // Matched on `relname` exactly rather than through `to_regclass('public.'||$1)`, which folds an
+        // unquoted name to lower case and so reported `__EFMigrationsHistory` as non-existent.
+        `SELECT c.oid::text AS oid, c.relkind::text AS relkind,
                 coalesce(c.relrowsecurity,false)      AS rls_enabled,
                 coalesce(c.relforcerowsecurity,false) AS rls_forced,
-                pg_relation_size(c.oid)               AS bytes
-           FROM pg_namespace n LEFT JOIN pg_class c ON c.relname=$1 AND c.relnamespace=n.oid
-          WHERE n.nspname='public'`,
+                pg_relation_size(c.oid)::text         AS bytes
+           FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public' AND c.relname = $1`,
         [table],
       );
+      const row = meta.rows[0];
+      const oid = row ? Number(row.oid) : null;
 
-      const own = await db.query<{ polname: string }>(
-        `SELECT p.polname FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid
-           JOIN pg_namespace n ON n.oid=c.relnamespace
-          WHERE n.nspname='public' AND c.relname=$1 ORDER BY 1`,
-        [table],
-      );
+      const own = row
+        ? await db.query<{ polname: string }>(`SELECT p.polname FROM pg_policy p WHERE p.polrelid = $1 ORDER BY 1`, [
+            oid,
+          ])
+        : { rows: [] as { polname: string }[] };
 
-      const views = await db.query<{ name: string }>(
-        `SELECT n.nspname||'.'||c.relname AS name
-           FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
-          WHERE c.relkind IN ('v','m') AND pg_get_viewdef(c.oid) ~* $1 ORDER BY 1`,
-        [re],
-      );
+      const fks = row
+        ? await db.query<{ name: string }>(
+            // pg_constraint is OID-based, so the phantom-FK class that `information_schema` produces
+            // (constraint_name is NOT unique across schemas) cannot arise here at all.
+            `SELECT src.relname||'.'||att.attname||' ('||con.conname||')' AS name
+               FROM pg_constraint con
+               JOIN pg_class src ON src.oid = con.conrelid
+               JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON true
+               JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+              WHERE con.contype = 'f' AND con.confrelid = $1
+              ORDER BY 1`,
+            [oid],
+          )
+        : { rows: [] as { name: string }[] };
 
-      const routines = await db.query<{ name: string }>(
-        `SELECT n.nspname||'.'||p.proname AS name
-           FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
-          WHERE n.nspname NOT IN ('pg_catalog','information_schema')
-            AND p.prosrc ~* $1 ORDER BY 1`,
-        [re],
-      );
+      const trigs = row
+        ? await db.query<{ name: string }>(
+            `SELECT t.tgname||' → '||p.proname AS name FROM pg_trigger t JOIN pg_proc p ON p.oid = t.tgfoid
+              WHERE t.tgrelid = $1 AND NOT t.tgisinternal ORDER BY 1`,
+            [oid],
+          )
+        : { rows: [] as { name: string }[] };
 
-      // §3(f): a policy on ANOTHER table whose USING/WITH CHECK references this one. Such a policy
-      // depends on the table remaining readable by whatever role evaluates it — so it must be
-      // dispositioned before revoking anything (#126) and before the flip.
-      const refPolicies = await db.query<{ name: string }>(
-        `SELECT c.relname||'.'||p.polname AS name
-           FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid
-          WHERE (coalesce(pg_get_expr(p.polqual,p.polrelid),'') ~* $1
-              OR coalesce(pg_get_expr(p.polwithcheck,p.polrelid),'') ~* $1)
-            AND c.relname <> $2
-          ORDER BY 1`,
-        [re, table],
-      );
-
-      const fks = await db.query<{ name: string }>(
-        `SELECT tc.table_name||'.'||kcu.column_name AS name
-           FROM information_schema.table_constraints tc
-           JOIN information_schema.key_column_usage kcu       ON tc.constraint_name=kcu.constraint_name
-           JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name=ccu.constraint_name
-          WHERE tc.constraint_type='FOREIGN KEY' AND tc.table_schema='public'
-            AND ccu.table_name=$1
-            -- constraint_name is NOT globally unique across schemas, so join on the schema too or a
-            -- same-named constraint elsewhere produces a phantom inbound FK.
-            AND kcu.constraint_schema = tc.constraint_schema
-            AND ccu.constraint_schema = tc.constraint_schema
-          ORDER BY 1`,
-        [table],
-      );
+      // pg_depend, GENERALLY — not just pg_rewrite. A column default, a generated column, an expression
+      // index or an extension member can depend on a table without any view or function existing.
+      // deptype 'n' is the explicit "this object needs that one" edge; 'a'/'i' are the table's own
+      // internals (its indexes, its constraints, its own policies) and would be pure noise.
+      const deps = row
+        ? await db.query<{ cls: string; what: string }>(
+            `SELECT DISTINCT d.classid::regclass::text AS cls,
+                    CASE d.classid
+                      WHEN 'pg_rewrite'::regclass    THEN 'view/rule '   || coalesce((SELECT vn.nspname||'.'||vc.relname FROM pg_rewrite r JOIN pg_class vc ON vc.oid = r.ev_class JOIN pg_namespace vn ON vn.oid = vc.relnamespace WHERE r.oid = d.objid), '?')
+                      WHEN 'pg_proc'::regclass       THEN 'function '    || coalesce(d.objid::regprocedure::text, '?')
+                      WHEN 'pg_trigger'::regclass    THEN 'trigger '     || coalesce((SELECT t.tgname||' on '||tc.relname FROM pg_trigger t JOIN pg_class tc ON tc.oid = t.tgrelid WHERE t.oid = d.objid), '?')
+                      WHEN 'pg_constraint'::regclass THEN 'constraint '  || coalesce((SELECT cn.conname||' on '||coalesce(cc.relname,'-') FROM pg_constraint cn LEFT JOIN pg_class cc ON cc.oid = cn.conrelid WHERE cn.oid = d.objid), '?')
+                      WHEN 'pg_policy'::regclass     THEN 'policy '      || coalesce((SELECT pc.relname||'.'||pp.polname FROM pg_policy pp JOIN pg_class pc ON pc.oid = pp.polrelid WHERE pp.oid = d.objid), '?')
+                      WHEN 'pg_attrdef'::regclass    THEN 'column default ' || coalesce((SELECT ac.relname||'.'||aa.attname FROM pg_attrdef ad JOIN pg_class ac ON ac.oid = ad.adrelid JOIN pg_attribute aa ON aa.attrelid = ad.adrelid AND aa.attnum = ad.adnum WHERE ad.oid = d.objid), '?')
+                      WHEN 'pg_class'::regclass      THEN 'relation '    || coalesce(d.objid::regclass::text, '?')
+                      ELSE d.classid::regclass::text || ' oid ' || d.objid
+                    END AS what
+               FROM pg_depend d
+              WHERE d.refclassid = 'pg_class'::regclass AND d.refobjid = $1 AND d.deptype = 'n'
+              ORDER BY 1, 2`,
+            [oid],
+          )
+        : { rows: [] as { cls: string; what: string }[] };
 
       const grants = await db.query<{ privilege_type: string }>(
         `SELECT DISTINCT privilege_type FROM information_schema.role_table_grants
-          WHERE table_schema='public' AND table_name=$1 AND grantee='app_tenant'
-          ORDER BY 1`,
+          WHERE table_schema = 'public' AND table_name = $1 AND grantee = 'app_tenant' ORDER BY 1`,
         [table],
       );
 
+      // Classes already reported by a named arm above are listed but not double-counted as blockers;
+      // anything else is a dependency nothing in this script models, which is exactly the case that
+      // deserves a human.
+      const NAMED = new Set(['pg_rewrite', 'pg_proc', 'pg_trigger', 'pg_constraint', 'pg_policy']);
+
+      // The two view oracles police each other. `pg_depend` is authoritative and text-free; the text
+      // arm reads `pg_get_viewdef`. A view present in one and absent from the other means one of them
+      // is broken, and the whole point of this rewrite is that a broken arm must not read as clean.
+      const viewsByText = await viewsQuery(re);
+      const viewsByDepend = deps.rows
+        .filter((d) => d.cls === 'pg_rewrite')
+        .map((d) => d.what.replace(/^view\/rule /, ''))
+        .filter((v) => v !== '?');
+
       reports.push({
         table,
-        exists: meta.rows[0]?.exists ?? false,
-        rlsEnabled: meta.rows[0]?.rls_enabled ?? false,
-        rlsForced: meta.rows[0]?.rls_forced ?? false,
+        exists: Boolean(row),
+        relkind: row?.relkind ?? null,
+        rlsEnabled: row?.rls_enabled ?? false,
+        rlsForced: row?.rls_forced ?? false,
         policies: own.rows.map((r) => r.polname),
-        bytes: meta.rows[0]?.bytes == null ? null : Number(meta.rows[0].bytes),
-        dependentViews: views.rows.map((r) => r.name),
-        dependentRoutines: routines.rows.map((r) => r.name),
-        policiesReferencing: refPolicies.rows.map((r) => r.name),
+        bytes: row?.bytes == null ? null : Number(row.bytes),
+        dependentViews: viewsByText,
+        dependentViewsByDepend: [...new Set(viewsByDepend)].sort(),
+        dependentRoutines: await routinesQuery(re),
+        triggers: trigs.rows.map((r) => r.name),
+        namedDependents: deps.rows.filter((d) => NAMED.has(d.cls)).map((d) => d.what),
+        otherDependents: deps.rows.filter((d) => !NAMED.has(d.cls)).map((d) => d.what),
+        policiesReferencing: await policiesQuery(re, table),
         inboundFks: fks.rows.map((r) => r.name),
         appTenantPrivs: grants.rows.map((r) => r.privilege_type),
       });
@@ -185,66 +618,199 @@ async function main(): Promise<void> {
     await db.end().catch(() => undefined);
   }
 
-  if (asJson) {
-    console.log(JSON.stringify({ tables: reports }, null, 2));
+  // ── Non-vacuity verdict, BEFORE any result is believed ──────────────────────────────────────────
+  const unproven = arms.filter((a) => a.population > 0 && !a.proven);
+  if (unproven.length > 0) {
+    die2(
+      `${unproven.length} arm(s) could not prove their matcher against a row that MUST match: ` +
+        `${unproven.map((a) => `${a.key} (${a.note})`).join('; ')}. A clean result from an unproven arm is ` +
+        'indistinguishable from a query that examined nothing.',
+    );
   }
 
-  const blockers: string[] = [];
   const flipSet = new Set(tables);
-
+  const blockers: string[] = [];
   for (const r of reports) {
-    if (!asJson) {
-      console.log(`\n── ${r.table} ──────────────────────────────────────────────`);
-      if (!r.exists) {
-        console.log('  ⚠ DOES NOT EXIST in public — check the name before flipping.');
-      } else {
-        console.log(
-          `  exists   yes   RLS ${r.rlsEnabled ? 'enabled' : 'DISABLED'}` +
-            `${r.rlsForced ? ' + forced' : ''}, ${r.policies.length} policy(ies)` +
-            `${r.policies.length ? ' [' + r.policies.join(', ') + ']' : ''}, ${r.bytes ?? '?'} bytes`,
-        );
-        console.log(`  app_tenant  ${r.appTenantPrivs.join(',') || '(none)'}`);
-      }
-      console.log(`  views/matviews referencing it   ${r.dependentViews.join(', ') || 'none'}`);
-      console.log(`  functions referencing it        ${r.dependentRoutines.join(', ') || 'none'}`);
-      console.log(`  policies elsewhere referencing  ${r.policiesReferencing.join(', ') || 'none'}`);
-      // A FK from a table also being flipped is fine — both sides move together.
-      const foreignFks = r.inboundFks.filter((f) => !flipSet.has(f.split('.')[0]));
-      console.log(
-        `  inbound FKs                     ${r.inboundFks.join(', ') || 'none'}` +
-          (foreignFks.length ? `  ← ${foreignFks.length} from OUTSIDE the flip set` : ''),
-      );
-    }
-
     if (!r.exists) blockers.push(`${r.table}: does not exist in public`);
-    for (const v of r.dependentViews) blockers.push(`${r.table}: view/matview ${v} references it`);
+    // The UNION of the two view oracles, so a miss by either one still blocks.
+    for (const v of [...new Set([...r.dependentViews, ...r.dependentViewsByDepend])].sort()) {
+      blockers.push(`${r.table}: view/matview ${v} references it`);
+    }
     for (const f of r.dependentRoutines) blockers.push(`${r.table}: function ${f} references it`);
+    for (const t of r.triggers) blockers.push(`${r.table}: trigger ${t}`);
+    for (const d of r.otherDependents) blockers.push(`${r.table}: pg_depend dependent ${d}`);
+  }
+  // Where the two oracles disagree, SAY SO rather than quietly taking the union. Both directions have
+  // legitimate explanations — a `pg_rewrite` dependency can be a RULE on an ordinary table, which the
+  // text arm never looks at, and a viewdef can name the table inside a string literal, which `pg_depend`
+  // correctly does not count — so this is a line for the reader, not an exit code. What is not
+  // acceptable is an unannotated union: it hides which method found what, and the day one of them stops
+  // working the other covers for it silently.
+  const oracleSplits = reports.flatMap((r) => {
+    const text = new Set(r.dependentViews);
+    const depend = new Set(r.dependentViewsByDepend);
+    return [
+      ...[...depend].filter((v) => !text.has(v)).map((v) => `${r.table}: ${v} — pg_depend only`),
+      ...[...text].filter((v) => !depend.has(v)).map((v) => `${r.table}: ${v} — text matcher only`),
+    ];
+  });
+  for (const h of repo.hits.filter((x) => x.kind === 'blocker')) {
+    blockers.push(`${h.table}: ${h.file}:${h.line} names \`${h.variant}\` — ${h.why}`);
+  }
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          tables,
+          note: diffNote || undefined,
+          census,
+          arms,
+          repo: { filesScanned: repo.filesScanned, perRoot: repo.perRoot, variants: repo.variants, hits: repo.hits },
+          reports,
+          oracleSplits,
+          blockers,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    printHuman(tables, census, arms, repo, reports, flipSet, oracleSplits);
   }
 
   if (blockers.length === 0) {
-    // Gated on !asJson: in --json mode stdout must be the JSON document and NOTHING else, or a consumer
-    // piping to jq/JSON.parse breaks precisely in the success case.
     if (!asJson) {
+      const unexercised = arms.filter((a) => a.population === 0);
+      console.log(`\n✓ No blocker for ${tables.join(', ')}.`);
+      if (unexercised.length > 0) {
+        console.log(
+          `  ⚠ ${unexercised.length} arm(s) searched an EMPTY population and therefore proved nothing on ` +
+            `their own: ${unexercised.map((a) => `${a.key} (0 ${a.populationLabel})`).join('; ')}.\n` +
+            `    That is a statement about the database, not about these tables — say so in the PR body ` +
+            'rather than reporting a clean scan.',
+        );
+      }
       console.log(
-        `\n✓ No database-side blocker for ${tables.join(', ')}.` +
-          `\n  Reported items above still belong in the flip PR body — notably app_tenant grants (#126,` +
-          `\n  dead DML after the flip) and any inbound FK from outside the flip set.\n`,
+        '  Reported INFO items still belong in the flip PR body — notably app_tenant grants (#126, dead\n' +
+          '  DML after the flip), any inbound FK from outside the flip set, and every data-file reference.\n',
       );
     }
     process.exit(0);
   }
 
-  console.error(`\n✖ ${blockers.length} database-side BLOCKER(s):\n`);
-  for (const b of blockers) console.error(`  ${b}`);
-  console.error(
-    '\nA view or function over the table keeps working after the Prisma model is deleted, and keeps' +
-      '\nbypassing whatever scoping the TS stack applied. Disposition each one BEFORE deleting the model' +
-      '\n(runbook §0 P2 / §5).\n',
+  writeSync(2, `\n✖ ${blockers.length} BLOCKER(s):\n\n${blockers.map((b) => `  ${b}`).join('\n')}\n`);
+  writeSync(
+    2,
+    '\nA view, function, trigger or dependent object over the table keeps working after the Prisma model' +
+      '\nis deleted, and keeps bypassing whatever scoping the TS stack applied. A data-file reader is' +
+      '\ninvisible to `tsc` by construction. Disposition each one BEFORE deleting the model (runbook §0 P2' +
+      '\n/ §5 step 5b).\n',
   );
   process.exit(1);
 }
 
+/**
+ * Prove an arm's matcher end-to-end: take a row the arm MUST match, pull a word out of the very text the
+ * arm searches, and re-run the arm's own query with it.
+ *
+ * The samples are drawn with the arm's own scope predicate on purpose — a sample selected more widely
+ * would still be found by a broken arm and would prove nothing about the scope.
+ */
+async function proveArm(
+  key: string,
+  label: string,
+  population: number,
+  populationLabel: string,
+  samples: { name: string; text: string }[],
+  run: (re: string) => Promise<string[]>,
+): Promise<Arm> {
+  if (population === 0) {
+    return { key, label, population, populationLabel, proven: true, note: 'population is empty — arm NOT EXERCISED' };
+  }
+  for (const sample of samples) {
+    const tokens = sample.text.match(/[A-Za-z_][A-Za-z0-9_]{2,}/g);
+    if (!tokens || tokens.length === 0) continue;
+    const found = await run(wordRe(tokens[0]));
+    if (found.includes(sample.name)) {
+      return { key, label, population, populationLabel, proven: true, note: `matcher proved against ${sample.name}` };
+    }
+  }
+  return {
+    key,
+    label,
+    population,
+    populationLabel,
+    proven: false,
+    note: `no sample of ${samples.length} could be re-found by the arm's own query`,
+  };
+}
+
+function printHuman(
+  tables: string[],
+  census: { tables: number; views: number; matviews: number; foreignTables: number },
+  arms: Arm[],
+  repo: ReturnType<typeof scanDataFiles>,
+  reports: TableReport[],
+  flipSet: Set<string>,
+  oracleSplits: string[],
+): void {
+  console.log(
+    `\nschema census (public): ${census.tables} tables, ${census.views} views, ${census.matviews} matviews, ` +
+      `${census.foreignTables} foreign tables`,
+  );
+  console.log('\npopulation each arm searched — a hit count is meaningless without it:');
+  for (const a of arms) {
+    console.log(`  ${a.key.padEnd(10)} ${String(a.population).padStart(5)} ${a.populationLabel.padEnd(58)} ${a.note}`);
+  }
+  console.log(
+    `  ${'datafiles'.padEnd(10)} ${String(repo.filesScanned).padStart(5)} files across ${repo.perRoot.length} pinned roots` +
+      `${' '.repeat(30)}${repo.perRoot.map((r) => `${r.path}=${r.files}`).join(' ')}`,
+  );
+
+  for (const r of reports) {
+    console.log(`\n── ${r.table} ──────────────────────────────────────────────`);
+    if (!r.exists) {
+      console.log('  ⚠ DOES NOT EXIST in public — check the name before flipping.');
+    } else {
+      console.log(
+        `  exists   yes (relkind ${r.relkind})   RLS ${r.rlsEnabled ? 'enabled' : 'DISABLED'}` +
+          `${r.rlsForced ? ' + forced' : ''}, ${r.policies.length} policy(ies)` +
+          `${r.policies.length ? ' [' + r.policies.join(', ') + ']' : ''}, ${r.bytes ?? '?'} bytes`,
+      );
+      console.log(`  app_tenant                      ${r.appTenantPrivs.join(',') || '(none)'}`);
+    }
+    console.log(`  views/matviews (text matcher)   ${r.dependentViews.join(', ') || 'none'}`);
+    console.log(`  views/matviews (pg_depend)      ${r.dependentViewsByDepend.join(', ') || 'none'}`);
+    console.log(`  functions referencing it        ${r.dependentRoutines.join(', ') || 'none'}`);
+    console.log(`  triggers on it                  ${r.triggers.join(', ') || 'none'}`);
+    console.log(`  policies elsewhere referencing  ${r.policiesReferencing.join(', ') || 'none'}`);
+    const foreignFks = r.inboundFks.filter((f) => !flipSet.has(f.split('.')[0]));
+    console.log(
+      `  inbound FKs                     ${r.inboundFks.join(', ') || 'none'}` +
+        (foreignFks.length ? `  ← ${foreignFks.length} from OUTSIDE the flip set` : ''),
+    );
+    console.log(`  pg_depend (named classes)       ${r.namedDependents.join(', ') || 'none'}`);
+    console.log(`  pg_depend (OTHER)               ${r.otherDependents.join(', ') || 'none'}`);
+  }
+
+  if (oracleSplits.length > 0) {
+    console.log('\n⚠ the two view oracles do not agree — read each one before believing either:');
+    for (const s of oracleSplits) console.log(`    ${s}`);
+  }
+
+  console.log('\n── data files ──────────────────────────────────────────────');
+  if (repo.hits.length === 0) {
+    console.log(`  no reference to ${tables.join(', ')} in ${repo.filesScanned} files across the pinned roots`);
+  }
+  for (const h of repo.hits) {
+    console.log(`  ${h.kind === 'blocker' ? 'BLOCK' : 'info '} ${h.file}:${h.line}  ${h.variant}  ${h.text}`);
+  }
+}
+
 main().catch((err) => {
-  console.error('✖ pre-flip-scan failed to run:', err instanceof Error ? err.message : err);
-  process.exit(1);
+  // Anything reaching here — an unreachable host, bad credentials, a rejected TLS handshake, a thrown
+  // query — means nothing was scanned. That is a did-not-run, not a clean bill of health, so it routes
+  // through die2 like every other failure path.
+  die2(err instanceof Error ? err.message : String(err));
 });

--- a/scripts/db/pre-flip-scan.ts
+++ b/scripts/db/pre-flip-scan.ts
@@ -368,24 +368,41 @@ async function main(): Promise<void> {
       ),
     );
 
+    // A function's body is NOT always in `prosrc`. Since PG14 a SQL-standard body — `LANGUAGE sql
+    // BEGIN ATOMIC ... END`, and equally the `RETURN <expr>` form — is stored PARSED in
+    // `pg_proc.prosqlbody`, leaving `prosrc = ''` (empty string, not null). Matching `prosrc` alone
+    // therefore cannot see such a function at all, and this is the ONLY blocking path for a routine:
+    // the general pg_depend query does find the edge, but `pg_proc` is in NAMED, so it is routed to
+    // `namedDependents` — printed as INFO and never pushed onto `blockers`. Net effect before this fix:
+    // a SQL-standard-body function reading the flipped table is discovered, printed, and the scan still
+    // exits 0. That is a false negative in a fail-closed control.
+    //
+    // `pg_get_function_sqlbody(oid)` returns NULL (not an error) for every non-SQL-body function,
+    // including aggregates and window functions, so the concatenation is always safe. Do NOT reach for
+    // `pg_get_functiondef(oid)` instead — it THROWS on aggregates, which would turn this arm into a
+    // permanent exit 2.
+    const routineBody = `(coalesce(p.prosrc,'') || coalesce(pg_get_function_sqlbody(p.oid)::text,''))`;
     const routinesQuery = async (re: string): Promise<string[]> => {
       const r = await db.query<{ name: string }>(
         `SELECT n.nspname||'.'||p.proname AS name
            FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-          WHERE ${scopedSchemas} AND p.prosrc ~* $1
+          WHERE ${scopedSchemas} AND ${routineBody} ~* $1
           ORDER BY 1`,
         [re],
       );
       return r.rows.map((x) => x.name);
     };
+    // The population must count what the matcher can actually search, or a database whose relevant
+    // routines are all SQL-standard-bodied reports population 0 — which proveArm reads as "arm not
+    // exercised", so the unproven gate cannot fire and the scan exits 0 on a second, independent path.
     const routinePop = await db.query<{ n: string }>(
       `SELECT count(*)::text AS n FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE ${scopedSchemas} AND p.prosrc IS NOT NULL AND p.prosrc <> ''`,
+        WHERE ${scopedSchemas} AND (p.prosrc IS NOT NULL AND p.prosrc <> '' OR p.prosqlbody IS NOT NULL)`,
     );
     const routineSamples = await db.query<{ name: string; text: string }>(
-      `SELECT n.nspname||'.'||p.proname AS name, p.prosrc AS text
+      `SELECT n.nspname||'.'||p.proname AS name, ${routineBody} AS text
          FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE ${scopedSchemas} AND length(p.prosrc) > 3
+        WHERE ${scopedSchemas} AND length(${routineBody}) > 3
         ORDER BY p.oid LIMIT 8`,
     );
     arms.push(
@@ -632,6 +649,15 @@ async function main(): Promise<void> {
   const blockers: string[] = [];
   for (const r of reports) {
     if (!r.exists) blockers.push(`${r.table}: does not exist in public`);
+    // The existence probe deliberately does NOT filter on relkind (the census at :304 and the Prisma
+    // fingerprint at :320 both do). Keep it broad so a name that resolves to the WRONG KIND of object is
+    // distinguishable from one that is absent — but then say so, because otherwise `exists` is true, the
+    // blocker above does not fire, and every OID-keyed arm below happily scans an object that is itself a
+    // reader. Assert the kind here rather than narrowing the query, which would make this branch
+    // unreachable and would break the `__EFMigrationsHistory` case-folding pin in the test.
+    if (r.exists && r.relkind !== 'r' && r.relkind !== 'p') {
+      blockers.push(`${r.table}: exists in public but is relkind ${r.relkind ?? '?'}, not an ordinary table`);
+    }
     // The UNION of the two view oracles, so a miss by either one still blocks.
     for (const v of [...new Set([...r.dependentViews, ...r.dependentViewsByDepend])].sort()) {
       blockers.push(`${r.table}: view/matview ${v} references it`);

--- a/tests/db/pre-flip-repo-scan.test.ts
+++ b/tests/db/pre-flip-repo-scan.test.ts
@@ -60,7 +60,13 @@ describe('scanDataFiles — against the real repository', () => {
         'smaller population and still reports "no hits" — the vacuous pass this control exists to prevent.',
     ).toEqual([]);
     expect(filesScanned).toBeGreaterThan(50);
-    for (const r of perRoot) expect(r.present, `${r.path} missing`).toBe(true);
+    // `present` is not enough, and the test's own name is the reason: an existing-but-EMPTY root yields
+    // { files: 0, present: true }, contributes nothing to `missingRoots`, and the CLI's gate only fires on
+    // a repo-wide filesScanned === 0. Three of the four roots happen to be pinned non-empty by the
+    // positive-control tests below, but `scripts/parity` is not — and it is the root whose whole rationale
+    // is that the parity harness reads through RAW SQL and so survives model deletion. Converting it to
+    // .mjs (the house pattern for scripts) would silently drop it to zero and every gate would stay green.
+    for (const r of perRoot) expect(r.files, `${r.path} contributed 0 files`).toBeGreaterThan(0);
     expect(perRoot.map((r) => r.path).sort()).toEqual(DATA_ROOTS.map((r) => r.path).sort());
   });
 

--- a/tests/db/pre-flip-repo-scan.test.ts
+++ b/tests/db/pre-flip-repo-scan.test.ts
@@ -1,0 +1,178 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { DATA_ROOTS, nameVariants, scanDataFiles } from '../../scripts/db/pre-flip-repo-scan.mjs';
+
+/**
+ * #132 — the DATA-DRIVEN reader arm of `scripts/db/pre-flip-scan.ts`, tested for real.
+ *
+ * WHY THIS FILE IS EXECUTED AND NOT A SOURCE-TEXT PIN. The database arms of the pre-flip scan cannot run
+ * under `npx vitest run` (no database), so they are pinned by their properties in
+ * `tests/db/pre-flip-scan.test.ts`. This arm has no such excuse: it reads files. So it is split into a
+ * pure module and exercised against the REAL repository, including the exact break that produced #132.
+ *
+ * THE BREAK BEING PINNED. Flip #2 removed `'successor'` / `'criticalRole'` from `ScopedEntity` and got a
+ * GREEN `tsc`, because the only thing that noticed was `contracts/access-fixtures/scope-where.json` — a
+ * cross-stack contract also asserted by `Tims.UnitTests`. None of the runbook's six P2 greps would have
+ * found it either: all six are `.ts`-scoped.
+ *
+ * NON-VACUITY FIRST, per this repo's standing lesson. Every assertion below that expects to find nothing
+ * is preceded by one that finds something, and the roots are checked to exist before any "no hits"
+ * result is believed — a scan over a missing directory reports clean and means nothing.
+ */
+
+const ROOT = join(__dirname, '..', '..');
+
+describe('nameVariants — a fixture names the MODEL, not the table', () => {
+  it('derives the camelCase singular that flip #2 actually broke', () => {
+    // `critical_roles` → the string in scope-where.json is `criticalRole`. Searching the snake-case
+    // table name alone finds nothing, which is precisely how the whole P2 sweep missed it.
+    expect(nameVariants('critical_roles')).toContain('criticalrole');
+    expect(nameVariants('successors')).toContain('successor');
+  });
+
+  it('covers snake/Pascal/camel × singular/plural, lower-cased for case-insensitive matching', () => {
+    expect(nameVariants('calibration_sessions').sort()).toEqual(
+      ['calibration_session', 'calibration_sessions', 'calibrationsession', 'calibrationsessions'].sort(),
+    );
+  });
+
+  it('does not mangle a name that is already singular or ends in a double s', () => {
+    expect(nameVariants('access_reviews')).toContain('access_review');
+    expect(nameVariants('addresses')).toContain('address');
+    expect(nameVariants('fx_rates')).toContain('fx_rate');
+  });
+
+  it('returns nothing for an empty name rather than matching everything', () => {
+    // A variant of `''` would match every line of every file. Cheap to get wrong, expensive to notice.
+    expect(nameVariants('')).toEqual([]);
+    expect(nameVariants('___')).toEqual([]);
+  });
+});
+
+describe('scanDataFiles — against the real repository', () => {
+  it('every pinned data root exists (the population is non-empty before anything is believed)', () => {
+    const { perRoot, missingRoots, filesScanned } = scanDataFiles(['successors'], ROOT);
+    expect(
+      missingRoots,
+      'a pinned data root has been renamed or deleted. Until DATA_ROOTS is updated, every scan searches a ' +
+        'smaller population and still reports "no hits" — the vacuous pass this control exists to prevent.',
+    ).toEqual([]);
+    expect(filesScanned).toBeGreaterThan(50);
+    for (const r of perRoot) expect(r.present, `${r.path} missing`).toBe(true);
+    expect(perRoot.map((r) => r.path).sort()).toEqual(DATA_ROOTS.map((r) => r.path).sort());
+  });
+
+  it('finds the flip-#2 break in scope-where.json, and classifies it as a BLOCKER', () => {
+    const { hits } = scanDataFiles(['critical_roles', 'successors'], ROOT);
+    const fixture = hits.filter((h) => h.file === 'contracts/access-fixtures/scope-where.json');
+    expect(
+      fixture.length,
+      'the scan no longer finds `successor`/`criticalRole` in contracts/access-fixtures/scope-where.json. ' +
+        'Either the fixture changed or the matcher is broken — in both cases a clean scan for a ' +
+        'succession flip would now be a lie.',
+    ).toBeGreaterThan(0);
+    for (const h of fixture) expect(h.kind).toBe('blocker');
+    // The message has to say "keep it", not "delete it": deleting the case removes the oracle pinning
+    // Tims.UnitTests' own ScopeWhereForFixtureTests (runbook §1 step 6).
+    expect(fixture[0].why).toMatch(/SURVIVE the flip/);
+    expect(fixture[0].why).toMatch(/Do NOT delete the case/);
+  });
+
+  it('flags a seed that still writes the model (§8 Q9), which is what flip #2 had to port', () => {
+    const { hits } = scanDataFiles(['surveys'], ROOT);
+    const seed = hits.filter((h) => h.file === 'packages/db/prisma/seed-demo.ts');
+    expect(seed.length, 'seed-demo.ts references to a flip target are no longer detected').toBeGreaterThan(0);
+    for (const h of seed) expect(h.kind).toBe('blocker');
+  });
+
+  it('reports DDL and parity references as INFO, not as blockers', () => {
+    // A `CREATE TABLE` in the flip-DDL is the artifact §0 P8 REQUIRES to exist. Failing on it would make
+    // the check cry wolf on every flip, and a check that cries wolf gets switched off.
+    const { hits } = scanDataFiles(['critical_roles', 'successors'], ROOT);
+    const ddl = hits.filter((h) => h.file.startsWith('services/Tims.Platform/db/flip-ddl/'));
+    expect(ddl.length, 'the flip-DDL for the flipped succession tables is no longer seen at all').toBeGreaterThan(0);
+    for (const h of ddl) expect(h.kind).toBe('info');
+  });
+
+  it('returns no hits for a table nobody names — the negative control, run only after the positives', () => {
+    const { hits, filesScanned } = scanDataFiles(['zzz_no_such_table'], ROOT);
+    expect(filesScanned).toBeGreaterThan(50);
+    expect(hits).toEqual([]);
+  });
+});
+
+describe('scanDataFiles — crafted trees', () => {
+  let sandbox: string;
+
+  beforeAll(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'preflip-repo-scan-'));
+  });
+  afterAll(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  function tree(name: string, files: Record<string, string>, roots = DATA_ROOTS.map((r) => r.path)): string {
+    const root = join(sandbox, name);
+    for (const r of roots) mkdirSync(join(root, r), { recursive: true });
+    for (const [rel, body] of Object.entries(files)) {
+      mkdirSync(join(root, rel.split('/').slice(0, -1).join('/')), { recursive: true });
+      writeFileSync(join(root, rel), body);
+    }
+    return root;
+  }
+
+  it('reports a missing root instead of silently searching a smaller population', () => {
+    const root = tree('missing-root', { 'contracts/a.json': '{}' }, ['contracts']);
+    const { missingRoots } = scanDataFiles(['widgets'], root);
+    expect(missingRoots).toContain('packages/db/prisma');
+    expect(missingRoots).toContain('scripts/parity');
+  });
+
+  it('does not match a longer identifier that merely contains the table name', () => {
+    // `calibration_sessions_pkey` is an index name, not a reader, and one hit per index per migration
+    // file would drown the report. Proved by mutation: dropping the boundary lookarounds for a plain
+    // substring match turns this red. (A `\b` version is NOT the mutation to write here — in JavaScript
+    // `\b` is equivalent, since `\w` includes `_`. It is the SQL side that cannot use `\b`.)
+    const root = tree('boundary', { 'contracts/x.json': '{"index":"calibration_sessions_pkey"}\n' });
+    expect(scanDataFiles(['calibration_sessions'], root).hits).toEqual([]);
+
+    const real = tree('boundary-real', { 'contracts/y.json': '{"entity":"calibration_sessions"}\n' });
+    expect(scanDataFiles(['calibration_sessions'], real).hits).toHaveLength(1);
+  });
+
+  it('matches case-insensitively, so SQL shouting the table name is still found', () => {
+    const root = tree('shout', {
+      'packages/db/prisma/manual/x.sql': 'ALTER TABLE PUBLIC.SURVEYS ENABLE ROW LEVEL SECURITY;\n',
+    });
+    const { hits } = scanDataFiles(['surveys'], root);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].kind).toBe('info');
+  });
+
+  it('skips node_modules at any depth', () => {
+    const root = tree('skip', {
+      'contracts/node_modules/pkg/fixture.json': '{"entity":"widget"}\n',
+      'contracts/real.json': '{"entity":"widget"}\n',
+    });
+    const { hits } = scanDataFiles(['widgets'], root);
+    expect(hits.map((h) => h.file)).toEqual(['contracts/real.json']);
+  });
+
+  it('classifies a seed by name, so a NEW seed file is covered without editing the matcher', () => {
+    const root = tree('seed', { 'packages/db/prisma/seed-engagement.ts': 'await db.survey.create({});\n' });
+    const { hits } = scanDataFiles(['surveys'], root);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].kind).toBe('blocker');
+    expect(hits[0].why).toMatch(/§8 Q9/);
+  });
+
+  it('records the line number, so a hit is a place to look and not just a file name', () => {
+    const root = tree('lines', { 'contracts/access-fixtures/f.json': '{\n  "a": 1,\n  "entity": "successor"\n}\n' });
+    const { hits } = scanDataFiles(['successors'], root);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].line).toBe(3);
+    expect(hits[0].text).toContain('successor');
+  });
+});

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -33,6 +33,23 @@
  *                                          exited 1 with five blockers instead of six — i.e. it silently
  *                                          lost a real reader. That pair is the whole argument for the
  *                                          matcher proofs.
+ *   - SQL-STANDARD-BODY function
+ *     (`LANGUAGE sql BEGIN ATOMIC
+ *      SELECT count(*) FROM critical_roles;
+ *      END`)                             → measured on a throwaway PG 17.10 cluster alongside a `plpgsql`
+ *                                          and a dollar-quoted `LANGUAGE sql` control: its `prosrc` is
+ *                                          `''`, so the pre-fix `p.prosrc ~* $1` arm returned NOTHING for
+ *                                          it, while `pg_depend` DID carry the edge — and because
+ *                                          `pg_proc` is in NAMED, that edge printed as INFO under
+ *                                          "pg_depend (named classes)" and never reached `blockers`. The
+ *                                          scan therefore printed the reader and exited 0. Fixed by
+ *                                          searching `prosrc || pg_get_function_sqlbody(oid)`; the
+ *                                          population and sample queries had to move with it, or the arm
+ *                                          reports population 0 and `proveArm` reads it as NOT EXERCISED,
+ *                                          which is a second independent path to a green exit.
+ *                                          (`pg_get_function_sqlbody` returns NULL rather than throwing
+ *                                          for non-SQL bodies; `pg_get_functiondef` THROWS on aggregates
+ *                                          and must not be substituted.)
  *   - `__EFMigrationsHistory`            → found, not a false "does not exist": the existence probe
  *                                          matches `relname` exactly and never folds case.
  *   - a same-named FK constraint in
@@ -82,6 +99,20 @@ let sandbox: string;
 type Run = { code: number; out: string };
 
 function run(args: string[], cwd: string, env: Record<string, string | undefined> = {}): Run {
+  // Recurrence guard for the live-production-connection defect. Stripping the inherited env (below) is
+  // NOT sufficient on its own: loadDbEnv() falls back to the BARE RELATIVE path `packages/db/.env`,
+  // resolved against `cwd`. From a sandbox that file does not exist, but from REPO_ROOT it is the real
+  // one, holding the production Supabase URL. So REPO_ROOT runs must always pin a URL explicitly.
+  // Deliberately NOT a default value for `env` — defaulting it would break the `no DIRECT_URL or
+  // DATABASE_URL` assertions (:168, :204) and silently vacate the cwd-resolution pin at :156, which can
+  // only observe loadDbEnv() reading a .env when no URL is preset. Sandbox cwds are exempt by design:
+  // there is no packages/db/.env under a mkdtemp root, which is what those tests rely on.
+  if (cwd === REPO_ROOT && env.DIRECT_URL === undefined && env.DATABASE_URL === undefined) {
+    throw new Error(
+      'run() from REPO_ROOT without DIRECT_URL/DATABASE_URL: loadDbEnv() would resolve the real ' +
+        'packages/db/.env and could open a LIVE PRODUCTION connection. Pass { DIRECT_URL: DEAD_URL }.',
+    );
+  }
   try {
     const out = execFileSync(TSX, [SCRIPT, ...args], {
       cwd,
@@ -248,13 +279,23 @@ describe('pre-flip-scan — --flip-diff derives the table list from the ledger',
   it('exits 0 without a database when the branch flips nothing, and states what it compared', () => {
     // A gate row has to be runnable on every PR, and most PRs flip nothing. The result must still be a
     // STATEMENT — "12 efcore[] tables there, 12 here, 0 newly efcore-owned" — rather than an empty result
-    // dressed up as a pass. No DIRECT_URL is supplied on purpose: with nothing to scan the check must not
-    // need a database at all, or it would be permanently ⚠️ NOT RUN for everyone and enforce nothing.
+    // dressed up as a pass. With nothing to scan the check must not need a database at all, or it would
+    // be permanently ⚠️ NOT RUN for everyone and enforce nothing.
+    //
+    // DEAD_URL is supplied even though this path must never reach a database, and that is the point: it
+    // makes "needs no database" PROVEN rather than assumed. This is the one run() call site that combines
+    // cwd = REPO_ROOT with the real repo layout, and run() (:84) builds the child env from scratch — so
+    // omitting a URL does not mean "no credentials", it means loadDbEnv() falls through to reading the
+    // BARE RELATIVE path `packages/db/.env`, resolved against this cwd. That file holds the production
+    // Supabase direct URL. It passes today only because `--base HEAD` on a clean tree exits at the empty
+    // -diff branch before loadDbEnv(); one uncommitted efcore[] entry — the exact working-tree state of a
+    // developer authoring a flip PR — makes a plain `npx vitest run` open a LIVE PRODUCTION connection.
+    // With DEAD_URL set, loadDbEnv() returns at its first line and any regression dies at 127.0.0.1:1.
     //
     // `--base HEAD` rather than the default `origin/main`: CI checks out at fetch-depth 1, where
     // `origin/main` is not a resolvable ref, and a test that only passes on a full clone is a test that
     // goes red for a reason unrelated to its subject. The DEFAULT is pinned as a property below.
-    const { code, out } = run(['--flip-diff', '--base', 'HEAD'], REPO_ROOT);
+    const { code, out } = run(['--flip-diff', '--base', 'HEAD'], REPO_ROOT, { DIRECT_URL: DEAD_URL });
     expect(code, `expected exit 0, got ${code}. Output:\n${out}`).toBe(0);
     expect(out).toMatch(/no ownership flip in this diff/);
     expect(out).toMatch(/efcore\[\] tables there/);
@@ -360,6 +401,22 @@ describe('pre-flip-scan — database-arm properties', () => {
     // Measured on PG 17.10: `\b` is a BACKSPACE in a Postgres advanced RE, so a `\b` matcher returns
     // false for every input — every arm would report clean forever.
     expect(SRC).toMatch(/const wordRe = \(t: string\): string => `\\\\y\$\{t/);
+  });
+
+  it('searches SQL-standard function bodies, which live in prosqlbody with prosrc = emptystring', () => {
+    // Measured on PG 17.10: `LANGUAGE sql BEGIN ATOMIC ... END` (and the `RETURN` form) store the body
+    // PARSED in pg_proc.prosqlbody and leave prosrc = ''. A `prosrc`-only matcher cannot see such a
+    // function, and because 'pg_proc' is in NAMED, the pg_depend edge that DOES exist is printed as INFO
+    // rather than pushed onto blockers — so the scan named the reader and still exited 0.
+    //
+    // Pinned as three separate properties because each one alone can be defeated: the MATCHER must
+    // search the concatenation, the POPULATION must count what the matcher can search (otherwise the arm
+    // reports 0 and proveArm reads it as NOT EXERCISED — a second path to a green exit), and
+    // pg_get_functiondef must never be substituted, as it THROWS on aggregates and would convert this
+    // arm into a permanent exit 2.
+    expect(SRC).toMatch(/coalesce\(p\.prosrc,''\) \|\| coalesce\(pg_get_function_sqlbody\(p\.oid\)::text,''\)/);
+    expect(SRC).toMatch(/p\.prosrc IS NOT NULL AND p\.prosrc <> '' OR p\.prosqlbody IS NOT NULL/);
+    expect(CODE).not.toMatch(/pg_get_functiondef/);
   });
 
   it('matches the table name exactly, so a mixed-case table is not a false "does not exist"', () => {

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -104,7 +104,7 @@ function run(args: string[], cwd: string, env: Record<string, string | undefined
   // resolved against `cwd`. From a sandbox that file does not exist, but from REPO_ROOT it is the real
   // one, holding the production Supabase URL. So REPO_ROOT runs must always pin a URL explicitly.
   // Deliberately NOT a default value for `env` — defaulting it would break the `no DIRECT_URL or
-  // DATABASE_URL` assertions (:168, :204) and silently vacate the cwd-resolution pin at :156, which can
+  // DATABASE_URL` assertions (:186, :222) and silently vacate the cwd-resolution pin at :174, which can
   // only observe loadDbEnv() reading a .env when no URL is preset. Sandbox cwds are exempt by design:
   // there is no packages/db/.env under a mkdtemp root, which is what those tests rely on.
   if (cwd === REPO_ROOT && env.DIRECT_URL === undefined && env.DATABASE_URL === undefined) {
@@ -283,8 +283,9 @@ describe('pre-flip-scan — --flip-diff derives the table list from the ledger',
     // be permanently ⚠️ NOT RUN for everyone and enforce nothing.
     //
     // DEAD_URL is supplied even though this path must never reach a database, and that is the point: it
-    // makes "needs no database" PROVEN rather than assumed. This is the one run() call site that combines
-    // cwd = REPO_ROOT with the real repo layout, and run() (:84) builds the child env from scratch — so
+    // makes "needs no database" PROVEN rather than assumed. This was the only REPO_ROOT call site that
+    // had not pinned a URL — the other four (:242, :249, :257, :268) already did — and run() (:101)
+    // builds the child env from scratch, so
     // omitting a URL does not mean "no credentials", it means loadDbEnv() falls through to reading the
     // BARE RELATIVE path `packages/db/.env`, resolved against this cwd. That file holds the production
     // Supabase direct URL. It passes today only because `--base HEAD` on a clean tree exits at the empty
@@ -414,8 +415,21 @@ describe('pre-flip-scan — database-arm properties', () => {
     // reports 0 and proveArm reads it as NOT EXERCISED — a second path to a green exit), and
     // pg_get_functiondef must never be substituted, as it THROWS on aggregates and would convert this
     // arm into a permanent exit 2.
-    expect(SRC).toMatch(/coalesce\(p\.prosrc,''\) \|\| coalesce\(pg_get_function_sqlbody\(p\.oid\)::text,''\)/);
-    expect(SRC).toMatch(/p\.prosrc IS NOT NULL AND p\.prosrc <> '' OR p\.prosqlbody IS NOT NULL/);
+    // Pin the USE, not just the definition. An earlier version of this test asserted only that the
+    // `routineBody` const EXISTS — which `routineSamples` keeps alive, so reverting the matcher alone to
+    // `AND p.prosrc ~* $1` reintroduced B2 with every pin in this file still green. Assert against CODE
+    // (comment-stripped, :87) so a citation of the old spelling in a comment cannot satisfy or break it.
+    expect(CODE).toMatch(
+      /const routineBody = .*coalesce\(p\.prosrc,''\) \|\| coalesce\(pg_get_function_sqlbody\(p\.oid\)::text,''\)/,
+    );
+    expect(CODE).toMatch(/AND \$\{routineBody\} ~\* \$1/);
+    // The matcher must not fall back to prosrc alone anywhere.
+    expect(CODE).not.toMatch(/p\.prosrc ~\*/);
+    // The population must count what the matcher can search, or an all-SQL-standard-body database
+    // reports 0 and proveArm reads it as NOT EXERCISED — a second, independent path to a green exit.
+    expect(CODE).toMatch(/p\.prosrc IS NOT NULL AND p\.prosrc <> '' OR p\.prosqlbody IS NOT NULL/);
+    // …and the samples must be drawn from the same concatenation the matcher searches.
+    expect(CODE).toMatch(/length\(\$\{routineBody\}\) > 3/);
     expect(CODE).not.toMatch(/pg_get_functiondef/);
   });
 
@@ -457,6 +471,19 @@ describe('pre-flip-scan — database-arm properties', () => {
     expect(SRC).toMatch(/if \(!r\.exists\) blockers\.push/);
     expect(SRC).toMatch(/for \(const f of r\.dependentRoutines\) blockers\.push/);
     expect(SRC).toMatch(/for \(const t of r\.triggers\) blockers\.push/);
+  });
+
+  it('blocks when the name resolves to something other than an ordinary table', () => {
+    // The existence probe deliberately carries no relkind filter, so that a name resolving to a
+    // view/matview/sequence is distinguishable from one that is absent. That only helps if the KIND is
+    // then asserted: otherwise `exists` is true, the !exists blocker does not fire, and every OID-keyed
+    // arm scans an object that is itself a reader. Matched against CODE — "ordinary table" also occurs
+    // in prose comments, so an SRC match here would pass on the comment alone.
+    expect(CODE).toMatch(/r\.relkind !== 'r' && r\.relkind !== 'p'/);
+    expect(CODE).toMatch(/blockers\.push\([\s\S]{0,120}not an ordinary table/);
+    // And the query must STAY broad — narrowing it makes the branch above unreachable and collapses the
+    // case into the "does not exist" message it exists to distinguish.
+    expect(CODE).toMatch(/WHERE n\.nspname = 'public' AND c\.relname = \$1/);
   });
 
   it('excludes the scanned table itself from the "policies elsewhere referencing it" query', () => {

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -1,66 +1,411 @@
-import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+/**
+ * #132 — FAILURE-PATH tests for `scripts/db/pre-flip-scan.ts`, plus property pins for the arms that
+ * cannot run without a database.
+ *
+ * THE CONTRACT UNDER TEST
+ *   0  ran, no blocker
+ *   1  ran, found a blocker
+ *   2  COULD NOT RUN — never to be reported as a pass
+ *
+ * Checks 14, 16 and 17 each shipped with a vacuous pass that certified a database they never examined,
+ * and each had to be fixed afterwards. This scan is the fourth control of that family, so its could-not-run
+ * paths are EXECUTED here — against the real script, from its real path — rather than asserted about its
+ * source text. Everything below runs offline: the sandbox cwds carry no credentials and the one URL
+ * supplied points at a closed loopback port.
+ *
+ * WHAT WAS PROVED AGAINST A REAL CLUSTER, AND IS NOT AUTOMATED HERE
+ * ----------------------------------------------------------------
+ * Exit 0 and exit 1 need a live database, so they were exercised by hand on a throwaway PostgreSQL 17.10
+ * cluster (`initdb` + `pg_ctl` on 127.0.0.1:55436, torn down afterwards) carrying the real Prisma schema
+ * via `prisma db push` (96 tables) plus deliberate readers over `surveys` / `survey_responses`:
+ *
+ *   - EMPTY database                    → exit 2, "only 0 of the 96 tables declared by the Prisma schema
+ *                                          exist in this database". NOT a tick. This was the first thing
+ *                                          checked, because it is the question the whole rewrite answers.
+ *   - view + matview + plpgsql function
+ *     + trigger + §3(f) policy + FK      → exit 1, 6 blockers, every arm firing
+ *   - after dropping them                → exit 0, and the summary NAMES the arms whose population was
+ *                                          empty instead of printing an unqualified tick
+ *   - MUTATION: the functions arm's predicate changed from `p.prosrc ~* $1` to
+ *     `p.prosrc ~* ('zzzz' || $1)`       → exit 2, "1 arm(s) could not prove their matcher against a row
+ *                                          that MUST match: functions". With the guard ALSO removed, the
+ *                                          same mutant printed "functions referencing it  none" and
+ *                                          exited 1 with five blockers instead of six — i.e. it silently
+ *                                          lost a real reader. That pair is the whole argument for the
+ *                                          matcher proofs.
+ *   - `__EFMigrationsHistory`            → found, not a false "does not exist": the existence probe
+ *                                          matches `relname` exactly and never folds case.
+ *   - a same-named FK constraint in
+ *     another schema                     → NOT reported as an inbound FK; `pg_constraint.confrelid` is an
+ *                                          OID, so `information_schema`'s non-unique `constraint_name`
+ *                                          cannot produce a phantom.
+ *   - `--flip-diff` with `surveys` added
+ *     to the ledger's `efcore[]`         → derived the table from the diff and blocked on it
+ *
+ * Making `npx vitest run` depend on a local PostgreSQL 17 install is the trade this repo already
+ * declined for check 17, for the good reason that a test everybody skips protects nothing. So the split
+ * is deliberate: could-not-run paths execute here, the database paths are pinned as properties, and the
+ * transcript above is the record.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+const SCRIPT_REL = 'scripts/db/pre-flip-scan.ts';
+const SCRIPT = join(REPO_ROOT, SCRIPT_REL);
+const TSX = join(REPO_ROOT, 'node_modules/.bin/tsx');
+const SRC = readFileSync(SCRIPT, 'utf8');
 
 /**
- * #132 — offline contract tests for `scripts/db/pre-flip-scan.ts`.
+ * The source with comment lines stripped, for the assertions that say a construct must NOT appear.
  *
- * WHY THESE ARE STATIC RATHER THAN EXECUTED. The script's real behaviour needs a live Postgres, and its
- * blocker paths WERE exercised against a throwaway PG17 cluster carrying a deliberate view and function
- * over a target table (both correctly reported as BLOCKERs, exit 1). That run cannot be committed —
- * `vitest` here has no database — so the runbook must not claim an automated test covers it. What IS
- * worth pinning automatically is the part that would rot silently: the exit-code contract and the
- * queries' correctness properties, each of which was a real finding.
- *
- * Same reasoning as `tests/db/schema-baseline-failure-paths.test.ts`: given #38, the properties a gate
- * depends on should fail loudly when edited away, even when the end-to-end path needs credentials.
+ * Written after this exact trap fired: the file EXPLAINS in a comment that it no longer uses
+ * `to_regclass('public.'||$1)`, and a naive `expect(SRC).not.toMatch(...)` failed on the explanation
+ * rather than on the code. A negative pin that a comment can trip is a negative pin that will be
+ * "fixed" by deleting the comment, which is the opposite of what anyone wanted.
  */
+const CODE = SRC.split('\n')
+  .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+  .join('\n');
 
-const ROOT = join(__dirname, '..', '..');
-const SRC = readFileSync(join(ROOT, 'scripts/db/pre-flip-scan.ts'), 'utf8');
+/** Port 1 on loopback: nothing listens there, so the connection fails without reaching any database. */
+const DEAD_URL = 'postgresql://nobody:nothing@127.0.0.1:1/none';
 
-describe('pre-flip-scan — exit-code contract', () => {
-  it('fails closed when no connection string is available', () => {
-    // An unrunnable scan must never read as a clean scan (#38 doctrine, same as checks 14/16/17).
-    expect(SRC).toMatch(/scan DID NOT RUN \(not a clean scan\)/);
-    const idx = SRC.indexOf('scan DID NOT RUN');
-    expect(SRC.slice(idx, idx + 200)).toMatch(/process\.exit\(1\)/);
+/** The data roots the scan pins by name. A sandbox needs all of them or it dies before anything else. */
+const ROOTS = ['contracts', 'packages/db/prisma', 'scripts/parity', 'services/Tims.Platform/db'];
+
+let sandbox: string;
+
+type Run = { code: number; out: string };
+
+function run(args: string[], cwd: string, env: Record<string, string | undefined> = {}): Run {
+  try {
+    const out = execFileSync(TSX, [SCRIPT, ...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Strip inherited DB credentials. Without this a developer's real .env turns an expected exit 2
+      // into a live PRODUCTION query — the trap the schema-baseline and tenant-grant failure tests both
+      // call out, and the reason the cwd-resolution test below runs first.
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? '',
+        NODE_ENV: process.env.NODE_ENV ?? 'test',
+        ...env,
+      },
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { code: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+/** A minimal ownership ledger, in the exact shape `parseLedger` requires (a single ```json block). */
+function ledger(efcore: string[]): string {
+  return `# ledger\n\n\`\`\`json\n${JSON.stringify({ defaultOwner: 'prisma', efcore }, null, 2)}\n\`\`\`\n`;
+}
+
+/** A throwaway cwd with the pinned data roots, optionally populated. */
+function makeCwd(name: string, opts: { roots?: string[]; files?: Record<string, string> } = {}): string {
+  const root = join(sandbox, name);
+  for (const r of opts.roots ?? ROOTS) mkdirSync(join(root, r), { recursive: true });
+  for (const [rel, body] of Object.entries(opts.files ?? {})) {
+    mkdirSync(join(root, rel.split('/').slice(0, -1).join('/')), { recursive: true });
+    writeFileSync(join(root, rel), body);
+  }
+  return root;
+}
+
+beforeAll(() => {
+  expect(
+    existsSync(TSX),
+    `${TSX} is missing. tsx is a declared devDependency (#124) — run \`pnpm install --frozen-lockfile\`. ` +
+      'This is an environment problem, not a failure of the script under test.',
+  ).toBe(true);
+  sandbox = mkdtempSync(join(tmpdir(), 'pre-flip-scan-test-'));
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+/**
+ * The 5 s default is not enough here and raising it is not papering over anything: every test below
+ * SPAWNS `tsx`, which costs ~1.5 s of startup before the script begins, and the sweep runs three of them.
+ * Measured: this file passes alone in ~7 s and timed out inside a full `npx vitest run`, where 290 other
+ * files are competing for the same cores. A flaky gate test is a gate that gets ignored.
+ */
+describe('pre-flip-scan — exit 2 means DID NOT RUN, never a pass', { timeout: 60_000 }, () => {
+  it("resolves .env relative to CWD — the property this suite's offline safety depends on", () => {
+    // THIS TEST RUNS FIRST ON PURPOSE (vitest executes in file order). The suite is only offline because
+    // `loadDbEnv` reads the BARE relative paths 'packages/db/.env' and '.env', which Node resolves from
+    // cwd. If that were ever changed to resolve from the script's own directory, the "no URL" test below
+    // would silently pick up a developer's real DIRECT_URL and fire queries at PRODUCTION. Pinning it
+    // here, ahead of that test, is what keeps the window closed.
+    const cwd = makeCwd('env-from-cwd', {
+      files: { 'contracts/a.json': '{}\n', 'packages/db/.env': `DIRECT_URL=${DEAD_URL}\n` },
+    });
+    const { code, out } = run(['widgets'], cwd);
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out, 'the sandbox .env was not read — .env resolution is no longer cwd-relative').not.toMatch(
+      /no DIRECT_URL or DATABASE_URL/,
+    );
+    expect(out).toMatch(/DID NOT RUN/);
   });
 
-  it('exits 1 on a blocker and 0 only when the blocker list is empty', () => {
-    expect(SRC).toMatch(/if \(blockers\.length === 0\)[\s\S]{0,900}?process\.exit\(0\)/);
-    expect(SRC).toMatch(/database-side BLOCKER\(s\)[\s\S]{0,600}?process\.exit\(1\)/);
+  it('exits 2 when given no tables at all', () => {
+    // The old script exited 1 here, which is the code for "found a blocker" — a caller could not tell a
+    // usage error from a real finding.
+    const { code, out } = run([], makeCwd('no-args', { files: { 'contracts/a.json': '{}\n' } }));
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/DID NOT RUN/);
+    expect(out).toMatch(/no tables given/);
   });
 
-  it('treats a missing table as a blocker rather than a clean result', () => {
-    expect(SRC).toMatch(/if \(!r\.exists\) blockers\.push/);
+  it('exits 2 when a pinned data root is missing, instead of searching a smaller population', () => {
+    // The vacuous-pass shape for the repo arm: with `contracts/` gone the scan still finds "no hits".
+    const cwd = makeCwd('missing-root', {
+      roots: ['packages/db/prisma'],
+      files: { 'packages/db/prisma/x.sql': '-- x\n' },
+    });
+    const { code, out } = run(['successors'], cwd, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/pinned data root\(s\) missing/);
+    expect(out).toMatch(/contracts/);
   });
 
-  it('classifies views AND functions as blockers, not merely as info', () => {
-    expect(SRC).toMatch(/for \(const v of r\.dependentViews\) blockers\.push/);
-    expect(SRC).toMatch(/for \(const f of r\.dependentRoutines\) blockers\.push/);
+  it('exits 2 when the roots exist but contain nothing to search', () => {
+    const { code, out } = run(['successors'], makeCwd('empty-roots'), { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/ZERO matching files/);
+  });
+
+  it('exits 2 when no connection URL is resolvable', () => {
+    const cwd = makeCwd('no-url', { files: { 'contracts/a.json': '{}\n' } });
+    const { code, out } = run(['successors'], cwd);
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/no DIRECT_URL or DATABASE_URL/);
+    expect(out).toMatch(/not a pass/);
+  });
+
+  it('exits 2 when the Prisma schema parses to zero tables — the database fingerprint is unusable', () => {
+    // Without a fingerprint there is no way to tell our database from an empty one, and every arm would
+    // then report "clean" against whatever it was pointed at.
+    const cwd = makeCwd('zero-prisma', {
+      roots: [...ROOTS, 'packages/db/prisma/schema'],
+      files: { 'contracts/a.json': '{}\n' },
+    });
+    const { code, out } = run(['successors'], cwd, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/parsed ZERO tables/);
+  });
+
+  it('exits 2 — not 1 — when the database is unreachable, running from the real repo root', () => {
+    // The real roots, the real Prisma schema, a dead socket. This is the path a CI job with a rotated
+    // secret takes, and conflating it with "found a blocker" is what made #124's acceptance criterion
+    // unsatisfiable for check 17 before it was fixed.
+    const { code, out } = run(['surveys'], REPO_ROOT, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/DID NOT RUN/);
+    expect(out).not.toMatch(/✓/);
+  });
+
+  it('exits 2 when --flip-diff cannot read the ledger at the base ref', () => {
+    const { code, out } = run(['--flip-diff', '--base', 'no-such-ref-for-tests'], REPO_ROOT, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/could not read docs\/architecture\/table-ownership\.md/);
+    // Guessing "no tables flipped" when the diff is unavailable would be a silent pass on a flip PR.
+    expect(out).toMatch(/would be a silent pass/);
+  });
+
+  it('exits 2 rather than quietly ignoring table names passed alongside --flip-diff', () => {
+    const { code, out } = run(['--flip-diff', 'surveys'], REPO_ROOT, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/derives the table list from the ledger/);
+  });
+
+  it('no could-not-run path prints a success tick', () => {
+    // Independent of exit codes: if a refactor lets a die path fall through to the happy message, this
+    // catches it even when the code still happens to be 2.
+    const cases: Array<[string, string[], string, Record<string, string>]> = [
+      ['no-args', [], makeCwd('sweep-args', { files: { 'contracts/a.json': '{}\n' } }), {}],
+      ['no-url', ['successors'], makeCwd('sweep-url', { files: { 'contracts/a.json': '{}\n' } }), {}],
+      ['unreachable', ['surveys'], REPO_ROOT, { DIRECT_URL: DEAD_URL }],
+    ];
+    for (const [name, args, cwd, env] of cases) {
+      const { code, out } = run(args, cwd, env);
+      expect(code, `${name}: expected exit 2`).toBe(2);
+      expect(out, `${name}: must not claim success`).not.toMatch(/✓/);
+    }
   });
 });
 
-describe('pre-flip-scan — query correctness properties (each was a real finding)', () => {
-  it('matches table names on a word boundary, so `successors` cannot match a longer identifier', () => {
-    expect(SRC).toMatch(/\\\\y\$\{t\}\\\\y/);
+describe('pre-flip-scan — --flip-diff derives the table list from the ledger', { timeout: 60_000 }, () => {
+  it('exits 0 without a database when the branch flips nothing, and states what it compared', () => {
+    // A gate row has to be runnable on every PR, and most PRs flip nothing. The result must still be a
+    // STATEMENT — "12 efcore[] tables there, 12 here, 0 newly efcore-owned" — rather than an empty result
+    // dressed up as a pass. No DIRECT_URL is supplied on purpose: with nothing to scan the check must not
+    // need a database at all, or it would be permanently ⚠️ NOT RUN for everyone and enforce nothing.
+    //
+    // `--base HEAD` rather than the default `origin/main`: CI checks out at fetch-depth 1, where
+    // `origin/main` is not a resolvable ref, and a test that only passes on a full clone is a test that
+    // goes red for a reason unrelated to its subject. The DEFAULT is pinned as a property below.
+    const { code, out } = run(['--flip-diff', '--base', 'HEAD'], REPO_ROOT);
+    expect(code, `expected exit 0, got ${code}. Output:\n${out}`).toBe(0);
+    expect(out).toMatch(/no ownership flip in this diff/);
+    expect(out).toMatch(/efcore\[\] tables there/);
+    expect(out).toMatch(/newly efcore-owned/);
   });
 
-  it('quotes the identifier in the existence probe, so a mixed-case table is not a false blocker', () => {
-    // to_regclass('public.'||$1) folds unquoted names to lowercase, which reported
-    // `__EFMigrationsHistory` as non-existent — a false BLOCKER. format('%I') quotes it.
-    expect(SRC).toMatch(/to_regclass\(format\('public\.%I', \$1\)\)/);
-    expect(SRC).not.toMatch(/to_regclass\('public\.'\|\|\$1\)/);
+  it('actually finds a flipped table — the positive control the gate row depends on', () => {
+    // WITHOUT THIS, THE GATE ROW IS VACUOUS. Check 18 runs `--flip-diff` on every branch and almost
+    // always reports "0 newly efcore-owned". If the ledger parse or the set difference broke, it would
+    // report exactly the same thing forever, and the one PR class it exists to catch — a flip — would
+    // sail through green. So: a throwaway git repo whose HEAD ledger lists one efcore table and whose
+    // working tree lists two, and the derived list has to name the difference.
+    const cwd = makeCwd('flip-positive', {
+      files: {
+        'contracts/a.json': '{}\n',
+        'docs/architecture/table-ownership.md': ledger(['old_table']),
+      },
+    });
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+    writeFileSync(join(cwd, 'docs/architecture/table-ownership.md'), ledger(['old_table', 'newly_flipped']));
+
+    const { code, out } = run(['--flip-diff', '--base', 'HEAD'], cwd, { DIRECT_URL: DEAD_URL });
+    expect(out).toMatch(/1 newly efcore-owned: newly_flipped/);
+    // It then goes on to need a database, and cannot reach one here. Exit 2 — never 0.
+    expect(code, `expected exit 2 after deriving the table, got ${code}. Output:\n${out}`).toBe(2);
   });
 
-  it('qualifies the FK join by constraint_schema, since constraint_name is not globally unique', () => {
-    expect(SRC).toMatch(/kcu\.constraint_schema = tc\.constraint_schema/);
-    expect(SRC).toMatch(/ccu\.constraint_schema = tc\.constraint_schema/);
+  it('exits 2 when the ledger at either end lists zero efcore tables', () => {
+    // An empty `efcore[]` on either side is a parse that did not work the way the caller assumes. Taking
+    // the difference anyway would make every table look newly-flipped, or none — both silently wrong.
+    const cwd = makeCwd('flip-empty-ledger', {
+      files: { 'contracts/a.json': '{}\n', 'docs/architecture/table-ownership.md': ledger([]) },
+    });
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+
+    const { code, out } = run(['--flip-diff', '--base', 'HEAD'], cwd, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/ZERO efcore\[\] tables/);
+  });
+
+  it('defaults the base ref to origin/main', () => {
+    // Pinned as a property because the tests above deliberately pass `--base HEAD` for portability.
+    expect(SRC).toMatch(/const base = baseIdx >= 0 \? argv\[baseIdx \+ 1\] : 'origin\/main'/);
+  });
+});
+
+/**
+ * Properties of the database arms. These cannot be executed under `npx vitest run`, and every one of
+ * them corresponds to a real finding or a real mutation — a source-text pin is weak, but silent rot in
+ * any of these turns a clean scan into a lie, which is worse than no scan.
+ */
+describe('pre-flip-scan — database-arm properties', () => {
+  it('every could-not-run path goes through die2, which exits 2', () => {
+    expect(SRC).toMatch(/function die2\(reason: string\): never \{[\s\S]{0,400}?process\.exit\(2\)/);
+    // writeSync, not console.error: process.exit() does not flush an async stderr pipe, and losing the
+    // reason is losing the only thing exit 2 communicates.
+    expect(SRC).toMatch(/writeSync\(\s*2,\s*`⚠ PRE-FLIP SCAN DID NOT RUN/);
+    // A thrown query is a did-not-run, not a clean result.
+    expect(SRC).toMatch(/main\(\)\.catch\(\(err\) => \{[\s\S]{0,600}?die2\(/);
+  });
+
+  it('exits 1 only when the blocker list is non-empty, and 0 only when it is empty', () => {
+    expect(SRC).toMatch(/if \(blockers\.length === 0\)[\s\S]{0,1400}?process\.exit\(0\)/);
+    expect(SRC).toMatch(/BLOCKER\(s\)[\s\S]{0,900}?process\.exit\(1\)/);
+  });
+
+  it('fingerprints the database against the Prisma schema, so an empty one cannot pass', () => {
+    // Proved for real: against an empty database this prints "only 0 of the 96 tables declared by the
+    // Prisma schema exist in this database" and exits 2.
+    expect(SRC).toMatch(/if \(present \* 2 < prismaTables\.length\)/);
+    expect(SRC).toMatch(
+      /empty database, a\s*\n?\s*\* ?restored copy or the wrong target|restored copy or the wrong target/,
+    );
+  });
+
+  it('refuses to believe an arm whose matcher could not be proved', () => {
+    expect(SRC).toMatch(/const unproven = arms\.filter\(\(a\) => a\.population > 0 && !a\.proven\)/);
+    expect(SRC).toMatch(/if \(unproven\.length > 0\)[\s\S]{0,400}?die2\(/);
+    // The proof re-runs the ARM'S OWN query against a row it must match. A proof that ran a different
+    // query would demonstrate nothing about the arm.
+    expect(SRC).toMatch(/const found = await run\(wordRe\(tokens\[0\]\)\)/);
+    expect(SRC).toMatch(/if \(found\.includes\(sample\.name\)\)/);
+  });
+
+  it('reports an empty population as NOT EXERCISED instead of as a clean result', () => {
+    expect(SRC).toMatch(/population is empty — arm NOT EXERCISED/);
+    expect(SRC).toMatch(/searched an EMPTY population and therefore proved nothing/);
+  });
+
+  it('uses the Postgres word boundary `\\y`, which `\\b` cannot replace', () => {
+    // Measured on PG 17.10: `\b` is a BACKSPACE in a Postgres advanced RE, so a `\b` matcher returns
+    // false for every input — every arm would report clean forever.
+    expect(SRC).toMatch(/const wordRe = \(t: string\): string => `\\\\y\$\{t/);
+  });
+
+  it('matches the table name exactly, so a mixed-case table is not a false "does not exist"', () => {
+    // `to_regclass('public.'||$1)` folds an unquoted name to lower case and reported
+    // `__EFMigrationsHistory` as non-existent — a false BLOCKER. Verified against the throwaway cluster.
+    expect(SRC).toMatch(/WHERE n\.nspname = 'public' AND c\.relname = \$1/);
+    expect(CODE).not.toMatch(/to_regclass\('public\.'\|\|\$1\)/);
+    expect(CODE).not.toMatch(/lower\(c\.relname\)/);
+  });
+
+  it('resolves inbound FKs by OID, so a same-named constraint elsewhere cannot become a phantom', () => {
+    // SUPERSEDED AND STRENGTHENED, not deleted. The previous version of this assertion pinned
+    // `kcu.constraint_schema = tc.constraint_schema`, a patch over `information_schema`'s non-unique
+    // `constraint_name`. `pg_constraint.confrelid` is an OID, so the ambiguity cannot arise at all —
+    // pin the stronger property rather than keep defending the older fix.
+    expect(SRC).toMatch(/con\.contype = 'f' AND con\.confrelid = \$1/);
+    expect(CODE).not.toMatch(/information_schema\.table_constraints/);
+  });
+
+  it('scans pg_depend generally, not just pg_rewrite, and only the explicit dependency edge', () => {
+    expect(SRC).toMatch(
+      /FROM pg_depend d\s*\n?\s*WHERE d\.refclassid = 'pg_class'::regclass AND d\.refobjid = \$1 AND d\.deptype = 'n'/,
+    );
+    // The classes it can name are named; whatever is left over is the bucket that needs a human.
+    expect(SRC).toMatch(
+      /const NAMED = new Set\(\['pg_rewrite', 'pg_proc', 'pg_trigger', 'pg_constraint', 'pg_policy'\]\)/,
+    );
+    expect(SRC).toMatch(/for \(const d of r\.otherDependents\) blockers\.push/);
+  });
+
+  it('blocks on views found by EITHER oracle, and reports where they disagree', () => {
+    expect(SRC).toMatch(/new Set\(\[\.\.\.r\.dependentViews, \.\.\.r\.dependentViewsByDepend\]\)/);
+    expect(SRC).toMatch(/pg_depend only/);
+    expect(SRC).toMatch(/text matcher only/);
+  });
+
+  it('classifies functions, triggers and missing tables as blockers', () => {
+    expect(SRC).toMatch(/if \(!r\.exists\) blockers\.push/);
+    expect(SRC).toMatch(/for \(const f of r\.dependentRoutines\) blockers\.push/);
+    expect(SRC).toMatch(/for \(const t of r\.triggers\) blockers\.push/);
   });
 
   it('excludes the scanned table itself from the "policies elsewhere referencing it" query', () => {
     expect(SRC).toMatch(/AND c\.relname <> \$2/);
+    // …and disables that exclusion for the self-test, or the sample could never be re-found.
+    expect(SRC).toMatch(/SENTINEL_TABLE/);
   });
 
   it('does not let a failed db.end() mask the original connection error', () => {
@@ -69,13 +414,12 @@ describe('pre-flip-scan — query correctness properties (each was a real findin
 });
 
 describe('pre-flip-scan — --json is a machine interface', () => {
-  it('emits nothing but JSON on stdout in --json mode, including on the clean path', () => {
-    // The success summary must be gated, or piping to jq breaks precisely when there is no blocker.
-    expect(SRC).toMatch(/if \(!asJson\) \{[\s\S]{0,400}?No database-side blocker/);
+  it('emits nothing but JSON on stdout, including on the clean and the no-flip paths', () => {
+    expect(SRC).toMatch(/if \(!asJson\) \{[\s\S]{0,700}?No blocker for/);
+    expect(SRC).toMatch(/asJson \? JSON\.stringify\(\{ flipDiff: true/);
   });
 
   it('sends blocker output to stderr so it cannot corrupt the JSON payload', () => {
-    const idx = SRC.indexOf('database-side BLOCKER(s)');
-    expect(SRC.slice(Math.max(0, idx - 120), idx)).toMatch(/console\.error/);
+    expect(SRC).toMatch(/writeSync\(2, `\\n✖ \$\{blockers\.length\} BLOCKER\(s\)/);
   });
 });

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -141,9 +141,23 @@ function ledger(efcore: string[]): string {
 }
 
 /** A throwaway cwd with the pinned data roots, optionally populated. */
-function makeCwd(name: string, opts: { roots?: string[]; files?: Record<string, string> } = {}): string {
+function makeCwd(
+  name: string,
+  opts: { roots?: string[]; files?: Record<string, string>; placeholders?: boolean } = {},
+): string {
   const root = join(sandbox, name);
-  for (const r of opts.roots ?? ROOTS) mkdirSync(join(root, r), { recursive: true });
+  for (const r of opts.roots ?? ROOTS) {
+    mkdirSync(join(root, r), { recursive: true });
+    // Every root gets at least one matching file. The CLI now die2s on a root that EXISTS but is EMPTY
+    // (an existing-but-empty root used to trip neither `missingRoots` nor the repo-wide
+    // `filesScanned === 0`, so it silently shrank the search population). A sandbox that creates bare
+    // directories therefore no longer models a healthy repo — it models the very defect that guard
+    // exists to catch, and would make every downstream test exit 2 for the wrong reason.
+    // `.gitkeep`-style placeholders would not do: the file must match the scanner's pinned extensions.
+    // `.json` because it is the one extension ALL four DATA_ROOTS accept (contracts also takes
+    // yaml/csv, Tims.Platform/db takes sql, the two TS roots take ts — json is the intersection).
+    if (opts.placeholders !== false) writeFileSync(join(root, r, '__placeholder.json'), '{}');
+  }
   for (const [rel, body] of Object.entries(opts.files ?? {})) {
     mkdirSync(join(root, rel.split('/').slice(0, -1).join('/')), { recursive: true });
     writeFileSync(join(root, rel), body);
@@ -210,9 +224,29 @@ describe('pre-flip-scan — exit 2 means DID NOT RUN, never a pass', { timeout: 
   });
 
   it('exits 2 when the roots exist but contain nothing to search', () => {
-    const { code, out } = run(['successors'], makeCwd('empty-roots'), { DIRECT_URL: DEAD_URL });
+    // placeholders:false — this test's whole subject is the repo-WIDE zero, and makeCwd now seeds every
+    // root by default (see its comment). With all four roots bare, the repo-wide guard fires first and
+    // owns this case; the per-root guard below covers the PARTIAL zero it cannot see.
+    const { code, out } = run(['successors'], makeCwd('empty-roots', { placeholders: false }), {
+      DIRECT_URL: DEAD_URL,
+    });
     expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
     expect(out).toMatch(/ZERO matching files/);
+  });
+
+  it('exits 2 when ONE root is present but empty — the partial zero the repo-wide guard cannot see', () => {
+    // The regression this guards: scripts/parity converting its .ts files to .mjs (the house pattern for
+    // scripts). The directory survives, so `missingRoots` stays empty; the other roots keep filesScanned
+    // comfortably non-zero, so the repo-wide guard stays quiet — and the scan silently stops searching
+    // the reader class whose entire rationale is that the parity harness reads and WRITES through raw
+    // SQL, surviving model deletion mechanically.
+    const cwd = makeCwd('one-empty-root', { placeholders: false, files: { 'contracts/a.json': '{}\n' } });
+    for (const r of ROOTS) if (r !== 'scripts/parity') writeFileSync(join(cwd, r, '__placeholder.json'), '{}');
+    const { code, out } = run(['successors'], cwd, { DIRECT_URL: DEAD_URL });
+    expect(code, `expected exit 2, got ${code}. Output:\n${out}`).toBe(2);
+    expect(out).toMatch(/present but EMPTY/);
+    expect(out).toMatch(/scripts\/parity/);
+    expect(out).toMatch(/not a pass/);
   });
 
   it('exits 2 when no connection URL is resolvable', () => {
@@ -459,6 +493,37 @@ describe('pre-flip-scan — database-arm properties', () => {
       /const NAMED = new Set\(\['pg_rewrite', 'pg_proc', 'pg_trigger', 'pg_constraint', 'pg_policy'\]\)/,
     );
     expect(SRC).toMatch(/for \(const d of r\.otherDependents\) blockers\.push/);
+  });
+
+  it('gives routines a SECOND blocking oracle, so an empty prosrc is no longer the only defence', () => {
+    // B2's residue. `pg_proc` is in NAMED, so its pg_depend edge used to route to `namedDependents` —
+    // printed under "pg_depend (named classes)" and never pushed onto `blockers`. The text arm was the
+    // ONLY blocking path for a routine, so a SQL-standard-bodied function (empty prosrc) was NAMED by
+    // the scan and then exited 0. Matched against CODE, not SRC: "pg_depend" appears in comments.
+    expect(CODE).toMatch(/const routinesByDepend = deps\.rows/);
+    expect(CODE).toMatch(/\.filter\(\(d\) => d\.cls === 'pg_proc'\)/);
+    expect(CODE).toMatch(/for \(const f of r\.dependentRoutinesByDepend\) \{/);
+    expect(CODE).toMatch(/blockers\.push\(`\$\{r\.table\}: function \$\{f\} references it \(pg_depend\)`\)/);
+  });
+
+  it('writes stdout SYNCHRONOUSLY, so a piped run cannot truncate the report', () => {
+    // Node's stdout is async when it is a pipe and process.exit() discards pending writes — the same
+    // property die2 already defends against on fd 2. Every stdout path here is immediately followed by
+    // an exit, so console.log truncates at the ~64KB pipe buffer (reproduced on darwin/node v25:
+    // 400KB console.log piped -> 65536 bytes; redirected to a file -> 400014). Matched against CODE so
+    // the explanatory comments that NAME console.log do not satisfy the pin.
+    expect(CODE).not.toMatch(/console\.log\(/);
+    expect(CODE).toMatch(/function out\(line = ''\): void \{/);
+    expect(CODE).toMatch(/writeSync\(1, `\$\{line\}\\n`\)/);
+  });
+
+  it('does NOT feed routines to oracleSplits — they are disjoint by construction, so it would cry wolf', () => {
+    // Deliberate asymmetry with views, and the reason is measured: a plpgsql or dollar-quoted
+    // `LANGUAGE sql` body records no pg_depend edge at all, while a SQL-standard body records one. The
+    // two routine oracles therefore DISAGREE for almost every function that exists, so a split line
+    // would fire forever in both directions — and a check that cries wolf gets switched off.
+    const splitBlock = CODE.slice(CODE.indexOf('const oracleSplits'), CODE.indexOf('for (const h of repo.hits'));
+    expect(splitBlock).not.toMatch(/dependentRoutines/);
   });
 
   it('blocks on views found by EITHER oracle, and reports where they disagree', () => {

--- a/tests/governance/gate-wiring.test.ts
+++ b/tests/governance/gate-wiring.test.ts
@@ -63,6 +63,12 @@ const WIRED_CHECKS: ReadonlyArray<{ check: number; script: string; runner: strin
     runner: 'npx tsx',
     what: 'app_tenant least privilege (#126)',
   },
+  {
+    check: 18,
+    script: 'scripts/db/pre-flip-scan.ts',
+    runner: 'npx tsx',
+    what: 'pre-flip dependency scan (#132)',
+  },
 ];
 
 /** The checks that need live production database credentials — the three #124 blocks from CI. */
@@ -196,6 +202,27 @@ describe('/gate check list ↔ the scripts it must run', () => {
     expect(
       /\*\*15 needs an external reviewer\*\*/.test(gate),
       `${GATE_REL} must say check 15 needs an external reviewer, so its blocker is not confused with #124's.`,
+    ).toBe(true);
+  });
+
+  it("states check 18's blocker separately again, and why a nightly job is the wrong home for it", () => {
+    // Positive pin, same reasoning as the two above: 18 is NOT part of #124's credential gap. It needs a
+    // database only when the branch actually flips a table, which is why it can sit in `/gate` and be
+    // green on ordinary PRs — and why putting it in #139's nightly sweep would produce "nothing to scan"
+    // every night forever, since a run from `main` has an empty ledger diff by construction.
+    expect(
+      /\*\*18 needs a database only on a branch that actually flips a table's owner\.\*\*/.test(gate),
+      `${GATE_REL} must state check 18's condition for needing a database. Lumping it into #124 would ` +
+        'make the credential gap look bigger than it is and would suggest a nightly job that can never ' +
+        'have anything to scan.',
+    ).toBe(true);
+
+    const row = GATE_ROWS.find((r) => r.check === 18);
+    expect(row, `${GATE_REL} has no row 18`).toBeDefined();
+    expect(
+      /Exit 1 = blocker, exit 2 = COULD NOT RUN/.test(row!.row),
+      `${GATE_REL} row 18 must spell out the 0/1/2 contract. A reader who treats exit 2 as a pass is the ` +
+        'exact failure #38, #124 and #132 all share.',
     ).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #132.

`pre-flip-scan.ts` is the control that finds the DB-side readers of a table about to be ownership-flipped — views, matviews, functions, triggers — i.e. exactly the blocker class no repo grep can see. It shipped unwired and carrying two ways to report a clean scan when it had not performed one.

## `d3441f32` — wire it, and give it its own non-vacuity controls

Wired as `/gate` check 18, with `tests/db/pre-flip-repo-scan.test.ts` asserting the repo-side population is non-empty before anything it reports is believed.

## `f2bda5c1` — two blockers

**B1 — `npx vitest run` could open a live production connection.**

`run()` builds the child env from scratch, so omitting a URL is not "no credentials": `loadDbEnv()` falls through to the **bare relative** `packages/db/.env`, resolved by Node against cwd — which that call site sets to the real repo root, where the file exists and carries the production Supabase direct URL.

It passed only because `--base HEAD` on a clean tree yields an empty ledger diff and the script exits at `:249`, before `loadDbEnv()` and `db.connect()`. **One uncommitted `efcore[]` ledger entry — the exact working-tree state of anyone authoring a flip PR, i.e. the population that runs this suite — falls through to `db.connect()` against production.**

Fixed by pinning `DIRECT_URL: DEAD_URL` at every `REPO_ROOT` call site, plus a general guard in `run()` that throws on any `REPO_ROOT` spawn with no URL. On the unintended path it now dies at `127.0.0.1:1`.

⚠️ **Do NOT "fix" this by defaulting `run()`'s `env` parameter.** Three reviewers independently traced that it breaks the two `no DIRECT_URL or DATABASE_URL` assertions and **vacates** the suite's flagship offline-safety pin — with a URL preset, `loadDbEnv()` returns on its first line and never opens the sandbox `.env`, so the test goes green while proving nothing. That is precisely the vacuous-pass class this branch exists to kill.

**B2 — a SQL-standard function body reading the flipped table was named, then the scan exited 0.**

A function declared `LANGUAGE sql BEGIN ATOMIC … END` (or the `RETURN` form; both PG14+) stores its parse tree in `pg_proc.prosqlbody` and leaves `prosrc = ''`. The text arm was the **only** blocking path for a routine, so it found nothing. Postgres _does_ record a `pg_depend` edge for a parsed SQL body — but `pg_proc` is in `NAMED`, so that edge printed as INFO and never reached `blockers`. The scan **named the reader and exited 0**.

Aggravator, same root cause: the population query counted `prosrc <> ''`, so a database whose relevant routines are all SQL-standard-bodied reports the functions arm as population 0 → `proveArm` returns `proven: true` → the unproven gate cannot fire. A second independent path to green.

Reproduced on a throwaway PG 17.10 cluster. Fixed by repairing the arm's matcher to `coalesce(p.prosrc,'') || coalesce(pg_get_function_sqlbody(p.oid)::text,'')`, moving the population and sample queries with it. `pg_get_functiondef` is deliberately **not** used — it throws on aggregates and would convert the arm into a permanent exit 2.

Exposure is latent, not live: the prod baseline shows both public functions dollar-quoted. Fixed anyway — this control's entire charter is objects no repo file describes, live DDL here is applied by hand, and prod is PG 17.

## `c2a7566f` — pin the USE of the matcher, not its definition

Tier-3 finding M1 against this branch's own `f2bda5c1`: the "three separately pinned properties" claim was overstated. The pin matched the `routineBody` **const definition**, which the sample query keeps alive, so reverting the matcher to `p.prosrc ~* $1` reintroduced B2 **with all 38 pins green**. Now pins the use site, matched against comment-stripped `CODE` rather than `SRC`.

## The four remaining findings — now CLOSED, not carried

**1. `pg_proc` had one blocking oracle where views have two.** The text arm was the only blocking path for a routine; `pg_proc` is in `NAMED`, so the `pg_depend` edge that _does_ exist for a SQL-standard body routed to `namedDependents`, printed as INFO, and never reached `blockers`. Fixed structurally, so a future matcher regression cannot reopen the live path `f2bda5c1` closed.

Routines are deliberately **NOT** added to `oracleSplits`, against the tier-3 note's suggestion and per the brief's measured reason: the two routine oracles are **disjoint by construction** (plpgsql and dollar-quoted `LANGUAGE sql` record no `pg_depend` edge; only SQL-standard bodies do), so a split line would fire for every function ever found, in both directions, forever — and a check that cries wolf gets switched off. Pinned in both directions.

**3. `proveArm` short-circuits on the first re-findable sample** — covered by the same fix. Only one of the two routine text sources is ever exercised, so a regression dropping `pg_get_function_sqlbody` would still report "population > 0, proven, 0 hits". The naive fix (require one sample of each) is **wrong**: prod plausibly has zero `prosqlbody` routines, which would make the arm a permanent NOT EXERCISED — the exact vacuity this branch exists to kill. A second independent oracle has no such failure mode.

**2. `main()` now dies on a per-ROOT zero.** An existing-but-empty root yields `{present: true, files: 0}` and tripped neither `missingRoots` nor the repo-wide `filesScanned === 0`. Reachable drift: `scripts/parity` converting to `.mjs` silently zeroes the one root whose whole rationale is that the parity harness reads and **writes** through raw SQL and so survives model deletion mechanically.

> The brief argued **against** `die2` here, because `services/Tims.Platform/db` holds ~7 artifacts due to be archived when the flips finish, and a hard fail would then block a production flip for a non-safety reason. That objection is real, so the remedy is named inline: drop that root from `DATA_ROOTS` in the same PR that archives it, so a shrinking search population is a **reviewed** decision rather than a silent one. Ordering is preserved — the repo-wide zero is still checked first and owns the all-roots-bare case.

**4. stdout is written synchronously.** All 29 `console.log` sites move to a single `writeSync(1, …)` helper. `process.exitCode` is deliberately not used instead: a lingering handle would turn a fail-closed control into a **hang**.

### Test-fixture consequence worth a reviewer's eye

`makeCwd()` now seeds every root with a matching file. Bare directories no longer model a healthy repo — they model the exact defect fix 2 catches, and would have made every downstream test exit 2 for the wrong reason. The one test whose subject **is** the repo-wide zero opts out via `placeholders: false`, and a new test covers the partial zero.

Three more mutation proofs, same method: delete the `pg_proc` oracle → 1 red; delete the per-root die → 1 red; revert one `out()` to `console.log` → 1 red.

## Verification

**Tier that actually ran: 3 (same-model adversarial panel). This is NOT cross-model review.**

- **Tier 1 (Codex, `/gate` check 15): exit 2 — NOT RUN.** Quota-blocked; the CLI's own message names 2026-08-15. Exit 2 is not a pass. Re-confirmed 2026-08-07 — 7th consecutive exit 2.
- **Tier 2 (OmniRoute, different-vendor): exit 2 — refused to run.** `OMNIROUTE_MODEL` unset, no default since 2026-08-05; the script refuses rather than silently downgrading.
- **Tier 3 substitute executed:** 3-lens panel (security/tenant-isolation · claim auditor · coverage), each prompted to refute and re-reading source at the commit blobs. **Zero blocking findings.** It produced M1 (fixed in `c2a7566f`), M2 (the untested `relkind` blocker), and the four open items above. It also **refuted** two claims raised against this branch — that it reverts #148 (the merge tree was computed read-only and inspected; every evaluation360 artifact stays byte-identical to main) and that `loadDbEnv()` "still exposes every entry point".

Panel limitations, stated rather than buried: read-only, no execution, no live DB arm. Claims about behaviour against a real Postgres are derived from the SQL text, not observed.

## Rebased, and the anchor is measured

Rebased onto `7d4a2298`. The one conflict was `gate.md`'s check table — main and this branch had both edited it. Resolved to main's 17 rows plus this branch's row 18, then the anchor **re-measured** rather than carried from either side.

**`npx vitest run` on the rebased branch, nothing else on the machine, redirected with `$?` checked, never piped: 2770 passing across 291 files, exit 0.**

The previous anchor of 2787/292 was derived on the pre-#148 lineage — stale **high**, which under "more is fine, fewer is a failure" would have failed loud for whoever ran `/gate` after merge.

⚠️ Worth knowing for anyone re-running this: the first run reported 2 failures in the evaluation360 schema and governance tests. **Not a regression** — this worktree's generated Prisma client predated flip #67 and still carried the deleted models. `prisma generate` then gave 2770/2770. A stale client in a worktree looks exactly like a real breakage.
