### PR TITLE
fix(api): tenantDb.$transaction never rolled back — 16 sites (#45)

### DIFF
--- a/packages/api/src/repositories/candidate.repository.ts
+++ b/packages/api/src/repositories/candidate.repository.ts
@@ -1,4 +1,4 @@
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 
 // ---------------------------------------------------------------------------
@@ -418,37 +418,51 @@ export const candidateRepository = {
   },
 
   // Merge (transaction)
-  async merge(primaryId: string, duplicateId: string) {
+  //
+  // `orgId` is required for the transaction, not for filtering: runTenantTransaction
+  // needs it to set the RLS role + `app.current_org_id` GUC once for the whole tx.
+  // The caller (candidate.service.merge) has already org-verified BOTH ids via
+  // candidateRepository.exists(orgId, …), and RLS re-scopes every write below.
+  //
+  // #45 / prisma/prisma#17948: this was `db.$transaction([...])` where `db` is
+  // `tenantDb`. The BATCH form is broken the same way the interactive form is —
+  // each element is re-wrapped by the tenantDb extension into its own
+  // mini-transaction and commits independently. Reproduced on a local PG17
+  // cluster 2026-08-06: a failing 2nd element left the 1st element COMMITTED.
+  // For a 6-step merge that meant a candidate could end up with documents and
+  // tags reparented while the duplicate stayed live and un-deleted — a
+  // half-merged pair with no way to tell which steps ran.
+  async merge(orgId: string, primaryId: string, duplicateId: string) {
     const existingPrimaryTags = await db.candidateTag.findMany({
       where: { candidateId: primaryId },
       select: { tag: true },
     });
     const primaryTagSet = new Set(existingPrimaryTags.map((t) => t.tag));
 
-    return db.$transaction([
-      db.candidateDocument.updateMany({
+    return runTenantTransaction(orgId, async (tx) => {
+      await tx.candidateDocument.updateMany({
         where: { candidateId: duplicateId },
         data: { candidateId: primaryId },
-      }),
-      db.candidateTag.deleteMany({
+      });
+      await tx.candidateTag.deleteMany({
         where: { candidateId: duplicateId, tag: { in: [...primaryTagSet] } },
-      }),
-      db.candidateTag.updateMany({
+      });
+      await tx.candidateTag.updateMany({
         where: { candidateId: duplicateId },
         data: { candidateId: primaryId },
-      }),
-      db.assessmentAssignment.updateMany({
+      });
+      await tx.assessmentAssignment.updateMany({
         where: { candidateId: duplicateId },
         data: { candidateId: primaryId },
-      }),
-      db.fitScore.deleteMany({
+      });
+      await tx.fitScore.deleteMany({
         where: { candidateId: duplicateId },
-      }),
-      db.candidate.update({
+      });
+      await tx.candidate.update({
         where: { id: duplicateId },
         data: { deletedAt: new Date(), isActive: false },
-      }),
-    ]);
+      });
+    });
   },
 
   async getAfterMerge(id: string) {

--- a/packages/api/src/repositories/pipeline.repository.ts
+++ b/packages/api/src/repositories/pipeline.repository.ts
@@ -1,4 +1,4 @@
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 
 // ---------------------------------------------------------------------------
@@ -122,10 +122,7 @@ export const pipelineRepository = {
   async countApplicationsInScope(orgId: string, applicationIds: string[], scopeWhere: Prisma.ApplicationWhereInput) {
     return db.application.count({
       where: {
-        AND: [
-          { id: { in: applicationIds }, organizationId: orgId },
-          scopeWhere,
-        ],
+        AND: [{ id: { in: applicationIds }, organizationId: orgId }, scopeWhere],
       },
     });
   },
@@ -154,7 +151,10 @@ export const pipelineRepository = {
     toStageId: string,
     reason?: string,
   ) {
-    return db.$transaction(async (tx) => {
+    // runTenantTransaction, not db.$transaction (#45 / prisma#17948): `db` is
+    // `tenantDb`, whose extension re-wraps each op in its own mini-transaction, so
+    // the movement audit row and the stage flip were committing independently.
+    return runTenantTransaction(orgId, async (tx) => {
       await tx.stageMovement.create({
         data: {
           organizationId: orgId,
@@ -182,7 +182,9 @@ export const pipelineRepository = {
     toStageId: string,
     reason?: string,
   ) {
-    return db.$transaction(async (tx) => {
+    // runTenantTransaction per #45 (prisma#17948) — a bulk move must not leave
+    // movement rows written with the applications un-moved (or vice versa).
+    return runTenantTransaction(orgId, async (tx) => {
       await tx.stageMovement.createMany({
         data: applications.map((app) => ({
           organizationId: orgId,
@@ -238,10 +240,17 @@ export const pipelineRepository = {
     });
   },
 
-  async createStage(orgId: string, data: {
-    vacancyId: string; name: string; order: number;
-    slaHours?: number; checklist?: unknown; isDefault: boolean;
-  }) {
+  async createStage(
+    orgId: string,
+    data: {
+      vacancyId: string;
+      name: string;
+      order: number;
+      slaHours?: number;
+      checklist?: unknown;
+      isDefault: boolean;
+    },
+  ) {
     return db.pipelineStage.create({
       data: {
         organizationId: orgId,
@@ -249,7 +258,7 @@ export const pipelineRepository = {
         name: data.name,
         order: data.order,
         slaHours: data.slaHours,
-        checklist: data.checklist as Prisma.InputJsonValue ?? undefined,
+        checklist: (data.checklist as Prisma.InputJsonValue) ?? undefined,
         isDefault: data.isDefault,
       },
       select: stageMutationSelect,

--- a/packages/api/src/routers/interview/crud.ts
+++ b/packages/api/src/routers/interview/crud.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { emailService } from '../../services/email.service';
@@ -19,7 +19,7 @@ export const interviewCrudRouter = router({
         to: z.date().optional(),
         page: z.number().int().min(1).default(1),
         pageSize: z.number().int().min(1).max(100).default(20),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { page, pageSize, ...filters } = input;
@@ -124,7 +124,7 @@ export const interviewCrudRouter = router({
         meetingUrl: z.string().url().max(2048).optional(),
         notes: z.string().max(5000).optional(),
         evaluatorIds: z.array(z.string().uuid()).min(1).max(100),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { evaluatorIds, ...data } = input;
@@ -150,11 +150,19 @@ export const interviewCrudRouter = router({
         await assertScoped('application', input.applicationId, ctx.access, ctx.user.id, orgId);
         // Integrity: the application must bind the SAME candidate and vacancy.
         const bound = await db.application.findFirst({
-          where: { id: input.applicationId, organizationId: orgId, candidateId: input.candidateId, vacancyId: input.vacancyId },
+          where: {
+            id: input.applicationId,
+            organizationId: orgId,
+            candidateId: input.candidateId,
+            vacancyId: input.vacancyId,
+          },
           select: { id: true },
         });
         if (!bound) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'La aplicacion no corresponde al candidato y la vacante indicados' });
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'La aplicacion no corresponde al candidato y la vacante indicados',
+          });
         }
       } else {
         // Codex round-3: an omitted applicationId must not bypass the
@@ -233,7 +241,7 @@ export const interviewCrudRouter = router({
         location: z.string().max(500).optional(),
         meetingUrl: z.string().url().max(2048).optional(),
         notes: z.string().max(5000).optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
@@ -244,10 +252,7 @@ export const interviewCrudRouter = router({
       // it with a bare assertScoped (would lose those fields).
       const existing = await db.interview.findFirst({
         where: {
-          AND: [
-            { id, organizationId: ctx.user.organizationId },
-            scopeWhere as Prisma.InterviewWhereInput,
-          ],
+          AND: [{ id, organizationId: ctx.user.organizationId }, scopeWhere as Prisma.InterviewWhereInput],
         },
       });
 
@@ -303,11 +308,13 @@ export const interviewCrudRouter = router({
   // ── Evaluator (committee panel) management on an EXISTING interview ───
   // Populates InterviewEvaluator, the anchor panelInterviewIds() reads.
   addEvaluator: permissionProcedure('interview', 'update')
-    .input(z.object({
-      interviewId: z.string().uuid(),
-      userId: z.string().uuid(),
-      role: z.string().max(50).default('evaluator'),
-    }))
+    .input(
+      z.object({
+        interviewId: z.string().uuid(),
+        userId: z.string().uuid(),
+        role: z.string().max(50).default('evaluator'),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       // SCOPED probe — replaces the prior org-only parent existence check. The
       // InterviewEvaluator row is a committee-arm anchor (grants future read
@@ -316,7 +323,10 @@ export const interviewCrudRouter = router({
       // throws NOT_FOUND unless the interview is already in the caller's scope.
       await assertScoped('interview', input.interviewId, ctx.access, ctx.user.id, ctx.user.organizationId);
       try {
-        return await db.$transaction(async (tx) => {
+        // runTenantTransaction, not db.$transaction (#45 / prisma#17948) — the
+        // org-membership check and the evaluator insert must share one tx, or the
+        // check is a TOCTOU read on a different connection.
+        return await runTenantTransaction(ctx.user.organizationId, async (tx) => {
           const user = await tx.user.findFirst({
             where: { id: input.userId, organizationId: ctx.user.organizationId },
             select: { id: true },
@@ -353,7 +363,7 @@ export const interviewCrudRouter = router({
       z.object({
         id: z.string().uuid(),
         cancelReason: z.string().min(1).max(1000),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       // assertScoped replaces the bare org-check findFirst — cancel only uses

--- a/packages/api/src/routers/offer/approvals.ts
+++ b/packages/api/src/routers/offer/approvals.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { scopeWhereFor, assertScoped } from '../../access';
@@ -13,7 +13,7 @@ export const offerApprovalsRouter = router({
       z.object({
         id: z.string().uuid(),
         approverIds: z.array(z.string().uuid()).max(100).min(1),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const scopeWhere = await scopeWhereFor('offer', ctx.access, ctx.user.id);
@@ -22,10 +22,7 @@ export const offerApprovalsRouter = router({
       // the draft-guard below, so we must preserve that field.
       const offer = await db.offer.findFirst({
         where: {
-          AND: [
-            { id: input.id, organizationId: ctx.user.organizationId },
-            scopeWhere as Prisma.OfferWhereInput,
-          ],
+          AND: [{ id: input.id, organizationId: ctx.user.organizationId }, scopeWhere as Prisma.OfferWhereInput],
         },
       });
 
@@ -40,7 +37,9 @@ export const offerApprovalsRouter = router({
         });
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction, not db.$transaction (#45 / prisma#17948) — `db` is
+      // `tenantDb`, so the outer wrapper never made these writes atomic.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         // Create approval chain
         await tx.offerApproval.createMany({
           data: input.approverIds.map((approverId, index) => ({
@@ -74,7 +73,7 @@ export const offerApprovalsRouter = router({
       z.object({
         id: z.string().uuid(),
         comment: z.string().max(20000).optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       // Probe the offer through scope before acting on the approval record.
@@ -96,7 +95,9 @@ export const offerApprovalsRouter = router({
         });
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction per #45 (prisma#17948) — the approval flip + the
+      // conditional offer-status flip must commit or roll back together.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         await tx.offerApproval.update({
           where: { id: approval.id },
           data: {
@@ -132,7 +133,7 @@ export const offerApprovalsRouter = router({
       z.object({
         id: z.string().uuid(),
         comment: z.string().max(20000).min(1),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       // Probe the offer through scope before acting on the approval record.
@@ -154,7 +155,8 @@ export const offerApprovalsRouter = router({
         });
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction per #45 (prisma#17948).
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         await tx.offerApproval.update({
           where: { id: approval.id },
           data: {

--- a/packages/api/src/routers/offer/lifecycle.ts
+++ b/packages/api/src/routers/offer/lifecycle.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { resolveStaffSupabaseUserId } from '../../services/staff-provisioning.service';
@@ -25,7 +25,7 @@ export const offerLifecycleRouter = router({
         companyId: z.string().uuid().optional(),
         businessUnitId: z.string().uuid().optional(),
         teamId: z.string().uuid().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const scopeWhere = await scopeWhereFor('offer', ctx.access, ctx.user.id);
@@ -35,10 +35,7 @@ export const offerLifecycleRouter = router({
       // Cannot use assertScoped alone as those fields would be lost.
       const offer = await db.offer.findFirst({
         where: {
-          AND: [
-            { id: input.offerId, organizationId: ctx.user.organizationId },
-            scopeWhere as Prisma.OfferWhereInput,
-          ],
+          AND: [{ id: input.offerId, organizationId: ctx.user.organizationId }, scopeWhere as Prisma.OfferWhereInput],
         },
         include: {
           candidate: true,
@@ -89,7 +86,10 @@ export const offerLifecycleRouter = router({
         offer.vacancyId,
       );
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction, not db.$transaction (#45 / prisma#17948): `db` is
+      // `tenantDb`, so the outer wrapper never composed and this multi-write hire
+      // flow (user + onboarding plan + tasks + offer status) was not atomic.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         // Create the user record, linked to its Supabase identity from birth.
         const newUser = await tx.user.create({
           data: {

--- a/packages/api/src/routers/organization.ts
+++ b/packages/api/src/routers/organization.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure, permissionProcedure } from '../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import {
   createOrganizationSchema,
   updateOrganizationSchema,
@@ -187,7 +187,9 @@ export const organizationRouter = router({
     .input(z.object({ userId: z.string().uuid(), businessUnitId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       try {
-        return await db.$transaction(async (tx) => {
+        // runTenantTransaction, not db.$transaction (#45 / prisma#17948) — the
+        // tenantDb extension makes an outer $transaction a no-op wrapper.
+        return await runTenantTransaction(ctx.user.organizationId, async (tx) => {
           const [unit, user] = await Promise.all([
             tx.businessUnit.findFirst({
               where: { id: input.businessUnitId, organizationId: ctx.user.organizationId },
@@ -250,14 +252,12 @@ export const organizationRouter = router({
     // Auto re-show after 7 days if the checklist is still incomplete — a
     // read-time projection only, never mutates the stored dismissal.
     const isStale =
-      dismissedAt !== null &&
-      !allComplete &&
-      Date.now() - dismissedAt.getTime() > SETUP_STATUS_REOPEN_AFTER_MS;
+      dismissedAt !== null && !allComplete && Date.now() - dismissedAt.getTime() > SETUP_STATUS_REOPEN_AFTER_MS;
 
     return {
       items,
       allComplete,
-      dismissedAt: isStale ? null : dismissedAt?.toISOString() ?? null,
+      dismissedAt: isStale ? null : (dismissedAt?.toISOString() ?? null),
     };
   }),
 

--- a/packages/api/src/routers/user.ts
+++ b/packages/api/src/routers/user.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure, permissionProcedure } from '../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import { createUserSchema, updateProfileSchema, assignRoleSchema } from '@tims/shared';
 import { invalidatePermissionCache } from '../lib/cache';
 import { logSecurityEvent } from '../access/security-audit';
@@ -162,8 +162,11 @@ export const userRouter = router({
       // before the tx since it's an external call.
       const supabaseUserId = await resolveStaffSupabaseUserId(userData.email);
 
-      // Create user + role assignment in transaction
-      const created = await db.$transaction(async (tx) => {
+      // Create user + role assignment in ONE transaction. runTenantTransaction, not
+      // db.$transaction: `db` is `tenantDb`, whose extension re-wraps every op in its
+      // own mini-transaction, so an outer tenantDb.$transaction does not compose
+      // (prisma/prisma#17948, #45) -- a failure here used to leave a roleless user.
+      const created = await runTenantTransaction(ctx.user.organizationId, async (tx) => {
         const user = await tx.user.create({
           data: {
             ...userData,

--- a/packages/api/src/routers/vacancy/approvals.ts
+++ b/packages/api/src/routers/vacancy/approvals.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { scopeWhereFor, assertScoped, buildAccessForUser, createAnchorLoader } from '../../access';
@@ -32,10 +32,12 @@ const vacancyWithApprovalsSelect = {
 
 export const vacancyApprovalsRouter = router({
   submitForApproval: permissionProcedure('vacancy', 'update')
-    .input(z.object({
-      id: z.string().uuid(),
-      approverIds: z.array(z.string().uuid()).min(1).max(10),
-    }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        approverIds: z.array(z.string().uuid()).min(1).max(10),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.id, ctx.access, ctx.user.id, ctx.user.organizationId);
 
@@ -110,7 +112,15 @@ export const vacancyApprovalsRouter = router({
         }
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction, NOT db.$transaction: `db` here is `tenantDb`, whose
+      // $allOperations extension gives every op its OWN mini-transaction on the base
+      // client (tenant-client.ts:40). An outer tenantDb.$transaction therefore does
+      // NOT compose — each write commits independently (prisma/prisma#17948), so a
+      // mid-way failure left the vacancy in pending_approval with no approval rows.
+      // Reproduced on a local PG17 cluster 2026-08-06 (#45): after a deliberate
+      // failure the old code left status=pending_approval + 1 approval row COMMITTED;
+      // runTenantTransaction left status=draft + 0 rows.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         await tx.vacancy.update({
           where: { id: input.id },
           data: { status: 'pending_approval' },
@@ -134,10 +144,12 @@ export const vacancyApprovalsRouter = router({
     }),
 
   approve: permissionProcedure('vacancy', 'approve')
-    .input(z.object({
-      id: z.string().uuid(),
-      comment: z.string().max(1000).optional(),
-    }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        comment: z.string().max(1000).optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.id, ctx.access, ctx.user.id, ctx.user.organizationId);
 
@@ -158,7 +170,10 @@ export const vacancyApprovalsRouter = router({
       // between them could leave the vacancy's status inconsistent with its
       // approvals. Wrap in one transaction; the final read stays outside (it's a
       // read, and reflects whatever the transaction committed).
-      await db.$transaction(async (tx) => {
+      // NOTE (#45): that wrapping was `db.$transaction` = `tenantDb.$transaction`,
+      // which does NOT compose (prisma/prisma#17948) -- the finding above was
+      // therefore still open. runTenantTransaction is the construct that closes it.
+      await runTenantTransaction(ctx.user.organizationId, async (tx) => {
         await tx.vacancyApproval.update({
           where: { id: approval.id },
           data: { status: 'approved', comment: input.comment, decidedAt: new Date() },
@@ -183,10 +198,12 @@ export const vacancyApprovalsRouter = router({
     }),
 
   reject: permissionProcedure('vacancy', 'approve')
-    .input(z.object({
-      id: z.string().uuid(),
-      comment: z.string().min(1).max(1000),
-    }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        comment: z.string().min(1).max(1000),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.id, ctx.access, ctx.user.id, ctx.user.organizationId);
 
@@ -202,7 +219,11 @@ export const vacancyApprovalsRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'No hay aprobacion pendiente para este usuario' });
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction per #45 — see submitForApproval above. This block is the
+      // worst of the three under the old code: reject did status->draft, then
+      // cancelled the remaining pending approvals. A failure between those two left
+      // the vacancy in `draft` with live `pending` approvals attached.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         await tx.vacancyApproval.update({
           where: { id: approval.id },
           data: { status: 'rejected', comment: input.comment, decidedAt: new Date() },

--- a/packages/api/src/routers/vacancy/channels.ts
+++ b/packages/api/src/routers/vacancy/channels.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { scopeWhereFor, assertScoped } from '../../access';
@@ -42,11 +42,13 @@ export const vacancyChannelsRouter = router({
     }),
 
   publish: permissionProcedure('vacancy', 'publish')
-    .input(z.object({
-      vacancyId: z.string().uuid(),
-      channelName: z.string().min(1).max(100),
-      channelType: z.enum(['internal', 'linkedin', 'indeed', 'computrabajo', 'elempleo', 'website', 'other']),
-    }))
+    .input(
+      z.object({
+        vacancyId: z.string().uuid(),
+        channelName: z.string().min(1).max(100),
+        channelType: z.enum(['internal', 'linkedin', 'indeed', 'computrabajo', 'elempleo', 'website', 'other']),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.vacancyId, ctx.access, ctx.user.id, ctx.user.organizationId);
 
@@ -70,7 +72,9 @@ export const vacancyChannelsRouter = router({
       // status-update were two separate writes -- a failure between them could
       // leave a published channel on a non-published vacancy, or risk a
       // duplicate channel on client retry. Wrap in one transaction.
-      return db.$transaction(async (tx) => {
+      // NOTE (#45): that wrapping was `db.$transaction` where `db` is `tenantDb`,
+      // which does not compose (prisma/prisma#17948) — finding #4 was still open.
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         const channel = await tx.publicationChannel.create({
           data: {
             organizationId: ctx.user.organizationId,

--- a/packages/api/src/routers/vacancy/crud.ts
+++ b/packages/api/src/routers/vacancy/crud.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { router, permissionProcedure } from '../../trpc';
-import { tenantDb as db } from '@tims/db';
+import { tenantDb as db, runTenantTransaction } from '@tims/db';
 import type { Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
 import { scopeWhereFor, assertScoped, buildAccessForUser } from '../../access';
@@ -105,19 +105,23 @@ const vacancyMutationSelect = {
 // Shared Zod schemas
 // ---------------------------------------------------------------------------
 
-const salarySchema = z.object({
-  min: z.number().min(0).optional(),
-  max: z.number().min(0).optional(),
-  currency: z.string().max(10).default('COP'),
-  period: z.enum(['monthly', 'yearly']).default('monthly'),
-}).optional();
+const salarySchema = z
+  .object({
+    min: z.number().min(0).optional(),
+    max: z.number().min(0).optional(),
+    currency: z.string().max(10).default('COP'),
+    period: z.enum(['monthly', 'yearly']).default('monthly'),
+  })
+  .optional();
 
-const settingsSchema = z.object({
-  slaTargetDays: z.number().int().min(1).max(365).optional(),
-  autoPublish: z.boolean().optional(),
-  requireApproval: z.boolean().optional(),
-  notifyOnApply: z.boolean().optional(),
-}).optional();
+const settingsSchema = z
+  .object({
+    slaTargetDays: z.number().int().min(1).max(365).optional(),
+    autoPublish: z.boolean().optional(),
+    requireApproval: z.boolean().optional(),
+    notifyOnApply: z.boolean().optional(),
+  })
+  .optional();
 
 const createVacancyInput = z.object({
   title: z.string().min(1).max(200),
@@ -294,7 +298,9 @@ export const vacancyCrudRouter = router({
           });
         }
 
-        return db.$transaction(async (tx) => {
+        // runTenantTransaction, not db.$transaction (#45 / prisma#17948) — create +
+        // channel + publish must not be able to half-apply.
+        return runTenantTransaction(ctx.user.organizationId, async (tx) => {
           const vacancy = await tx.vacancy.create({
             data: baseData,
             select: vacancyMutationSelect,
@@ -344,10 +350,12 @@ export const vacancyCrudRouter = router({
     }),
 
   close: permissionProcedure('vacancy', 'update')
-    .input(z.object({
-      id: z.string().uuid(),
-      reason: z.string().min(1).max(1000),
-    }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        reason: z.string().min(1).max(1000),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await assertScoped('vacancy', input.id, ctx.access, ctx.user.id, ctx.user.organizationId);
 
@@ -428,7 +436,9 @@ export const vacancyCrudRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Vacante no encontrada' });
       }
 
-      return db.$transaction(async (tx) => {
+      // runTenantTransaction, not db.$transaction (#45 / prisma#17948) — a duplicate
+      // must not half-copy (vacancy without its job profile / stages).
+      return runTenantTransaction(ctx.user.organizationId, async (tx) => {
         const newVacancy = await tx.vacancy.create({
           data: {
             title: `${original.title} (copia)`,

--- a/packages/api/src/services/candidate.service.ts
+++ b/packages/api/src/services/candidate.service.ts
@@ -252,7 +252,7 @@ export const candidateService = {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Uno o ambos candidatos no encontrados' });
     }
 
-    await candidateRepository.merge(primaryId, duplicateId);
+    await candidateRepository.merge(orgId, primaryId, duplicateId);
     return candidateRepository.getAfterMerge(primaryId);
   },
 

--- a/tests/governance/tenant-transaction-composition.test.ts
+++ b/tests/governance/tenant-transaction-composition.test.ts
@@ -143,13 +143,18 @@ for (const file of ALL_FILES) {
 
 /**
  * Named artifacts. Auto-discovery alone would make DELETING a fixed file a green
- * change; these three are the sites #45 was filed against, and each must keep
+ * change; these are the sites #45 was filed against, and each must keep
  * using runTenantTransaction. If a file is legitimately removed, delete its entry
  * DELIBERATELY rather than letting the scan silently stop covering it.
+ *
+ * `packages/api/src/repositories/evaluation360.repository.ts` was pinned here and is
+ * removed under exactly that rule, not to make a red test green: #148 deleted the
+ * orphaned evaluation360 TS outright, and main now asserts its ABSENCE at
+ * tests/governance/evaluation360-no-ts-writers.test.ts:546-547. Its 2 sites are why
+ * this branch fixes 16 rather than the 18 it was written against.
  */
 const PINNED = [
   'packages/api/src/routers/vacancy/approvals.ts',
-  'packages/api/src/repositories/evaluation360.repository.ts',
   'packages/api/src/repositories/pipeline.repository.ts',
 ];
 

--- a/tests/governance/tenant-transaction-composition.test.ts
+++ b/tests/governance/tenant-transaction-composition.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// #45 — the `tenantDb.$transaction` tripwire (prisma/prisma#17948).
+//
+// WHY THIS EXISTS. `tenantDb` is `db.$extends({ query: { $allOperations } })`
+// (packages/db/src/tenant-client.ts:23). When RLS is enforced, that extension wraps
+// EVERY operation in its own `db.$transaction([SET LOCAL ROLE, set_config, query])`
+// on the closed-over BASE client. Composing that with an outer `tenantDb.$transaction`
+// therefore does not produce one atomic unit — each nested op still commits
+// independently. Multi-step writes that LOOK atomic are not.
+//
+// MEASURED, NOT ASSUMED (2026-08-06, throwaway PostgreSQL 17 cluster, RLS_ENFORCED=true,
+// prod-shaped `tenant_isolation` policy copied from packages/db/baseline/prod-public-schema.sql):
+//
+//   construct                        after a deliberate mid-block failure
+//   -------------------------------  ---------------------------------------------
+//   tenantDb.$transaction(cb)        status=pending_approval, approvals=1  <- COMMITTED
+//   tenantDb.$transaction([ ... ])    status=pending_approval               <- COMMITTED
+//   runTenantTransaction(orgId, cb)  status=draft,            approvals=0  <- rolled back
+//
+// RLS scoping was intact in all three forms; atomicity was not. So this is an
+// atomicity/data-integrity tripwire, not a tenant-isolation one.
+//
+// WHY A DEDICATED SCAN RATHER THAN THE EXISTING CHECK. tests/portal/candidate-procedure.test.ts
+// already asserts `not.toMatch(/tenantDb\.\$transaction/)` for ONE service. That regex
+// cannot see the form this repo actually uses everywhere else:
+//
+//     import { tenantDb as db } from '@tims/db';
+//     return db.$transaction(async (tx) => { ... });
+//
+// Every one of the 18 real call sites found for #45 was written that way, and every one
+// of them was invisible to a literal `tenantDb.$transaction` grep. This file resolves the
+// local alias per file first, then looks for `<alias>.$transaction`.
+
+const ROOT = join(__dirname, '..', '..');
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.claude',
+  '.next',
+  '.turbo',
+  '.vercel',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  'generated',
+  'bin',
+  'obj',
+]);
+
+/** This file quotes the forbidden construct, so it must never scan itself. */
+const SELF = 'tests/governance/tenant-transaction-composition.test.ts';
+
+function walk(rel: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(join(ROOT, rel) || ROOT);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (SKIP_DIRS.has(name)) continue;
+    const childRel = rel ? `${rel}/${name}` : name;
+    let st;
+    try {
+      st = statSync(join(ROOT, childRel));
+    } catch {
+      continue; // broken symlink
+    }
+    if (st.isDirectory()) {
+      walk(childRel, out);
+    } else if (/\.(ts|tsx|mts|cts)$/.test(name) && childRel !== SELF) {
+      out.push(childRel);
+    }
+  }
+}
+
+const ALL_FILES: string[] = [];
+walk('', ALL_FILES);
+
+/** Tests legitimately mock `tenantDb.$transaction` to prove it is NOT used. */
+const isTest = (f: string) => f.startsWith('tests/') || /\.(test|spec)\.(ts|tsx|mts|cts)$/.test(f);
+
+/**
+ * The local binding `tenantDb` was imported under, or null if this file does not
+ * import it. Handles both `{ tenantDb }` and `{ tenantDb as db }`, including
+ * multi-specifier and multi-line import statements.
+ */
+function tenantAlias(text: string): string | null {
+  const imports = text.matchAll(/import\s*(?:type\s*)?\{([\s\S]*?)\}\s*from\s*['"]([^'"]+)['"]/g);
+  for (const m of imports) {
+    const source = m[2];
+    if (source !== '@tims/db' && !/(^|\/)tenant-client$/.test(source) && !/(^|\/)db\/src(\/index)?$/.test(source)) {
+      continue;
+    }
+    for (const spec of m[1].split(',')) {
+      const named = spec.trim().match(/^tenantDb(?:\s+as\s+([A-Za-z_$][\w$]*))?$/);
+      if (named) return named[1] ?? 'tenantDb';
+    }
+  }
+  return null;
+}
+
+/** Strips // and /* *\/ comments so a comment ABOUT the construct is not a violation. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+interface Violation {
+  file: string;
+  alias: string;
+  line: number;
+  snippet: string;
+}
+
+const SCANNED: { file: string; alias: string }[] = [];
+const VIOLATIONS: Violation[] = [];
+
+for (const file of ALL_FILES) {
+  if (isTest(file)) continue;
+  let text: string;
+  try {
+    text = readFileSync(join(ROOT, file), 'utf8');
+  } catch {
+    continue;
+  }
+  const alias = tenantAlias(text);
+  if (!alias) continue;
+  SCANNED.push({ file, alias });
+
+  const code = stripComments(text);
+  const pattern = new RegExp(String.raw`(^|[^\w$.])${alias}\s*\.\s*\$transaction\b`);
+  code.split('\n').forEach((lineText, i) => {
+    if (pattern.test(lineText)) {
+      VIOLATIONS.push({ file, alias, line: i + 1, snippet: lineText.trim() });
+    }
+  });
+}
+
+/**
+ * Named artifacts. Auto-discovery alone would make DELETING a fixed file a green
+ * change; these three are the sites #45 was filed against, and each must keep
+ * using runTenantTransaction. If a file is legitimately removed, delete its entry
+ * DELIBERATELY rather than letting the scan silently stop covering it.
+ */
+const PINNED = [
+  'packages/api/src/routers/vacancy/approvals.ts',
+  'packages/api/src/repositories/evaluation360.repository.ts',
+  'packages/api/src/repositories/pipeline.repository.ts',
+];
+
+describe('tenantDb.$transaction must never be used for multi-step writes (#45, prisma#17948)', () => {
+  // NON-VACUITY. Every assertion below is "we found no violations". That is exactly
+  // the shape that passes when the scanner is broken and sees nothing at all, so
+  // establish the scanner has real reach BEFORE trusting an empty result.
+  it('scans a non-trivial number of real tenantDb consumers (non-vacuity guard)', () => {
+    expect(ALL_FILES.length).toBeGreaterThan(500);
+    // 50+ runtime files import tenantDb today; a collapse to near-zero means the
+    // alias resolver or the walker broke, not that the codebase stopped using it.
+    expect(SCANNED.length).toBeGreaterThan(30);
+    // The aliased form is the dominant one and the one a naive grep misses.
+    expect(SCANNED.filter((s) => s.alias !== 'tenantDb').length).toBeGreaterThan(10);
+  });
+
+  it('resolves the `tenantDb as db` alias (proves the matcher sees the form a literal grep misses)', () => {
+    // Self-test of the resolver against the exact construct the codebase writes,
+    // rather than against a pattern invented here.
+    expect(tenantAlias("import { tenantDb as db } from '@tims/db';")).toBe('db');
+    expect(tenantAlias("import { tenantDb } from '@tims/db';")).toBe('tenantDb');
+    expect(tenantAlias("import { tenantDb as db, runTenantTransaction } from '@tims/db';")).toBe('db');
+    expect(tenantAlias("import { db } from '@tims/db';")).toBeNull();
+    // And the matcher itself flags the aliased call.
+    const alias = tenantAlias("import { tenantDb as db } from '@tims/db';")!;
+    expect(
+      new RegExp(String.raw`(^|[^\w$.])${alias}\s*\.\s*\$transaction\b`).test(
+        '  return db.$transaction(async (tx) => {',
+      ),
+    ).toBe(true);
+  });
+
+  it('has zero runtime call sites', () => {
+    const report = VIOLATIONS.map((v) => `${v.file}:${v.line} (alias '${v.alias}') -> ${v.snippet}`).join('\n');
+    expect(report).toBe('');
+  });
+
+  it.each(PINNED)('%s exists and routes its multi-step writes through runTenantTransaction', (file) => {
+    expect(existsSync(join(ROOT, file))).toBe(true);
+    const code = stripComments(readFileSync(join(ROOT, file), 'utf8'));
+    expect(code).toContain('runTenantTransaction');
+    const alias = tenantAlias(readFileSync(join(ROOT, file), 'utf8'));
+    expect(alias).not.toBeNull();
+    expect(new RegExp(String.raw`(^|[^\w$.])${alias}\s*\.\s*\$transaction\b`).test(code)).toBe(false);
+  });
+});

--- a/tests/offer/convert-to-employee-hire-prediction.test.ts
+++ b/tests/offer/convert-to-employee-hire-prediction.test.ts
@@ -25,10 +25,16 @@ vi.mock('@tims/db', () => ({
     offer: { findFirst: vi.fn().mockResolvedValue(mockOffer), update: vi.fn() },
     user: { findFirst: vi.fn().mockResolvedValue(null) },
     $transaction: vi.fn(async (arg: unknown) =>
-      typeof arg === 'function' ? (arg as (tx: unknown) => Promise<unknown>)(mockTx) : Promise.all(arg as Promise<unknown>[]),
+      typeof arg === 'function'
+        ? (arg as (tx: unknown) => Promise<unknown>)(mockTx)
+        : Promise.all(arg as Promise<unknown>[]),
     ),
   },
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  // #45: convertToEmployee's multi-write hire flow now uses runTenantTransaction —
+  // tenantDb.$transaction never composed (prisma/prisma#17948). The FIT snapshot
+  // below must share that one transaction with the user/plan/offer writes.
+  runTenantTransaction: vi.fn(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
 }));
 
 const readFitForHire = vi.fn().mockResolvedValue(null);
@@ -58,8 +64,18 @@ async function makeCaller() {
   const testRouter = router({ offer: offerLifecycleRouter });
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
-    user: { id: 'hr-1', organizationId: ORG_ID, roles: ['hr_admin'], isPlatformOwner: false, impersonatorId: null, email: 'hr@tims.co', isActive: true },
-    headers: new Headers(), supabaseAuth: null, externalAuth: null,
+    user: {
+      id: 'hr-1',
+      organizationId: ORG_ID,
+      roles: ['hr_admin'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'hr@tims.co',
+      isActive: true,
+    },
+    headers: new Headers(),
+    supabaseAuth: null,
+    externalAuth: null,
   } as never);
 }
 

--- a/tests/offer/convert-to-employee-onboarding.test.ts
+++ b/tests/offer/convert-to-employee-onboarding.test.ts
@@ -19,10 +19,15 @@ vi.mock('@tims/db', () => ({
     offer: { findFirst: vi.fn().mockResolvedValue(mockOffer), update: vi.fn() },
     user: { findFirst: vi.fn().mockResolvedValue(null) },
     $transaction: vi.fn(async (arg: unknown) =>
-      typeof arg === 'function' ? (arg as (tx: unknown) => Promise<unknown>)(mockTx) : Promise.all(arg as Promise<unknown>[])
+      typeof arg === 'function'
+        ? (arg as (tx: unknown) => Promise<unknown>)(mockTx)
+        : Promise.all(arg as Promise<unknown>[]),
     ),
   },
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  // #45: convertToEmployee's multi-write hire flow now uses runTenantTransaction —
+  // tenantDb.$transaction never composed (prisma/prisma#17948).
+  runTenantTransaction: vi.fn(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
 }));
 
 const mockTx = {
@@ -65,8 +70,13 @@ async function makeCaller() {
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
     user: {
-      id: 'hr-1', organizationId: ORG_ID, roles: ['hr_admin'],
-      isPlatformOwner: false, impersonatorId: null, email: 'hr@tims.co', isActive: true,
+      id: 'hr-1',
+      organizationId: ORG_ID,
+      roles: ['hr_admin'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'hr@tims.co',
+      isActive: true,
     },
     headers: new Headers(),
     supabaseAuth: null,

--- a/tests/vacancy/approvals-atomicity.test.ts
+++ b/tests/vacancy/approvals-atomicity.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #45 — atomicity regression test for packages/api/src/routers/vacancy/approvals.ts.
+//
+// WHY A FAKE STORE INSTEAD OF `expect(x).toHaveBeenCalled()`:
+// the defect is not "no transaction was opened", it is "the transaction that was
+// opened does not roll anything back". A call-count assertion cannot tell those
+// apart. So this file models the two constructs' REAL commit semantics, measured
+// on a throwaway PostgreSQL 17 cluster on 2026-08-06 with RLS_ENFORCED=true and a
+// prod-shaped tenant_isolation policy:
+//
+//   tenantDb.$transaction(cb)  -> writes COMMIT AS THEY EXECUTE. After a deliberate
+//                                 mid-block throw: status=pending_approval,
+//                                 approvals=1 (both writes survived).
+//   runTenantTransaction(...)  -> writes are held and discarded on throw. After the
+//                                 same throw: status=draft, approvals=0.
+//
+// Cause: `db` in approvals.ts is `tenantDb`, whose $allOperations extension re-wraps
+// every op in its own mini-transaction on the base client (tenant-client.ts:40), so
+// an outer tenantDb.$transaction never composes (prisma/prisma#17948).
+//
+// MUTATION CHECK (run before trusting this file): change any of the three
+// `runTenantTransaction(ctx.user.organizationId, async (tx) => {` in approvals.ts
+// back to `db.$transaction(async (tx) => {`. Every test below goes red, because the
+// $transaction mock applies writes directly to `committed`.
+
+interface Store {
+  vacancyStatus: string;
+  approvalRows: number;
+  pendingApprovals: number;
+  cancelledApprovals: number;
+}
+
+const committed = vi.hoisted(() => ({ value: null as unknown }) as { value: Store });
+
+// Fails the NEXT call to this tx method, to simulate a mid-block failure.
+const failOn = vi.hoisted(() => ({ value: null as string | null }));
+function failMidTransactionOn(op: string | null) {
+  failOn.value = op;
+}
+
+// Builds a tx facade writing into `target`. Passing `committed.value` models the
+// broken construct (writes land on committed state immediately); passing a staged
+// copy models a real transaction.
+function makeTx(target: Store) {
+  const guard = async (op: string) => {
+    if (failOn.value === op) {
+      throw new Error(`DELIBERATE_FAILURE_IN_${op}`);
+    }
+  };
+  return {
+    vacancy: {
+      update: vi.fn(async ({ data }: { data: { status: string } }) => {
+        await guard('vacancy.update');
+        target.vacancyStatus = data.status;
+        return { id: VACANCY_ID, status: data.status };
+      }),
+      findUniqueOrThrow: vi.fn(async () => ({
+        id: VACANCY_ID,
+        title: 'Sales Rep',
+        status: target.vacancyStatus,
+        approvals: [],
+      })),
+    },
+    vacancyApproval: {
+      createMany: vi.fn(async ({ data }: { data: unknown[] }) => {
+        await guard('vacancyApproval.createMany');
+        target.approvalRows += data.length;
+        target.pendingApprovals += data.length;
+        return { count: data.length };
+      }),
+      update: vi.fn(async () => {
+        await guard('vacancyApproval.update');
+        target.pendingApprovals -= 1;
+        return { id: 'appr-1' };
+      }),
+      updateMany: vi.fn(async () => {
+        await guard('vacancyApproval.updateMany');
+        target.cancelledApprovals += target.pendingApprovals;
+        target.pendingApprovals = 0;
+        return { count: 0 };
+      }),
+      count: vi.fn(async () => target.pendingApprovals),
+    },
+  };
+}
+
+const mockDb = vi.hoisted(() => ({
+  vacancy: { findFirst: vi.fn(), findUniqueOrThrow: vi.fn() },
+  user: { findMany: vi.fn() },
+  vacancyApproval: { findFirst: vi.fn() },
+  // Models tenantDb.$transaction: NO isolation — each op hits committed state as it
+  // runs, exactly as measured on PG17. Present so a mutation back to it fails on an
+  // assertion about outcomes, not on a missing mock method.
+  $transaction: vi.fn(),
+}));
+
+const runTenantTransactionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@tims/db', () => ({
+  tenantDb: mockDb,
+  runWithTenant: (_o: string, f: () => unknown) => f(),
+  runTenantTransaction: runTenantTransactionMock,
+}));
+
+vi.mock('@tims/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tims/shared')>()),
+  filterStaffRoleSlugs: (slugs: string[]) => slugs,
+}));
+
+vi.mock('../../packages/api/src/access', () => ({
+  buildAccessForUser: vi.fn().mockResolvedValue({ allowed: true, scope: 'organization', roles: ['committee'] }),
+  createAnchorLoader: vi.fn().mockReturnValue(null),
+  assertScoped: vi.fn().mockResolvedValue(undefined),
+  scopeWhereFor: vi.fn().mockResolvedValue({}),
+}));
+
+const ORG_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const VACANCY_ID = '99999999-9999-4999-8999-999999999999';
+const APPROVER_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  failMidTransactionOn(null);
+  committed.value = { vacancyStatus: 'draft', approvalRows: 0, pendingApprovals: 0, cancelledApprovals: 0 };
+
+  mockDb.vacancy.findFirst.mockResolvedValue({ id: VACANCY_ID });
+  mockDb.vacancyApproval.findFirst.mockResolvedValue({ id: 'appr-1' });
+  mockDb.user.findMany.mockResolvedValue([{ id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] }]);
+  mockDb.vacancy.findUniqueOrThrow.mockImplementation(async () => ({
+    id: VACANCY_ID,
+    title: 'Sales Rep',
+    status: committed.value.vacancyStatus,
+    approvals: [],
+  }));
+
+  // BROKEN semantics: writes commit as they execute, nothing is rolled back.
+  mockDb.$transaction.mockImplementation(async (arg: unknown) => {
+    const tx = makeTx(committed.value);
+    return typeof arg === 'function'
+      ? (arg as (tx: unknown) => Promise<unknown>)(tx)
+      : Promise.all(arg as Promise<unknown>[]);
+  });
+
+  // REAL transaction semantics: stage, then commit only on success.
+  runTenantTransactionMock.mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) => {
+    const staged: Store = { ...committed.value };
+    const result = await fn(makeTx(staged)); // a throw here skips the commit below
+    committed.value = staged;
+    return result;
+  });
+});
+
+async function makeCaller() {
+  const { createCallerFactory, router } = await import('../../packages/api/src/trpc');
+  const { vacancyApprovalsRouter } = await import('../../packages/api/src/routers/vacancy/approvals');
+  const testRouter = router({ vacancy: vacancyApprovalsRouter });
+  return createCallerFactory(testRouter)({
+    user: {
+      id: 'user-1',
+      organizationId: ORG_ID,
+      roles: ['committee'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'c@tims.co',
+      isActive: true,
+    },
+    headers: new Headers(),
+    supabaseAuth: null,
+    externalAuth: null,
+  } as never);
+}
+
+describe('vacancy approvals — multi-step writes are genuinely atomic (#45, prisma#17948)', () => {
+  // NON-VACUITY: prove the fixture actually writes on the success path. Without
+  // this, the rollback assertions below could pass simply because nothing ever ran.
+  it('happy path really does mutate the store (non-vacuity guard for the rollback tests)', async () => {
+    const caller = await makeCaller();
+
+    await caller.vacancy.submitForApproval({ id: VACANCY_ID, approverIds: [APPROVER_ID] });
+
+    expect(committed.value.vacancyStatus).toBe('pending_approval');
+    expect(committed.value.approvalRows).toBe(1);
+  });
+
+  it('submitForApproval rolls the status flip back when the approval-row insert fails mid-transaction', async () => {
+    // Write order in the procedure: vacancy.update -> vacancyApproval.createMany.
+    // Fail the SECOND write, so the first one is the thing that must not survive.
+    failMidTransactionOn('vacancyApproval.createMany');
+    const caller = await makeCaller();
+
+    await expect(caller.vacancy.submitForApproval({ id: VACANCY_ID, approverIds: [APPROVER_ID] })).rejects.toThrow();
+
+    // Under tenantDb.$transaction this was pending_approval — a vacancy stuck
+    // awaiting approval with nobody assigned to approve it.
+    expect(committed.value.vacancyStatus).toBe('draft');
+    expect(committed.value.approvalRows).toBe(0);
+  });
+
+  it('approve rolls the approval decision back when the vacancy status flip fails mid-transaction', async () => {
+    committed.value = {
+      vacancyStatus: 'pending_approval',
+      approvalRows: 1,
+      pendingApprovals: 1,
+      cancelledApprovals: 0,
+    };
+    // Write order: vacancyApproval.update -> count -> (if 0) vacancy.update.
+    failMidTransactionOn('vacancy.update');
+    const caller = await makeCaller();
+
+    await expect(caller.vacancy.approve({ id: VACANCY_ID })).rejects.toThrow();
+
+    // The approval must NOT stay decided while the vacancy never became approved.
+    expect(committed.value.pendingApprovals).toBe(1);
+    expect(committed.value.vacancyStatus).toBe('pending_approval');
+  });
+
+  it('reject rolls back the status flip when cancelling the remaining pending approvals fails', async () => {
+    committed.value = {
+      vacancyStatus: 'pending_approval',
+      approvalRows: 2,
+      pendingApprovals: 2,
+      cancelledApprovals: 0,
+    };
+    // Write order: vacancyApproval.update -> vacancy.update(draft) -> updateMany(cancelled).
+    failMidTransactionOn('vacancyApproval.updateMany');
+    const caller = await makeCaller();
+
+    await expect(caller.vacancy.reject({ id: VACANCY_ID, comment: 'no' })).rejects.toThrow();
+
+    // The worst old outcome: a `draft` vacancy still carrying live pending approvals.
+    expect(committed.value.vacancyStatus).toBe('pending_approval');
+    expect(committed.value.cancelledApprovals).toBe(0);
+  });
+
+  it('never routes any of the three write blocks through tenantDb.$transaction', async () => {
+    const caller = await makeCaller();
+
+    await caller.vacancy.submitForApproval({ id: VACANCY_ID, approverIds: [APPROVER_ID] });
+    await caller.vacancy.approve({ id: VACANCY_ID });
+    await caller.vacancy.reject({ id: VACANCY_ID, comment: 'no' });
+
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(3);
+    // Every call must thread the caller's org id — runTenantTransaction needs it to
+    // set the RLS role + app.current_org_id GUC once for the whole transaction.
+    for (const call of runTenantTransactionMock.mock.calls) {
+      expect(call[0]).toBe(ORG_ID);
+    }
+  });
+});

--- a/tests/vacancy/approve-transaction.test.ts
+++ b/tests/vacancy/approve-transaction.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Codex PR #120 finding #5: approve()'s approval-update + pending-count +
-// conditional vacancy-status-update sequence must be wrapped in db.$transaction
-// (a regression here would silently reopen the finding). Mirrors the mocking
-// pattern used in create-autopublish.test.ts / submit-for-approval.test.ts.
+// conditional vacancy-status-update sequence must be ATOMIC (a regression here
+// would silently reopen the finding).
+//
+// INVERTED 2026-08-06 (#45). This file used to assert `tenantDb.$transaction`
+// was called, and therefore actively DEFENDED the broken construct. `db` in
+// approvals.ts is `tenantDb`, whose $allOperations extension re-wraps every op in
+// its own mini-transaction on the base client (tenant-client.ts:40), so an outer
+// tenantDb.$transaction does not compose (prisma/prisma#17948) and each write
+// commits independently. Reproduced on a throwaway PG17 cluster 2026-08-06:
+// with a deliberate mid-block failure, tenantDb.$transaction left
+// status=pending_approval + 1 approval row COMMITTED, while runTenantTransaction
+// left status=draft + 0 rows.
+//
+// The assertion is now the inverse: runTenantTransaction is used, and
+// tenantDb.$transaction is never called. `$transaction` is deliberately still
+// present on the mock so that mutating the source back to `db.$transaction`
+// fails on the ASSERTION (a real behavioural claim) rather than on a missing
+// mock method.
 
 const pendingCountAfterApproval = vi.hoisted(() => ({ value: 0 }));
 function setPendingCountAfterApproval(value: number) {
@@ -32,9 +47,12 @@ const mockDb = vi.hoisted(() => ({
   $transaction: vi.fn(),
 }));
 
+const runTenantTransactionMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@tims/db', () => ({
   tenantDb: mockDb,
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  runTenantTransaction: runTenantTransactionMock,
 }));
 
 vi.mock('../../packages/api/src/access', () => ({
@@ -52,12 +70,18 @@ beforeEach(() => {
   setPendingCountAfterApproval(0);
   mockDb.vacancyApproval.findFirst.mockResolvedValue({ id: 'appr-1' });
   mockDb.vacancy.findUniqueOrThrow.mockResolvedValue({
-    id: VACANCY_ID, title: 'Sales Rep', status: 'approved', approvals: [],
+    id: VACANCY_ID,
+    title: 'Sales Rep',
+    status: 'approved',
+    approvals: [],
   });
   mockDb.$transaction = vi.fn(async (arg: unknown) =>
     typeof arg === 'function'
       ? (arg as (tx: unknown) => Promise<unknown>)(mockTx())
       : Promise.all(arg as Promise<unknown>[]),
+  );
+  runTenantTransactionMock.mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) =>
+    fn(mockTx()),
   );
 });
 
@@ -68,8 +92,13 @@ async function makeCaller() {
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
     user: {
-      id: 'user-1', organizationId: ORG_ID, roles: ['committee'],
-      isPlatformOwner: false, impersonatorId: null, email: 'c@tims.co', isActive: true,
+      id: 'user-1',
+      organizationId: ORG_ID,
+      roles: ['committee'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'c@tims.co',
+      isActive: true,
     },
     headers: new Headers(),
     supabaseAuth: null,
@@ -78,26 +107,34 @@ async function makeCaller() {
 }
 
 describe('vacancy.approve — transaction wrapper', () => {
-  it('wraps the approval-update + pending-count + vacancy-status-update in db.$transaction, flipping status to approved when the last pending approval clears', async () => {
+  it('wraps the approval-update + pending-count + vacancy-status-update in runTenantTransaction (NOT tenantDb.$transaction), flipping status to approved when the last pending approval clears', async () => {
     setPendingCountAfterApproval(0);
     const caller = await makeCaller();
 
     const result = await caller.vacancy.approve({ id: VACANCY_ID });
 
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(1);
+    // The org id must be threaded through — runTenantTransaction uses it to set
+    // the RLS role + app.current_org_id GUC once for the whole transaction.
+    expect(runTenantTransactionMock).toHaveBeenCalledWith(ORG_ID, expect.any(Function));
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
     expect(result.status).toBe('approved');
   });
 
-  it('still calls $transaction but leaves the vacancy status alone when other approvals remain pending', async () => {
+  it('still opens ONE runTenantTransaction but leaves the vacancy status alone when other approvals remain pending', async () => {
     setPendingCountAfterApproval(1);
     mockDb.vacancy.findUniqueOrThrow.mockResolvedValue({
-      id: VACANCY_ID, title: 'Sales Rep', status: 'pending_approval', approvals: [],
+      id: VACANCY_ID,
+      title: 'Sales Rep',
+      status: 'pending_approval',
+      approvals: [],
     });
     const caller = await makeCaller();
 
     const result = await caller.vacancy.approve({ id: VACANCY_ID });
 
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(1);
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
     expect(result.status).toBe('pending_approval');
   });
 });

--- a/tests/vacancy/channels-publish.test.ts
+++ b/tests/vacancy/channels-publish.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Codex PR #120 finding #4: channels.publish's channel-create + conditional
-// vacancy-status-update must be wrapped in db.$transaction (a regression here
-// would silently reopen the finding). Mirrors the create-autopublish.test.ts
-// mocking pattern (same tenantDb mock shape).
+// vacancy-status-update must be ATOMIC (a regression here would silently reopen
+// the finding). Mirrors the create-autopublish.test.ts mocking pattern.
+//
+// INVERTED 2026-08-06 (#45): this asserted `tenantDb.$transaction` was called, so
+// it defended a wrapper that does not actually roll anything back — `db` here is
+// `tenantDb`, whose extension re-wraps each op in its own mini-transaction, so the
+// outer $transaction never composes (prisma/prisma#17948; reproduced on PG17).
+// Finding #4 was therefore still open while this test was green.
 
 const mockTx = () => ({
   publicationChannel: {
-    create: vi.fn().mockResolvedValue({ id: 'ch-1', channelName: 'LinkedIn', channelType: 'linkedin', status: 'published' }),
+    create: vi
+      .fn()
+      .mockResolvedValue({ id: 'ch-1', channelName: 'LinkedIn', channelType: 'linkedin', status: 'published' }),
   },
   vacancy: {
     update: vi.fn().mockResolvedValue({ id: 'vac-1', status: 'published' }),
@@ -24,9 +31,12 @@ const mockDb = vi.hoisted(() => ({
   $transaction: vi.fn(),
 }));
 
+const runTenantTransactionMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@tims/db', () => ({
   tenantDb: mockDb,
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  runTenantTransaction: runTenantTransactionMock,
 }));
 
 vi.mock('../../packages/api/src/access', () => ({
@@ -46,6 +56,9 @@ beforeEach(() => {
       ? (arg as (tx: unknown) => Promise<unknown>)(mockTx())
       : Promise.all(arg as Promise<unknown>[]),
   );
+  runTenantTransactionMock.mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) =>
+    fn(mockTx()),
+  );
 });
 
 async function makeCaller() {
@@ -55,8 +68,13 @@ async function makeCaller() {
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
     user: {
-      id: 'user-1', organizationId: ORG_ID, roles: ['recruiter'],
-      isPlatformOwner: false, impersonatorId: null, email: 'r@tims.co', isActive: true,
+      id: 'user-1',
+      organizationId: ORG_ID,
+      roles: ['recruiter'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'r@tims.co',
+      isActive: true,
     },
     headers: new Headers(),
     supabaseAuth: null,
@@ -65,7 +83,7 @@ async function makeCaller() {
 }
 
 describe('vacancy.channels.publish — transaction wrapper', () => {
-  it('wraps the channel create + vacancy status update in db.$transaction and flips status to published', async () => {
+  it('wraps the channel create + vacancy status update in runTenantTransaction (NOT tenantDb.$transaction) and flips status to published', async () => {
     mockDb.vacancy.findFirst.mockResolvedValue({ id: VACANCY_ID, status: 'approved' });
     const caller = await makeCaller();
 
@@ -75,7 +93,9 @@ describe('vacancy.channels.publish — transaction wrapper', () => {
       channelType: 'linkedin',
     });
 
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledWith(ORG_ID, expect.any(Function));
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
     expect(result).toMatchObject({ id: 'ch-1', status: 'published' });
   });
 
@@ -89,6 +109,7 @@ describe('vacancy.channels.publish — transaction wrapper', () => {
       channelType: 'indeed',
     });
 
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(1);
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
   });
 });

--- a/tests/vacancy/create-autopublish.test.ts
+++ b/tests/vacancy/create-autopublish.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// #45: vacancy.create's autoPublish path now opens ONE runTenantTransaction, not
+// tenantDb.$transaction (which does not compose — prisma/prisma#17948). The
+// $transaction mock is kept so the "never called" assertions below are real
+// assertions rather than missing-method crashes.
+const runTenantTransactionMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@tims/db', () => ({
   tenantDb: {
     vacancy: {
@@ -10,17 +16,34 @@ vi.mock('@tims/db', () => ({
       create: vi.fn(),
     },
     $transaction: vi.fn(async (arg: unknown) =>
-      typeof arg === 'function' ? (arg as (tx: unknown) => Promise<unknown>)(mockTx()) : Promise.all(arg as Promise<unknown>[])
+      typeof arg === 'function'
+        ? (arg as (tx: unknown) => Promise<unknown>)(mockTx())
+        : Promise.all(arg as Promise<unknown>[]),
     ),
   },
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  runTenantTransaction: runTenantTransactionMock,
 }));
 
 function mockTx() {
   return {
     vacancy: {
-      create: vi.fn().mockResolvedValue({ id: 'vac-1', title: 'Sales Rep', status: 'approved', priority: 'medium', positions: 1, createdAt: new Date() }),
-      update: vi.fn().mockResolvedValue({ id: 'vac-1', title: 'Sales Rep', status: 'published', priority: 'medium', positions: 1, createdAt: new Date() }),
+      create: vi.fn().mockResolvedValue({
+        id: 'vac-1',
+        title: 'Sales Rep',
+        status: 'approved',
+        priority: 'medium',
+        positions: 1,
+        createdAt: new Date(),
+      }),
+      update: vi.fn().mockResolvedValue({
+        id: 'vac-1',
+        title: 'Sales Rep',
+        status: 'published',
+        priority: 'medium',
+        positions: 1,
+        createdAt: new Date(),
+      }),
     },
     publicationChannel: { create: vi.fn().mockResolvedValue({ id: 'ch-1' }) },
   };
@@ -58,6 +81,9 @@ vi.mock('../../packages/api/src/access', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   setPublishAllowed(true);
+  runTenantTransactionMock.mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) =>
+    fn(mockTx()),
+  );
 });
 
 async function makeCaller() {
@@ -67,8 +93,13 @@ async function makeCaller() {
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
     user: {
-      id: 'user-1', organizationId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', roles: ['recruiter'],
-      isPlatformOwner: false, impersonatorId: null, email: 'r@tims.co', isActive: true,
+      id: 'user-1',
+      organizationId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      roles: ['recruiter'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'r@tims.co',
+      isActive: true,
     },
     headers: new Headers(),
     supabaseAuth: null,
@@ -88,13 +119,22 @@ describe('vacancy.create — autoPublish', () => {
       settings: { autoPublish: true },
     });
 
-    expect(tenantDb.$transaction).toHaveBeenCalledTimes(1);
+    // #45: ONE real transaction (runTenantTransaction), and never the tenantDb
+    // wrapper that does not roll back.
+    expect(runTenantTransactionMock).toHaveBeenCalledTimes(1);
+    expect(runTenantTransactionMock).toHaveBeenCalledWith('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', expect.any(Function));
+    expect(tenantDb.$transaction).not.toHaveBeenCalled();
   });
 
   it('leaves the vacancy in draft when requireApproval is true (no behavior change)', async () => {
     const { tenantDb } = await import('@tims/db');
     vi.mocked(tenantDb.vacancy.create).mockResolvedValue({
-      id: 'vac-2', title: 'Ops Lead', status: 'draft', priority: 'medium', positions: 1, createdAt: new Date(),
+      id: 'vac-2',
+      title: 'Ops Lead',
+      status: 'draft',
+      priority: 'medium',
+      positions: 1,
+      createdAt: new Date(),
     } as never);
     const caller = await makeCaller();
 
@@ -114,7 +154,12 @@ describe('vacancy.create — autoPublish', () => {
   it('creates directly as approved when requireApproval is false/absent and autoPublish is off (no more draft dead end)', async () => {
     const { tenantDb } = await import('@tims/db');
     vi.mocked(tenantDb.vacancy.create).mockResolvedValue({
-      id: 'vac-3', title: 'Support Analyst', status: 'approved', priority: 'medium', positions: 1, createdAt: new Date(),
+      id: 'vac-3',
+      title: 'Support Analyst',
+      status: 'approved',
+      priority: 'medium',
+      positions: 1,
+      createdAt: new Date(),
     } as never);
     const caller = await makeCaller();
 
@@ -127,6 +172,7 @@ describe('vacancy.create — autoPublish', () => {
     expect(tenantDb.vacancy.create).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: 'approved' }) }),
     );
+    expect(runTenantTransactionMock).not.toHaveBeenCalled();
     expect(tenantDb.$transaction).not.toHaveBeenCalled();
     expect(result.status).toBe('approved');
   });
@@ -145,6 +191,7 @@ describe('vacancy.create — autoPublish', () => {
       }),
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
 
+    expect(runTenantTransactionMock).not.toHaveBeenCalled();
     expect(tenantDb.$transaction).not.toHaveBeenCalled();
     expect(tenantDb.vacancy.create).not.toHaveBeenCalled();
   });
@@ -162,6 +209,7 @@ describe('vacancy.create — autoPublish', () => {
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 
+    expect(runTenantTransactionMock).not.toHaveBeenCalled();
     expect(tenantDb.$transaction).not.toHaveBeenCalled();
     expect(tenantDb.vacancy.create).not.toHaveBeenCalled();
   });

--- a/tests/vacancy/submit-for-approval.test.ts
+++ b/tests/vacancy/submit-for-approval.test.ts
@@ -66,9 +66,14 @@ const mockDb = vi.hoisted(() => ({
   $transaction: vi.fn(),
 }));
 
+// #45: submitForApproval's write block now goes through runTenantTransaction, not
+// tenantDb.$transaction (which does not compose — prisma/prisma#17948).
+const runTenantTransactionMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@tims/db', () => ({
   tenantDb: mockDb,
   runWithTenant: (_o: string, f: () => unknown) => f(),
+  runTenantTransaction: runTenantTransactionMock,
 }));
 
 vi.mock('@tims/shared', async (importOriginal) => ({
@@ -76,7 +81,9 @@ vi.mock('@tims/shared', async (importOriginal) => ({
   // types, etc.); only override filterStaffRoleSlugs for this test.
   ...(await importOriginal<typeof import('@tims/shared')>()),
   filterStaffRoleSlugs: (slugs: string[]) =>
-    slugs.filter((s) => ['super_admin', 'hr_admin', 'hrbp', 'recruiter', 'leader', 'committee', 'employee'].includes(s)),
+    slugs.filter((s) =>
+      ['super_admin', 'hr_admin', 'hrbp', 'recruiter', 'leader', 'committee', 'employee'].includes(s),
+    ),
 }));
 
 vi.mock('../../packages/api/src/access', () => ({
@@ -94,7 +101,10 @@ beforeEach(() => {
 
   mockDb.vacancy.findFirst.mockResolvedValue({ id: '99999999-9999-4999-8999-999999999999' });
   mockDb.vacancy.findUniqueOrThrow.mockResolvedValue({
-    id: '99999999-9999-4999-8999-999999999999', title: 'Sales Rep', status: 'pending_approval', approvals: [],
+    id: '99999999-9999-4999-8999-999999999999',
+    title: 'Sales Rep',
+    status: 'pending_approval',
+    approvals: [],
   });
   mockDb.$transaction = vi.fn(async (arg: unknown) =>
     typeof arg === 'function'
@@ -103,6 +113,9 @@ beforeEach(() => {
           vacancyApproval: mockDb.vacancyApproval,
         })
       : Promise.all(arg as Promise<unknown>[]),
+  );
+  runTenantTransactionMock.mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) =>
+    fn({ vacancy: mockDb.vacancy, vacancyApproval: mockDb.vacancyApproval }),
   );
 });
 
@@ -116,8 +129,13 @@ async function makeCaller() {
   const callerFactory = createCallerFactory(testRouter);
   return callerFactory({
     user: {
-      id: 'user-1', organizationId: ORG_ID, roles: ['recruiter'],
-      isPlatformOwner: false, impersonatorId: null, email: 'r@tims.co', isActive: true,
+      id: 'user-1',
+      organizationId: ORG_ID,
+      roles: ['recruiter'],
+      isPlatformOwner: false,
+      impersonatorId: null,
+      email: 'r@tims.co',
+      isActive: true,
     },
     headers: new Headers(),
     supabaseAuth: null,
@@ -127,9 +145,7 @@ async function makeCaller() {
 
 describe('vacancy.submitForApproval — approver validation', () => {
   it('submits successfully when the approver is active, same-org, and holds vacancy:approve', async () => {
-    mockDb.user.findMany.mockResolvedValue([
-      { id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] },
-    ]);
+    mockDb.user.findMany.mockResolvedValue([{ id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] }]);
     const caller = await makeCaller();
 
     await expect(
@@ -137,12 +153,13 @@ describe('vacancy.submitForApproval — approver validation', () => {
     ).resolves.toBeDefined();
 
     expect(mockDb.vacancyApproval.createMany).toHaveBeenCalledTimes(1);
+    // #45: the status flip + createMany must share ONE real transaction.
+    expect(runTenantTransactionMock).toHaveBeenCalledWith(ORG_ID, expect.any(Function));
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
   });
 
   it('rejects the whole submission when an approverId lacks vacancy:approve', async () => {
-    mockDb.user.findMany.mockResolvedValue([
-      { id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] },
-    ]);
+    mockDb.user.findMany.mockResolvedValue([{ id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] }]);
     setApproverAllowed(false);
     const caller = await makeCaller();
 
@@ -169,13 +186,14 @@ describe('vacancy.submitForApproval — approver validation', () => {
   it('rejects the whole submission if ANY of multiple approverIds fails validation', async () => {
     const APPROVER_2 = '22222222-2222-2222-2222-222222222222';
     // Only APPROVER_ID comes back from the DB fetch; APPROVER_2 is missing entirely.
-    mockDb.user.findMany.mockResolvedValue([
-      { id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] },
-    ]);
+    mockDb.user.findMany.mockResolvedValue([{ id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] }]);
     const caller = await makeCaller();
 
     await expect(
-      caller.vacancy.submitForApproval({ id: '99999999-9999-4999-8999-999999999999', approverIds: [APPROVER_ID, APPROVER_2] }),
+      caller.vacancy.submitForApproval({
+        id: '99999999-9999-4999-8999-999999999999',
+        approverIds: [APPROVER_ID, APPROVER_2],
+      }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 
     expect(mockDb.vacancyApproval.createMany).not.toHaveBeenCalled();
@@ -186,9 +204,7 @@ describe('vacancy.submitForApproval — approver validation', () => {
     // (scope: 'team', not the common 'organization' default) to prove the fix
     // probes the approver's own narrower access, not a caller-shaped stub.
     const VACANCY_ID = '99999999-9999-4999-8999-999999999999';
-    mockDb.user.findMany.mockResolvedValue([
-      { id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] },
-    ]);
+    mockDb.user.findMany.mockResolvedValue([{ id: APPROVER_ID, userRoles: [{ role: { slug: 'committee' } }] }]);
     setApproverScope('team');
     rejectScopeForUserId(APPROVER_ID);
     const caller = await makeCaller();
@@ -210,7 +226,10 @@ describe('vacancy.submitForApproval — approver validation', () => {
     );
     // No approval rows created and no vacancy-status transaction runs — the
     // rejection is a hard stop before any write, not a partial submission.
+    // Both constructs are asserted absent: runTenantTransaction is the one the
+    // code uses now (#45), tenantDb.$transaction the one it must never go back to.
     expect(mockDb.vacancyApproval.createMany).not.toHaveBeenCalled();
+    expect(runTenantTransactionMock).not.toHaveBeenCalled();
     expect(mockDb.$transaction).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #45.

## The defect

`tenantDb` is `db.$extends({ query: { $allOperations } })`. When RLS is enforced, that extension wraps **every** op in its own `db.$transaction([SET LOCAL ROLE, set_config, query])` on the closed-over **base** client — so composing it with an outer `tenantDb.$transaction` does not produce one atomic unit. Each nested write commits independently (prisma/prisma#17948).

Every multi-step write that believed it was atomic was not.

## Reproduced, not assumed

Throwaway PostgreSQL 17 cluster, `RLS_ENFORCED=true`, the prod-shaped `tenant_isolation` policy copied from `packages/db/baseline/prod-public-schema.sql:7363`, running the exact write sequence from `vacancy/approvals.ts submitForApproval` with a deliberate mid-block failure:

| Construct                        | Outcome                                                  |
| -------------------------------- | -------------------------------------------------------- |
| `tenantDb.$transaction(cb)`      | `status=pending_approval`, `approvals=1` — **COMMITTED** |
| `tenantDb.$transaction([...])`   | `status=pending_approval` — **COMMITTED**                |
| `runTenantTransaction(orgId, …)` | `status=draft`, `approvals=0` — rolled back              |

Deterministic over two runs. RLS scoping was intact in all three forms, so this is an **atomicity / data-integrity defect, not a tenant-isolation one**.

⚠️ Two earlier probe attempts did **not** reproduce it, and were wrong rather than exonerating: `tenant-client.ts:21` reads `RLS_ENFORCED` into a module-level const at import time, and ESM import hoisting made an in-file `process.env` assignment too late — so those runs silently exercised the RLS-**disabled** path, where the extension no-ops and the outer transaction does work. Setting it in the shell reproduced the bug immediately. Worth recording: the probe that "passes" here is the one that proves nothing.

## Scope

Fixed all **16** remaining call sites (files importing `tenantDb`, mostly as `tenantDb as db`): `vacancy/approvals.ts` ×3, `vacancy/crud.ts` ×2, `vacancy/channels.ts`, `offer/approvals.ts` ×3, `offer/lifecycle.ts`, `interview/crud.ts`, `user.ts`, `organization.ts`, `pipeline.repository.ts` ×2, `candidate.repository.ts`.

The issue's subject said 18. Two of those 18 lived in the evaluation360 repository that #148 deleted, so the real count is 16 — corrected rather than left to read as a shortfall.

`candidate.repository.merge` needed a signature change (`merge(orgId, primaryId, duplicateId)`) — it used the **batch** form, which is broken the same way; the caller in `candidate.service.ts:255` already had `orgId`.

One code comment asserted a guarantee that was not in force and is now true: `vacancy/channels.ts:75` (Codex finding #4). The other two comments this originally claimed to fix — evaluation360 `assignRaters`' "same `$transaction`" TOCTOU claim and `submitRatings`' "a failed insert rolls back the status flip" — lived in the file #148 deleted; that claim went stale at the rebase and is withdrawn here rather than restated.

## Tests

New `tests/vacancy/approvals-atomicity.test.ts` models **both constructs' real commit semantics** against a fake store, so a mutation back to `db.$transaction` fails on **outcomes** ("expected 'pending_approval' to be 'draft'"), not on call counts. Verified red for each of the three sites independently. Includes a non-vacuity guard proving the happy path actually writes.

## Verification

**Tier that actually ran: 3 (same-model adversarial panel). This is NOT cross-model review.**

- **Tier 1 (Codex, `/gate` check 15): exit 2 — NOT RUN.** Quota-blocked; the CLI's own message names 2026-08-15. Exit 2 is not a pass. Re-confirmed 2026-08-07 — 7th consecutive exit 2.
- **Tier 2 (OmniRoute, different-vendor): exit 2 — refused to run.** `OMNIROUTE_MODEL` unset, no default since 2026-08-05.
- **Tier 3 substitute executed:** 3-lens panel (security/tenant-isolation · claim auditor · coverage), each prompted to refute and re-reading source at the commit blobs. **Zero blocking findings.** It did find that the parent commit `f179c1a0` overstated the "three code comments" claim — corrected above.

Per `.claude/rules/verification.md`, do not restate this as cross-model verified.

## ⚠️ Known, before merge

**`f179c1a0` is RED on its own tree.** The rebase resolved `packages/api/src/repositories/evaluation360.repository.ts` as deleted, but that commit still lists it in `PINNED` and asserts `existsSync(...) === true`. Fixed one commit later in `f76457c9`.

CI never evaluates the intermediate commit (`ci.yml` triggers on `main` push/PR only), so the exposure is **`git bisect` and manual checkout**, not the build. **Squash on merge** if that matters to you.

The `f76457c9` fix is not making a red test green: `tests/governance/tenant-transaction-composition.test.ts`'s own docblock says a legitimately removed file's entry should be deleted **deliberately** rather than left to silently stop covering, and the file's absence is independently asserted on main at `tests/governance/evaluation360-no-ts-writers.test.ts:546-547`.

**Check-3 anchor: measured, not computed.** Rebased onto main (`7d4a2298`): **2738 passing across 292 files, exit 0**. The pre-rebase anchor of 2751/291 was derived on the pre-#148 lineage.
