### PR TITLE
fix(compliance): the DSAR right-of-access export wrote no §21 audit row at all

### DIFF
--- a/apps/web/app/(admin)/platform/support/data-requests.tsx
+++ b/apps/web/app/(admin)/platform/support/data-requests.tsx
@@ -17,7 +17,14 @@ export function DataRequests() {
     if (!subject || !subject.includes('@')) return;
     setExporting(true);
     try {
-      const result = await utils.platform.exportSubjectData.fetch({ email: subject });
+      // staleTime/gcTime 0 is REQUIRED, not a tuning choice. The QueryClient default
+      // is `staleTime: 300_000` (trpc-provider.tsx), and `utils.*.fetch` is
+      // `queryClient.fetchQuery` — which serves a fresh cache entry with NO server
+      // round-trip. Exporting the same subject twice inside 5 minutes would then
+      // re-download the full PII bundle (salary, DOB, demographics) while writing
+      // ZERO `data_access_logs` and ZERO `audit_logs` rows, because the procedure
+      // never runs. Every export of this bundle must reach the server and be audited.
+      const result = await utils.platform.exportSubjectData.fetch({ email: subject }, { staleTime: 0, gcTime: 0 });
       const blob = new Blob([result.json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/docs/architecture/compliance/cb-1-audit-immutability.md
+++ b/docs/architecture/compliance/cb-1-audit-immutability.md
@@ -23,8 +23,19 @@ Engine-level append-only that survives privilege changes (`AuditImmutability.Bui
 Append (INSERT) is unaffected — the table stays append-only, not read-only.
 
 **Pre-prod finding (over-grant):** migration `20260612000000_access_control_models` granted `app_tenant`
-`SELECT, INSERT, UPDATE, DELETE` on `data_access_logs` — but the only writer is `db.dataAccessLog.create`
-(`packages/api/src/access/audit.ts`, INSERT-only). So prod currently lets the tenant role DELETE audit rows.
+`SELECT, INSERT, UPDATE, DELETE` on `data_access_logs` — but every writer is INSERT-only. So prod
+currently lets the tenant role DELETE audit rows.
+
+> **Updated 2026-08-07.** There are now **two** writers, not one. `logDataAccess`
+> (`packages/api/src/access/audit.ts`) writes through `tenantDb` and is the writer this grant
+> concerns. `auditSensitiveRead` (`packages/api/src/routers/platform/data-requests.ts`) writes the
+> §21 rows for the cross-org DSAR right-of-access export through the **privileged BYPASSRLS `db`**
+> with an explicit `organizationId`, because the tenant path cannot insert a row carrying a
+> *different* org than the operator's GUC (the fail-closed `tenant_isolation` WITH CHECK rejects it).
+> It does not touch the `app_tenant` grant either way, and it is also INSERT-only
+> (`createMany`) — so the least-privilege argument and the append-only trigger below are both
+> unchanged. Any third writer must be added here.
+
 CB-1 additionally `REVOKE UPDATE, DELETE ON data_access_logs FROM app_tenant` (least-privilege, SOC 2 CC6.3 /
 ISO A.8.2) so grants match intent; the trigger is the hard control that blocks it regardless of grants.
 Verified INSERT-only across the codebase (no `dataAccessLog.update/delete/deleteMany`, no raw DELETE/TRUNCATE).

--- a/packages/api/src/lib/client-ip.ts
+++ b/packages/api/src/lib/client-ip.ts
@@ -1,0 +1,26 @@
+/**
+ * Trusted client-IP derivation, shared by the rate limiter and the audit writers.
+ *
+ * NEVER trust the client-controlled left-most `x-forwarded-for` value — an attacker
+ * sets it freely. Prefer `x-real-ip` (written by the platform edge, not spoofable);
+ * otherwise take the LAST hop of `x-forwarded-for`, the entry appended by the
+ * trusted proxy, never the first.
+ *
+ * This lives in its own leaf module rather than in `trpc.ts` because `trpc.ts`
+ * bootstraps auth, env validation and Redis at import time. Anything that needs the
+ * derivation — including tests that want to exercise it for real rather than mock
+ * it — can import this without dragging that in.
+ */
+export function clientIpFrom(headers: Headers): string | null {
+  const realIp = headers.get('x-real-ip')?.trim();
+  if (realIp) return realIp;
+  const xff = headers.get('x-forwarded-for');
+  if (xff) {
+    const hops = xff
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (hops.length > 0) return hops[hops.length - 1];
+  }
+  return null;
+}

--- a/packages/api/src/routers/platform/data-requests.ts
+++ b/packages/api/src/routers/platform/data-requests.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { logger } from '@tims/shared';
 import { router } from '../../trpc';
 import { db } from '@tims/db';
+import { dataClassOf } from '../../access';
 import { platformProcedure } from './_common';
 
 // ---------------------------------------------------------------------------
@@ -14,6 +15,59 @@ import { platformProcedure } from './_common';
 // Platform-owner only. Deletion requests are handled manually for now (they
 // carry legal-retention nuance + cascade risk) — a separate future capability.
 // ---------------------------------------------------------------------------
+
+// §21 sensitive-read audit (data_access_logs) for this cross-org surface.
+//
+// `logDataAccess()` from ../../access is deliberately NOT used here, and must not
+// be substituted in: it writes through `tenantDb`, and a platform owner who HAS an
+// org of their own flows through `runWithTenant(ownOrg)` (trpc.ts:106-128), so the
+// insert would run under `SET LOCAL ROLE app_tenant` with the org GUC pinned to the
+// OPERATOR's org. A row carrying the SUBJECT's organizationId is then rejected by
+// the fail-closed `tenant_isolation` WITH CHECK — which for the restricted
+// (fail-closed) compensation rows would abort the export. It would break for
+// exactly the operators who have an org and silently work for those who don't.
+// This surface is cross-org by construction, so it writes through the privileged
+// BYPASSRLS `db` with an explicit organizationId, the same way the `audit_logs`
+// insert further down already does.
+//
+// Failure policy is derived from the SAME registry as logDataAccess
+// (classification.ts): restricted → fail-CLOSED (throw before returning),
+// confidential → fail-SOFT (log and continue). `opts.failClosed` overrides it for
+// mixed-class tables, exactly as logDataAccess documents for assessmentResult.
+async function auditSensitiveRead(
+  actor: { actorId: string; ipAddress: string | null; userAgent: string | null },
+  entity: string,
+  rows: ReadonlyArray<{ id: string; organizationId: string }>,
+  opts?: { failClosed?: boolean },
+): Promise<void> {
+  if (rows.length === 0) return;
+  const failClosed = opts?.failClosed ?? dataClassOf(entity) === 'restricted';
+  try {
+    await db.dataAccessLog.createMany({
+      data: rows.map((r) => ({
+        organizationId: r.organizationId,
+        actorId: actor.actorId,
+        dataType: entity,
+        recordId: r.id,
+        action: 'export',
+        ipAddress: actor.ipAddress,
+        userAgent: actor.userAgent,
+      })),
+    });
+  } catch (err) {
+    if (failClosed) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'No se pudo registrar el acceso a datos restringidos; acceso abortado',
+        cause: err,
+      });
+    }
+    logger.warn(
+      { err, entity, rows: rows.length, actorId: actor.actorId },
+      'data_access_logs write failed for DSAR export — continuing (fail-soft)',
+    );
+  }
+}
 
 export const dataRequestsRouter = router({
   exportSubjectData: platformProcedure
@@ -27,15 +81,28 @@ export const dataRequestsRouter = router({
         db.user.findMany({
           where: { email: { equals: email, mode: 'insensitive' } },
           select: {
-            id: true, email: true, firstName: true, lastName: true,
-            jobTitle: true, isActive: true, organizationId: true, createdAt: true,
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            jobTitle: true,
+            isActive: true,
+            organizationId: true,
+            createdAt: true,
           },
         }),
         db.candidate.findMany({
           where: { email: { equals: email, mode: 'insensitive' } },
           select: {
-            id: true, email: true, firstName: true, lastName: true, phone: true,
-            source: true, currentTitle: true, organizationId: true, createdAt: true,
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            phone: true,
+            source: true,
+            currentTitle: true,
+            organizationId: true,
+            createdAt: true,
           },
         }),
       ]);
@@ -45,58 +112,114 @@ export const dataRequestsRouter = router({
       }
       // NOTE (CB-1c): this DSAR export is already audited below as `data_subject_export`,
       // per affected SUBJECT org (better attribution than a generic platform_export), so
-      // no logPlatformExport call is added here.
+      // no logPlatformExport call is added here. That row records the EXPORT EVENT; the
+      // §21 per-record `data_access_logs` rows written below are a separate obligation
+      // and neither substitutes for the other.
 
       const candidateIds = candidates.map((c) => c.id);
       const userIds = users.map((u) => u.id);
 
-      const [applications, interviews, offers, assessments, demographics, compensation] =
-        await Promise.all([
-          candidateIds.length
-            ? db.application.findMany({
-                where: { candidateId: { in: candidateIds } },
-                select: { id: true, status: true, appliedAt: true, rejectedReason: true, vacancyId: true },
-              })
-            : [],
-          candidateIds.length
-            ? db.interview.findMany({
-                where: { candidateId: { in: candidateIds } },
-                select: { id: true, type: true, status: true, scheduledAt: true },
-              })
-            : [],
-          candidateIds.length
-            ? db.offer.findMany({
-                where: { candidateId: { in: candidateIds } },
-                select: { id: true, status: true, salary: true, currency: true, startDate: true, contractType: true, createdAt: true },
-              })
-            : [],
-          candidateIds.length
-            ? db.assessmentAssignment.findMany({
-                where: { candidateId: { in: candidateIds } },
-                select: {
-                  id: true, status: true, assignedAt: true, completedAt: true,
-                  assessmentType: { select: { name: true } },
-                  result: { select: { normalizedScore: true } },
-                },
-              })
-            : [],
-          userIds.length
-            ? // Deliberate carve-out: employee.prisma's "DOB never returned raw,
-              // only age bands" rule governs ANALYTICS/dashboards. A Habeas-Data /
-              // GDPR right-of-access export is the one channel where the subject is
-              // entitled to their exact self-ID data, so raw dateOfBirth is correct here.
-              db.employeeDemographics.findMany({
-                where: { userId: { in: userIds } },
-                select: { gender: true, ethnicity: true, nationality: true, disabilityStatus: true, dateOfBirth: true },
-              })
-            : [],
-          userIds.length
-            ? db.employeeCompensation.findMany({
-                where: { userId: { in: userIds } },
-                select: { currentSalary: true, currency: true, effectiveDate: true },
-              })
-            : [],
-        ]);
+      const [applications, interviews, offers, assessments, demographics, compensation] = await Promise.all([
+        candidateIds.length
+          ? db.application.findMany({
+              where: { candidateId: { in: candidateIds } },
+              select: { id: true, status: true, appliedAt: true, rejectedReason: true, vacancyId: true },
+            })
+          : [],
+        candidateIds.length
+          ? db.interview.findMany({
+              where: { candidateId: { in: candidateIds } },
+              select: { id: true, type: true, status: true, scheduledAt: true },
+            })
+          : [],
+        candidateIds.length
+          ? db.offer.findMany({
+              where: { candidateId: { in: candidateIds } },
+              select: {
+                id: true,
+                status: true,
+                salary: true,
+                currency: true,
+                startDate: true,
+                contractType: true,
+                createdAt: true,
+              },
+            })
+          : [],
+        candidateIds.length
+          ? db.assessmentAssignment.findMany({
+              where: { candidateId: { in: candidateIds } },
+              select: {
+                id: true,
+                status: true,
+                assignedAt: true,
+                completedAt: true,
+                assessmentType: { select: { name: true } },
+                // id + organizationId are selected for the §21 audit row below
+                // (data_access_logs.recordId is @db.Uuid and organizationId is a
+                // required scalar); they are the subject's own record keys, so
+                // including them in the bundle is consistent with users/candidates.
+                result: { select: { id: true, organizationId: true, normalizedScore: true } },
+              },
+            })
+          : [],
+        userIds.length
+          ? // Deliberate carve-out: employee.prisma's "DOB never returned raw,
+            // only age bands" rule governs ANALYTICS/dashboards. A Habeas-Data /
+            // GDPR right-of-access export is the one channel where the subject is
+            // entitled to their exact self-ID data, so raw dateOfBirth is correct here.
+            db.employeeDemographics.findMany({
+              where: { userId: { in: userIds } },
+              // id + organizationId: see the §21 audit note on `result` above.
+              select: {
+                id: true,
+                organizationId: true,
+                gender: true,
+                ethnicity: true,
+                nationality: true,
+                disabilityStatus: true,
+                dateOfBirth: true,
+              },
+            })
+          : [],
+        userIds.length
+          ? db.employeeCompensation.findMany({
+              where: { userId: { in: userIds } },
+              // id + organizationId: see the §21 audit note on `result` above.
+              select: {
+                id: true,
+                organizationId: true,
+                currentSalary: true,
+                currency: true,
+                effectiveDate: true,
+              },
+            })
+          : [],
+      ]);
+
+      // §21 +AUDIT: one data_access_logs row per sensitive record actually exposed
+      // by this bundle, keyed to that record's OWN organizationId, written BEFORE
+      // the data is returned so a fail-closed audit failure aborts the export.
+      // These three are exactly the CLASSIFICATION entities this surface reads at
+      // confidential-or-above; `offer.salary` and `candidate` are unregistered
+      // (dataClassOf → 'internal') and are covered by the data_subject_export
+      // audit_logs row below.
+      const auditActor = {
+        actorId: ctx.user.impersonatorId ?? ctx.user.id,
+        ipAddress: ctx.headers.get('x-forwarded-for') || ctx.headers.get('x-real-ip'),
+        userAgent: ctx.headers.get('user-agent'),
+      };
+      const exposedResults = assessments.map((a) => a.result).filter((r): r is NonNullable<typeof r> => r !== null);
+      await Promise.all([
+        // restricted → fail-CLOSED (derived, not hardcoded).
+        auditSensitiveRead(auditActor, 'employeeCompensation', compensation),
+        // confidential → fail-SOFT.
+        auditSensitiveRead(auditActor, 'employeeDemographics', demographics),
+        // assessmentResult is restricted HEADLINE (raw psychometrics), but this
+        // bundle exposes only `normalizedScore`, which is confidential — the mixed
+        // -class override logDataAccess documents for exactly this table.
+        auditSensitiveRead(auditActor, 'assessmentResult', exposedResults, { failClosed: false }),
+      ]);
 
       const bundle = {
         subject: email,
@@ -114,35 +237,29 @@ export const dataRequestsRouter = router({
       // the record durably lands before the serverless function can freeze; the
       // per-write .catch keeps a logging failure from blocking the right-of-access.
       const affectedOrgIds = [
-        ...new Set(
-          [...users, ...candidates]
-            .map((r) => r.organizationId)
-            .filter((id): id is string => !!id),
-        ),
+        ...new Set([...users, ...candidates].map((r) => r.organizationId).filter((id): id is string => !!id)),
       ];
       // Fall back to the operator's own org so an org-less subject (User.organizationId
       // is nullable) is still audited under the platform owner's org. `''` (org-less
       // operator) is falsy and excluded.
       const auditOrgIds =
-        affectedOrgIds.length > 0
-          ? affectedOrgIds
-          : ctx.user.organizationId
-            ? [ctx.user.organizationId]
-            : [];
+        affectedOrgIds.length > 0 ? affectedOrgIds : ctx.user.organizationId ? [ctx.user.organizationId] : [];
       const auditMeta = { email, matched: { users: users.length, candidates: candidates.length } };
       if (auditOrgIds.length > 0) {
         await Promise.all(
           auditOrgIds.map((organizationId) =>
-            db.auditLog.create({
-              data: {
-                organizationId,
-                actorId: ctx.user.id,
-                action: 'data_subject_export',
-                entity: 'data_subject',
-                entityId: email,
-                metadata: auditMeta,
-              },
-            }).catch(() => {}),
+            db.auditLog
+              .create({
+                data: {
+                  organizationId,
+                  actorId: ctx.user.id,
+                  action: 'data_subject_export',
+                  entity: 'data_subject',
+                  entityId: email,
+                  metadata: auditMeta,
+                },
+              })
+              .catch(() => {}),
           ),
         );
       } else {

--- a/packages/api/src/routers/platform/data-requests.ts
+++ b/packages/api/src/routers/platform/data-requests.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { logger } from '@tims/shared';
 import { router } from '../../trpc';
+import { clientIpFrom } from '../../lib/client-ip';
 import { db } from '@tims/db';
 import { dataClassOf } from '../../access';
 import { platformProcedure } from './_common';
@@ -63,7 +64,9 @@ async function auditSensitiveRead(
       });
     }
     logger.warn(
-      { err, entity, rows: rows.length, actorId: actor.actorId },
+      // err.message only — a PrismaClientValidationError serializes the whole
+      // argument object, which carries the actor's ipAddress (personal data).
+      { err: err instanceof Error ? err.message : String(err), entity, rows: rows.length, actorId: actor.actorId },
       'data_access_logs write failed for DSAR export — continuing (fail-soft)',
     );
   }
@@ -206,13 +209,23 @@ export const dataRequestsRouter = router({
       // audit_logs row below.
       const auditActor = {
         actorId: ctx.user.impersonatorId ?? ctx.user.id,
-        ipAddress: ctx.headers.get('x-forwarded-for') || ctx.headers.get('x-real-ip'),
+        // clientIpFrom, not the raw left-most x-forwarded-for: this is the one
+        // forensic field §21 exists to produce, and the first XFF hop is
+        // attacker-chosen. See the derivation note in trpc.ts.
+        ipAddress: clientIpFrom(ctx.headers),
         userAgent: ctx.headers.get('user-agent'),
       };
       const exposedResults = assessments.map((a) => a.result).filter((r): r is NonNullable<typeof r> => r !== null);
+
+      // Compensation FIRST and on its own, deliberately not inside the Promise.all
+      // below. It is the only fail-CLOSED entity, and data_access_logs is append-only
+      // (a BEFORE DELETE OR UPDATE trigger, baseline:5547). If it ran concurrently
+      // and failed, the two fail-soft writes would already have COMMITTED — leaving
+      // permanent, uncorrectable rows asserting that this operator exported that
+      // subject's demographics, for an export that threw and returned nothing.
+      // Sequencing it first means a fail-closed abort leaves no residue at all.
+      await auditSensitiveRead(auditActor, 'employeeCompensation', compensation);
       await Promise.all([
-        // restricted → fail-CLOSED (derived, not hardcoded).
-        auditSensitiveRead(auditActor, 'employeeCompensation', compensation),
         // confidential → fail-SOFT.
         auditSensitiveRead(auditActor, 'employeeDemographics', demographics),
         // assessmentResult is restricted HEADLINE (raw psychometrics), but this
@@ -252,11 +265,19 @@ export const dataRequestsRouter = router({
               .create({
                 data: {
                   organizationId,
-                  actorId: ctx.user.id,
+                  // Same actor derivation as the §21 rows above. It used to be a bare
+                  // ctx.user.id, so under impersonation ONE export produced two audit
+                  // rows naming two different actors — data_access_logs blaming the
+                  // real operator and audit_logs blaming the impersonated user for an
+                  // export they did not perform.
+                  actorId: auditActor.actorId,
                   action: 'data_subject_export',
                   entity: 'data_subject',
                   entityId: email,
                   metadata: auditMeta,
+                  // Columns exist on AuditLog and were simply never populated here.
+                  ipAddress: auditActor.ipAddress,
+                  userAgent: auditActor.userAgent,
                 },
               })
               .catch(() => {}),
@@ -266,8 +287,18 @@ export const dataRequestsRouter = router({
         // Doubly org-less (org-less operator exporting an org-less subject): no valid
         // AuditLog.organizationId exists, so record the access in the structured log
         // rather than let a PII export go completely unaudited.
+        //
+        // `auditMeta` is deliberately NOT spread in: it carries the data subject's
+        // plaintext email, and CLAUDE.md bans PII in logs. The counts are the part
+        // that has forensic value; the subject is identifiable from the audit_logs
+        // row whenever one exists, and this branch is precisely the case where it
+        // does not — so the subject stays out of the log rather than being written
+        // to a sink with different retention and access controls than the audit
+        // tables. (tests/security/pii-protection.test.ts only greps the console
+        // logging idiom, so it does not catch the pino `logger.*` calls this
+        // codebase actually uses — see the follow-up issue.)
         logger.warn(
-          { action: 'data_subject_export', actorId: ctx.user.id, ...auditMeta },
+          { action: 'data_subject_export', actorId: auditActor.actorId, matched: auditMeta.matched },
           'PII data-subject export had no org context for auditLog — logged here instead',
         );
       }

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -2,6 +2,7 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import type { Context } from './context';
 import { db, runWithTenant } from '@tims/db';
+import { clientIpFrom } from './lib/client-ip';
 import { checkRateLimit, getRateLimitCategory } from './middleware/rate-limit';
 import { buildAccessForUser, createAnchorLoader, type AccessContext } from './access';
 import { resolveApiKeyPrincipal, buildExternalAccessUser } from './access/external-auth';
@@ -29,17 +30,8 @@ export const createCallerFactory = t.createCallerFactory;
 // platform edge, not client-spoofable); otherwise use the LAST hop of
 // `x-forwarded-for` (the entry appended by the trusted proxy), never the first.
 function anonymousIdentifier(headers: Headers): string {
-  const realIp = headers.get('x-real-ip')?.trim();
-  if (realIp) return `ip:${realIp}`;
-  const xff = headers.get('x-forwarded-for');
-  if (xff) {
-    const hops = xff
-      .split(',')
-      .map((p) => p.trim())
-      .filter(Boolean);
-    if (hops.length > 0) return `ip:${hops[hops.length - 1]}`;
-  }
-  return 'anonymous';
+  const ip = clientIpFrom(headers);
+  return ip ? `ip:${ip}` : 'anonymous';
 }
 
 // Rate limiting middleware

--- a/tests/governance/sensitive-read-audit.test.ts
+++ b/tests/governance/sensitive-read-audit.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { CLASSIFICATION, auditRequiredFor } from '../../packages/api/src/access';
+
+// ── §21 +AUDIT: every ROW-LEVEL read of a confidential-or-above entity must write
+//    a data_access_logs row ──────────────────────────────────────────────────────
+//
+// This is the CLASS-level control. The DSAR right-of-access export went months
+// writing no `data_access_logs` row at all, and the reason it went unnoticed is that
+// NOTHING enumerated which readers owe one:
+//
+//   - `auditRequiredFor()` — the canonical "does this entity need a row" predicate —
+//     is called by no production code at all, only by tests.
+//   - `tests/access/scope-wiring-sensitive-data.test.ts` has per-file tripwires for
+//     assessment.ts and compensation.ts, and had none for data-requests.ts.
+//
+// So the instance got fixed and the class stayed open. This closes the class.
+//
+// The entity list is DERIVED from `CLASSIFICATION` via the real `auditRequiredFor`,
+// never hardcoded: registering a new confidential-or-above entity automatically
+// extends this control, and de-registering one is caught by the pin at the bottom.
+
+const API_SRC = join(__dirname, '../../packages/api/src');
+
+/** Reads that return ROW DATA. Each such row is a §21 auditable disclosure. */
+const ROW_LEVEL = ['findMany', 'findFirst', 'findUnique', 'findFirstOrThrow', 'findUniqueOrThrow'] as const;
+
+/**
+ * Reads that return only a SCALAR or a grouped tally. Deliberately a separate bucket
+ * rather than an allowlist of files, because the distinction is structural, not
+ * per-site: `DataAccessEvent` requires a `recordId` (`packages/api/src/access/audit.ts`),
+ * and an aggregate has no record to name — the mechanism cannot express it. The
+ * applicable control for these is k-anonymity / sub-floor suppression
+ * (`suppressBelowMin5`), not per-record audit.
+ */
+const AGGREGATE = ['count', 'groupBy', 'aggregate'] as const;
+
+const AUDIT_WRITE = /logDataAccess\(|dataAccessLog\./;
+
+/**
+ * Comment-stripped source. Same shape as `tests/db/pre-flip-scan.test.ts`'s `CODE`.
+ *
+ * NOT optional, and this was caught by mutation rather than reasoning: the first version
+ * of this control tested `AUDIT_WRITE` against raw source, and `data-requests.ts` passed
+ * on the strength of the COMMENT that says `logDataAccess()` is deliberately NOT used
+ * there. Reverting that file to its pre-#155 unaudited state left the suite green — the
+ * control certified a file as audited because its prose named the helper it does not
+ * call. Same defect the calibration tripwire had, one layer up.
+ */
+function codeOnly(src: string): string {
+  return src
+    .split('\n')
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n');
+}
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...tsFilesUnder(p));
+    else if (name.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Scans the WHOLE source, never line by line.
+ *
+ * This is the lesson the calibration tripwire learned the hard way: a line-anchored
+ * scan misses the spelling the formatter actually produces. The real shape in this
+ * repo keeps the model on the first line and wraps the METHOD — e.g.
+ * `tenantDb.userBusinessUnit\n  .findMany({…})` at access/anchors.ts:40-41. (The
+ * other conceivable wrap, receiver-newline-dot-model, has zero occurrences in this
+ * repo, so it is deliberately not invented here.)
+ *
+ * The mechanism that crosses lines is the `\s*` in the pattern — `\s` matches `\n` —
+ * applied to the unsplit string. An earlier version ALSO collapsed whitespace first and
+ * the docblock credited the collapse; mutating the collapse away changed nothing, which
+ * is how the real mechanism was identified. The redundant step is gone so there is one
+ * mechanism, and the fixture test below mutation-proves it by deleting `\s*`.
+ */
+export function readsIn(src: string, entities: readonly string[]): Array<{ entity: string; method: string }> {
+  const methods = [...ROW_LEVEL, ...AGGREGATE].join('|');
+  const found: Array<{ entity: string; method: string }> = [];
+  for (const e of entities) {
+    const re = new RegExp(`\\.\\s*${e}\\s*\\.\\s*(${methods})\\b`, 'g');
+    for (const m of src.matchAll(re)) found.push({ entity: e, method: m[1] });
+  }
+  return found;
+}
+
+const AUDITED_ENTITIES = Object.keys(CLASSIFICATION).filter((e) => auditRequiredFor(e));
+
+interface Reader {
+  file: string;
+  rowLevel: Array<{ entity: string; method: string }>;
+  aggregate: Array<{ entity: string; method: string }>;
+  audits: boolean;
+}
+
+const readers: Reader[] = tsFilesUnder(API_SRC)
+  .map((abs) => {
+    // Comment-stripped for BOTH halves: a commented-out delegate read must not count as
+    // a reader, and prose naming logDataAccess must not count as an audit.
+    const src = codeOnly(readFileSync(abs, 'utf8'));
+    const reads = readsIn(src, AUDITED_ENTITIES);
+    return {
+      file: relative(join(__dirname, '../..'), abs),
+      rowLevel: reads.filter((r) => (ROW_LEVEL as readonly string[]).includes(r.method)),
+      aggregate: reads.filter((r) => (AGGREGATE as readonly string[]).includes(r.method)),
+      audits: AUDIT_WRITE.test(src),
+    };
+  })
+  .filter((r) => r.rowLevel.length > 0 || r.aggregate.length > 0);
+
+/**
+ * Files that read an audit-required entity but ONLY in aggregate. Pinned by name so a
+ * file gaining its first row-level read cannot slip in silently — it would move buckets
+ * and fail the primary assertion, and this list would go stale-red at the same time.
+ * Adding an entry is a deliberate edit with a reviewer attached, which is the point.
+ */
+const AGGREGATE_ONLY = [
+  'packages/api/src/repositories/alert-evaluation.repository.ts', // salaryAdjustment.count — alert metrics
+  'packages/api/src/repositories/candidate-assessment.repository.ts', // assessmentResult.count ×3 — percentile norming
+  'packages/api/src/repositories/dei.repository.ts', // employeeDemographics.groupBy — min-5 suppressed
+  'packages/api/src/routers/monitoring.ts', // salaryAdjustment.count, surveyResponse.count — suppressBelowMin5
+].sort();
+
+describe('§21 — every row-level read of a confidential+ entity is audited', () => {
+  it('derives its entity list from the real CLASSIFICATION registry, and that registry is non-empty', () => {
+    // Non-vacuity first: if `auditRequiredFor` ever returned false for everything, every
+    // assertion below would pass while checking nothing.
+    expect(AUDITED_ENTITIES.length).toBeGreaterThanOrEqual(5);
+    expect(AUDITED_ENTITIES).toEqual(
+      expect.arrayContaining([
+        'employeeCompensation',
+        'salaryAdjustment',
+        'assessmentResult',
+        'employeeDemographics',
+        'surveyResponse',
+      ]),
+    );
+  });
+
+  it('found a non-trivial population of readers — a clean result over zero files proves nothing', () => {
+    expect(readers.length).toBeGreaterThanOrEqual(6);
+    expect(readers.some((r) => r.rowLevel.length > 0)).toBe(true);
+  });
+
+  it('every file with a ROW-LEVEL read writes a data_access_logs row', () => {
+    const unaudited = readers
+      .filter((r) => r.rowLevel.length > 0 && !r.audits)
+      .map((r) => `${r.file} reads ${[...new Set(r.rowLevel.map((x) => `${x.entity}.${x.method}`))].join(', ')}`);
+    expect(
+      unaudited,
+      'These files return ROW DATA for a confidential-or-above entity without writing a data_access_logs ' +
+        'row. Either audit the read (logDataAccess for tenant-scoped paths; see data-requests.ts for why a ' +
+        'cross-org surface must use the privileged client instead), or narrow the read to an aggregate and ' +
+        'add it to AGGREGATE_ONLY with a reason.',
+    ).toEqual([]);
+  });
+
+  it('the aggregate-only readers are exactly the pinned set', () => {
+    const actual = readers
+      .filter((r) => r.rowLevel.length === 0 && r.aggregate.length > 0)
+      .map((r) => r.file)
+      .sort();
+    expect(actual).toEqual(AGGREGATE_ONLY);
+  });
+
+  it('the scan sees a Prettier-WRAPPED chain, not just a single-line one', () => {
+    // Drives the real scanner, not the regex — the distinction that made the calibration
+    // tripwire blind. Fixture shape copied from access/anchors.ts:40-41, the way this repo
+    // actually formats a wrapped delegate read.
+    const wrapped = `
+      const rows = await tenantDb.employeeCompensation
+        .findMany({ where: { organizationId }, select: { currentSalary: true } })
+        .then((r) => r);
+    `;
+    expect(readsIn(wrapped, AUDITED_ENTITIES)).toEqual([{ entity: 'employeeCompensation', method: 'findMany' }]);
+  });
+
+  it('classifies aggregate and row-level reads into the right buckets', () => {
+    const src = 'await db.salaryAdjustment.count({}); await db.employeeDemographics.findMany({});';
+    const reads = readsIn(src, AUDITED_ENTITIES);
+    expect(reads).toContainEqual({ entity: 'salaryAdjustment', method: 'count' });
+    expect(reads).toContainEqual({ entity: 'employeeDemographics', method: 'findMany' });
+  });
+});

--- a/tests/platform/data-requests-dsar-audit.test.ts
+++ b/tests/platform/data-requests-dsar-audit.test.ts
@@ -223,6 +223,109 @@ describe('DSAR export — failure policy is derived from the classification regi
   });
 });
 
+describe('DSAR export — cases the first round of these tests did not cover', () => {
+  it('keys rows per-record when one subject spans TWO orgs — the reason logDataAccess cannot be used', async () => {
+    // A user in org A and a same-email candidate in org B is reachable, and it is
+    // the entire justification for writing through the privileged client with an
+    // explicit per-row org. A single-org fixture cannot prove it.
+    const ORG_B = '77777777-7777-4777-8777-777777777777';
+    findMany.employeeCompensation.mockResolvedValue([
+      { id: COMP_ID, organizationId: SUBJECT_ORG, currentSalary: 100 },
+      { id: '88888888-8888-4888-8888-888888888888', organizationId: ORG_B, currentSalary: 200 },
+    ]);
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    const comp = writtenRows().filter((r) => r.dataType === 'employeeCompensation');
+    expect(comp).toHaveLength(2);
+    expect(new Set(comp.map((r) => r.organizationId))).toEqual(new Set([SUBJECT_ORG, ORG_B]));
+  });
+
+  it('audits a candidate-only subject (no User row) — the common ATS case', async () => {
+    findMany.user.mockResolvedValue([]);
+    findMany.employeeDemographics.mockResolvedValue([]);
+    findMany.employeeCompensation.mockResolvedValue([]);
+    const out = await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(out.counts.candidates).toBe(1);
+    // The user-side reads are skipped entirely, so only the assessment result remains.
+    expect(writtenRows().map((r) => r.dataType)).toEqual(['assessmentResult']);
+  });
+
+  it('writes no assessmentResult row for an assignment that was never completed', async () => {
+    findMany.assessmentAssignment.mockResolvedValue([
+      { id: 'asg-1', status: 'pending', result: null },
+      { id: 'asg-2', status: 'done', result: { id: RESULT_ID, organizationId: SUBJECT_ORG, normalizedScore: 71 } },
+    ]);
+    const out = await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(out.counts.assessments).toBe(2);
+    expect(writtenRows().filter((r) => r.dataType === 'assessmentResult')).toHaveLength(1);
+  });
+
+  it('rejects a non-platform-owner — the owner gate this harness keeps real', async () => {
+    const outsider = createCaller({
+      user: { id: 'staff-1', organizationId: SUBJECT_ORG, isPlatformOwner: false },
+      headers: new Headers(),
+    }) as unknown as DsarCaller;
+    await expect(outsider.exportSubjectData({ email: 'a@b.com' })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(dataAccessCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('derives ipAddress from the LAST x-forwarded-for hop, not the attacker-chosen first', async () => {
+    const c = createCaller({
+      user: { id: 'operator-1', organizationId: OPERATOR_ORG, isPlatformOwner: true },
+      headers: new Headers({ 'x-forwarded-for': '1.2.3.4, 10.0.0.9' }),
+    }) as unknown as DsarCaller;
+    await c.exportSubjectData({ email: 'a@b.com' });
+    for (const r of writtenRows()) expect(r.ipAddress).toBe('10.0.0.9');
+  });
+
+  it('prefers x-real-ip over x-forwarded-for entirely', async () => {
+    const c = createCaller({
+      user: { id: 'operator-1', organizationId: OPERATOR_ORG, isPlatformOwner: true },
+      headers: new Headers({ 'x-forwarded-for': '1.2.3.4', 'x-real-ip': '10.0.0.9' }),
+    }) as unknown as DsarCaller;
+    await c.exportSubjectData({ email: 'a@b.com' });
+    for (const r of writtenRows()) expect(r.ipAddress).toBe('10.0.0.9');
+  });
+});
+
+describe('DSAR export — a fail-closed abort must leave no residue', () => {
+  it('writes NO fail-soft rows when the fail-closed compensation audit fails', async () => {
+    // data_access_logs is append-only (BEFORE DELETE OR UPDATE trigger), so a row
+    // written before the abort can never be corrected. Concurrent writes would leave
+    // permanent rows asserting an export that in fact threw and returned nothing.
+    dataAccessCreateMany.mockImplementation((args: { data: Array<{ dataType: string }> }) =>
+      args.data[0]?.dataType === 'employeeCompensation'
+        ? Promise.reject(new Error('audit write failed'))
+        : Promise.resolve({ count: args.data.length }),
+    );
+    await expect(caller().exportSubjectData({ email: 'a@b.com' })).rejects.toBeInstanceOf(TRPCError);
+    expect(writtenRows().filter((r) => r.dataType !== 'employeeCompensation')).toHaveLength(0);
+  });
+
+  it('aborts with INTERNAL_SERVER_ERROR, not a code the UI echoes to the browser', async () => {
+    // data-requests.tsx surfaces NOT_FOUND messages verbatim; anything else is
+    // collapsed to generic copy. A drift to NOT_FOUND would leak internals.
+    dataAccessCreateMany.mockRejectedValue(new Error('audit write failed'));
+    await expect(caller().exportSubjectData({ email: 'a@b.com' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});
+
+describe('DSAR export — the bundle shape is pinned', () => {
+  it('exposes exactly the documented key set per section', async () => {
+    // The product's only statutory-disclosure surface. Nothing pinned the bundle
+    // before, so a future select adding an SSN or password column was caught by
+    // zero tests.
+    const out = await caller().exportSubjectData({ email: 'a@b.com' });
+    const bundle = JSON.parse(out.json);
+    expect(Object.keys(bundle).sort()).toEqual(['generatedAt', 'hr', 'identity', 'recruitment', 'subject']);
+    expect(Object.keys(bundle.identity).sort()).toEqual(['candidates', 'users']);
+    expect(Object.keys(bundle.recruitment).sort()).toEqual(['applications', 'assessments', 'interviews', 'offers']);
+    expect(Object.keys(bundle.hr).sort()).toEqual(['compensation', 'demographics']);
+    expect(bundle.subject).toBe('a@b.com');
+  });
+});
+
 describe('DSAR export — the §21 rows do not replace the export-event audit', () => {
   it('still writes the data_subject_export audit_logs row, keyed to the subject org', async () => {
     await caller().exportSubjectData({ email: 'a@b.com' });
@@ -230,6 +333,22 @@ describe('DSAR export — the §21 rows do not replace the export-event audit', 
     const arg = auditLogCreate.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(arg.data.action).toBe('data_subject_export');
     expect(arg.data.organizationId).toBe(SUBJECT_ORG);
+  });
+
+  it('names the SAME actor on both audit rows under impersonation', async () => {
+    // Previously data_access_logs used `impersonatorId ?? id` while audit_logs used a
+    // bare ctx.user.id, so one export produced two rows blaming two different people.
+    await caller(OPERATOR_ORG, 'real-admin-9').exportSubjectData({ email: 'a@b.com' });
+    const auditArg = auditLogCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(auditArg.data.actorId).toBe('real-admin-9');
+    for (const r of writtenRows()) expect(r.actorId).toBe(auditArg.data.actorId);
+  });
+
+  it('stamps ip / user-agent on the export-event row too', async () => {
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    const auditArg = auditLogCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(auditArg.data.ipAddress).toBe('203.0.113.7');
+    expect(auditArg.data.userAgent).toBe('jest-ua/1.0');
   });
 
   it('the §21 write happens BEFORE the export-event row, so a fail-closed abort leaves no false receipt', async () => {

--- a/tests/platform/data-requests-dsar-audit.test.ts
+++ b/tests/platform/data-requests-dsar-audit.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { initTRPC, TRPCError } from '@trpc/server';
+
+// ── §21 +AUDIT coverage for the DSAR right-of-access export ──────────────────
+// `exportSubjectData` is the only statutory-compliance surface in the product and
+// until now had ZERO behavioural tests. It reads three CLASSIFICATION entities at
+// confidential-or-above (employeeCompensation = restricted, employeeDemographics =
+// confidential, assessmentResult = restricted headline / confidential here) and
+// wrote no `data_access_logs` row for any of them — the only audit was a
+// fail-OPEN `audit_logs` insert to a DIFFERENT table.
+//
+// These tests pin the behaviour, not the source text: a grep-only pin would tick
+// green against a call that never runs.
+//
+// We mock `@tims/db` and `../trpc` (so `protectedProcedure` is a pass-through and
+// the REAL `platformProcedure` owner gate still runs), and keep the REAL access
+// barrel so the fail-closed/fail-soft policy is derived from the real registry.
+
+const findMany = {
+  user: vi.fn(),
+  candidate: vi.fn(),
+  application: vi.fn(),
+  interview: vi.fn(),
+  offer: vi.fn(),
+  assessmentAssignment: vi.fn(),
+  employeeDemographics: vi.fn(),
+  employeeCompensation: vi.fn(),
+};
+const dataAccessCreateMany = vi.fn();
+const auditLogCreate = vi.fn();
+const loggerWarn = vi.fn();
+
+vi.mock('@tims/db', () => ({
+  db: {
+    user: { findMany: (...a: unknown[]) => findMany.user(...a) },
+    candidate: { findMany: (...a: unknown[]) => findMany.candidate(...a) },
+    application: { findMany: (...a: unknown[]) => findMany.application(...a) },
+    interview: { findMany: (...a: unknown[]) => findMany.interview(...a) },
+    offer: { findMany: (...a: unknown[]) => findMany.offer(...a) },
+    assessmentAssignment: { findMany: (...a: unknown[]) => findMany.assessmentAssignment(...a) },
+    employeeDemographics: { findMany: (...a: unknown[]) => findMany.employeeDemographics(...a) },
+    employeeCompensation: { findMany: (...a: unknown[]) => findMany.employeeCompensation(...a) },
+    dataAccessLog: { createMany: (...a: unknown[]) => dataAccessCreateMany(...a) },
+    auditLog: { create: (...a: unknown[]) => auditLogCreate(...a) },
+  },
+  // audit.ts binds to tenantDb at module load; never exercised on this path.
+  tenantDb: {},
+}));
+
+vi.mock('@tims/shared', async () => {
+  const actual = await vi.importActual<typeof import('@tims/shared')>('@tims/shared');
+  return { ...actual, logger: { ...actual.logger, warn: (...a: unknown[]) => loggerWarn(...a) } };
+});
+
+vi.mock('../../packages/api/src/trpc', () => {
+  const t = initTRPC
+    .context<{
+      user: { id: string; organizationId: string; isPlatformOwner: boolean; impersonatorId?: string | null };
+      headers: Headers;
+    }>()
+    .create();
+  return { router: t.router, protectedProcedure: t.procedure };
+});
+
+import { dataRequestsRouter } from '../../packages/api/src/routers/platform/data-requests';
+import { dataClassOf } from '../../packages/api/src/access';
+
+const t = initTRPC
+  .context<{
+    user: { id: string; organizationId: string; isPlatformOwner: boolean; impersonatorId?: string | null };
+    headers: Headers;
+  }>()
+  .create();
+const createCaller = t.createCallerFactory(
+  dataRequestsRouter as unknown as Parameters<typeof t.createCallerFactory>[0],
+);
+
+interface DsarCaller {
+  exportSubjectData(input: { email: string }): Promise<{ json: string; counts: Record<string, number> }>;
+}
+
+// The SUBJECT's org — deliberately different from the operator's, because that
+// divergence is the whole reason this cannot go through tenantDb/logDataAccess.
+const SUBJECT_ORG = '22222222-2222-4222-8222-222222222222';
+const OPERATOR_ORG = '99999999-9999-4999-8999-999999999999';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const CANDIDATE_ID = '66666666-6666-4666-8666-666666666666';
+const COMP_ID = '33333333-3333-4333-8333-333333333333';
+const DEMO_ID = '44444444-4444-4444-8444-444444444444';
+const RESULT_ID = '55555555-5555-4555-8555-555555555555';
+
+const caller = (operatorOrg = OPERATOR_ORG, impersonatorId?: string) =>
+  createCaller({
+    user: { id: 'operator-1', organizationId: operatorOrg, isPlatformOwner: true, impersonatorId },
+    headers: new Headers({ 'x-forwarded-for': '203.0.113.7', 'user-agent': 'jest-ua/1.0' }),
+  }) as unknown as DsarCaller;
+
+/** Rows returned by each mocked read. `sensitive: false` = no confidential+ rows. */
+function seed(opts: { sensitive?: boolean } = {}) {
+  const sensitive = opts.sensitive ?? true;
+  findMany.user.mockResolvedValue([
+    { id: USER_ID, email: 'a@b.com', firstName: 'A', lastName: 'B', organizationId: SUBJECT_ORG },
+  ]);
+  // A candidate row is required for the recruitment-side reads to run at all:
+  // applications/interviews/offers/assessments are gated on `candidateIds.length`.
+  findMany.candidate.mockResolvedValue([
+    { id: CANDIDATE_ID, email: 'a@b.com', firstName: 'A', lastName: 'B', organizationId: SUBJECT_ORG },
+  ]);
+  findMany.application.mockResolvedValue([]);
+  findMany.interview.mockResolvedValue([]);
+  findMany.offer.mockResolvedValue([]);
+  findMany.assessmentAssignment.mockResolvedValue(
+    sensitive
+      ? [{ id: 'asg-1', status: 'done', result: { id: RESULT_ID, organizationId: SUBJECT_ORG, normalizedScore: 71 } }]
+      : [],
+  );
+  findMany.employeeDemographics.mockResolvedValue(
+    sensitive ? [{ id: DEMO_ID, organizationId: SUBJECT_ORG, gender: 'female', dateOfBirth: null }] : [],
+  );
+  findMany.employeeCompensation.mockResolvedValue(
+    sensitive ? [{ id: COMP_ID, organizationId: SUBJECT_ORG, currentSalary: 100, currency: 'COP' }] : [],
+  );
+}
+
+/** All data_access_logs rows written, flattened across the per-entity createMany calls. */
+function writtenRows(): Array<Record<string, unknown>> {
+  return dataAccessCreateMany.mock.calls.flatMap((c) => (c[0] as { data: Array<Record<string, unknown>> }).data);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dataAccessCreateMany.mockResolvedValue({ count: 1 });
+  auditLogCreate.mockResolvedValue({});
+  seed();
+});
+
+describe('DSAR export — §21 data_access_logs rows', () => {
+  it('writes one row per exposed sensitive record, for all three registered entities', async () => {
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    const rows = writtenRows();
+    expect(rows.map((r) => r.dataType).sort()).toEqual([
+      'assessmentResult',
+      'employeeCompensation',
+      'employeeDemographics',
+    ]);
+  });
+
+  it('keys each row to the RECORD’s org, never the operator’s', async () => {
+    await caller(OPERATOR_ORG).exportSubjectData({ email: 'a@b.com' });
+    const orgs = new Set(writtenRows().map((r) => r.organizationId));
+    expect(orgs).toEqual(new Set([SUBJECT_ORG]));
+    expect(orgs.has(OPERATOR_ORG)).toBe(false);
+  });
+
+  it('records the record id as recordId (a real uuid), not the email or the user id', async () => {
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    const byType = Object.fromEntries(writtenRows().map((r) => [r.dataType, r.recordId]));
+    expect(byType.employeeCompensation).toBe(COMP_ID);
+    expect(byType.employeeDemographics).toBe(DEMO_ID);
+    expect(byType.assessmentResult).toBe(RESULT_ID);
+    expect(Object.values(byType)).not.toContain('a@b.com');
+    expect(Object.values(byType)).not.toContain(USER_ID);
+  });
+
+  it('stamps action=export plus the caller ip / user-agent', async () => {
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    for (const r of writtenRows()) {
+      expect(r.action).toBe('export');
+      expect(r.ipAddress).toBe('203.0.113.7');
+      expect(r.userAgent).toBe('jest-ua/1.0');
+    }
+  });
+
+  it('attributes to the impersonator when the session is impersonating', async () => {
+    await caller(OPERATOR_ORG, 'real-admin-9').exportSubjectData({ email: 'a@b.com' });
+    for (const r of writtenRows()) expect(r.actorId).toBe('real-admin-9');
+  });
+
+  it('writes nothing when the subject has no confidential-or-above records', async () => {
+    seed({ sensitive: false });
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(dataAccessCreateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('DSAR export — failure policy is derived from the classification registry', () => {
+  /** Reject only the createMany carrying `dataType`; resolve every other entity. */
+  const failOnly = (dataType: string) =>
+    dataAccessCreateMany.mockImplementation((args: { data: Array<{ dataType: string }> }) =>
+      args.data[0]?.dataType === dataType
+        ? Promise.reject(new Error('audit write failed'))
+        : Promise.resolve({ count: args.data.length }),
+    );
+
+  it('employeeCompensation is restricted → fail-CLOSED: the export aborts and returns no data', async () => {
+    failOnly('employeeCompensation');
+    await expect(caller().exportSubjectData({ email: 'a@b.com' })).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it('employeeDemographics is confidential → fail-SOFT: the export still returns', async () => {
+    failOnly('employeeDemographics');
+    const out = await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(out.counts.demographics).toBe(1);
+    expect(loggerWarn).toHaveBeenCalled();
+  });
+
+  it('assessmentResult is fail-SOFT here via the documented mixed-class override', async () => {
+    // Headline dataClass is `restricted` (raw psychometrics), so without the
+    // explicit `{ failClosed: false }` this would abort — the bundle exposes only
+    // the confidential `normalizedScore`.
+    expect(dataClassOf('assessmentResult')).toBe('restricted');
+    failOnly('assessmentResult');
+    const out = await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(out.counts.assessments).toBe(1);
+  });
+
+  it('the registry entries the policy is derived from still exist', () => {
+    // dataClassOf() falls back to 'internal' for an UNREGISTERED entity, so deleting
+    // either entry would silently downgrade compensation from fail-closed to
+    // fail-soft with no tsc error and no runtime warning. This is that tripwire.
+    expect(dataClassOf('employeeCompensation')).toBe('restricted');
+    expect(dataClassOf('employeeDemographics')).toBe('confidential');
+  });
+});
+
+describe('DSAR export — the §21 rows do not replace the export-event audit', () => {
+  it('still writes the data_subject_export audit_logs row, keyed to the subject org', async () => {
+    await caller().exportSubjectData({ email: 'a@b.com' });
+    expect(auditLogCreate).toHaveBeenCalledTimes(1);
+    const arg = auditLogCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(arg.data.action).toBe('data_subject_export');
+    expect(arg.data.organizationId).toBe(SUBJECT_ORG);
+  });
+
+  it('the §21 write happens BEFORE the export-event row, so a fail-closed abort leaves no false receipt', async () => {
+    dataAccessCreateMany.mockRejectedValue(new Error('audit write failed'));
+    await expect(caller().exportSubjectData({ email: 'a@b.com' })).rejects.toBeInstanceOf(TRPCError);
+    expect(auditLogCreate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/security/pii-protection.test.ts
+++ b/tests/security/pii-protection.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 
 const ROOT = join(__dirname, '../..');
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...tsFilesUnder(p));
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
 
 function grepCode(pattern: string, paths: string[]): string[] {
   try {
@@ -24,6 +34,51 @@ describe('PII Protection', () => {
       ['packages/api/src/'],
     );
     expect(violations).toEqual([]);
+  });
+
+  it('should NOT log PII through the pino logger either', () => {
+    // The assertion above only greps `console.log`. This codebase does not log that way —
+    // it logs through pino (`logger.warn/error/info` from @tims/shared), so CLAUDE.md's
+    // "no console.log with PII" ban was unenforceable against the idiom actually in use.
+    // Found while fixing the DSAR §21 audit gap: `data-requests.ts` was spreading the data
+    // subject's plaintext email into a `logger.warn` payload, four lines from the audit
+    // code, and no test objected.
+    //
+    // ⚠️ KNOWN LIMIT, stated rather than implied: this catches a LITERAL key
+    // (`{ email }`, `{ email: x }`). It does NOT catch a spread — `{ ...auditMeta }`,
+    // which is exactly how the DSAR leak was actually written. Verified by mutation:
+    // restoring the real `...auditMeta` spread leaves this green. Resolving a spread
+    // needs type information, not a source scan. So this control raises the floor
+    // (the obvious spelling can no longer land) without closing the class, and the
+    // review checklist still has to catch a spread of an object holding PII.
+    //
+    // Deliberately narrow on the key list too: a pattern this cannot express precisely
+    // is worse than no control, because a check that cries wolf gets switched off.
+    //
+    // Scanned ACROSS LINES, not with grep. `grepCode` is line-based, and Prettier puts the
+    // payload object on its own line:
+    //     logger.warn(
+    //       { action: 'x', email, matched },
+    //       'message',
+    //     );
+    // A line-anchored pattern sees `logger.warn(` and the payload separately and matches
+    // neither — verified by mutation: the line-based version stayed green against a
+    // deliberately reintroduced `email` key.
+    const violations: string[] = [];
+    for (const file of tsFilesUnder(join(ROOT, 'packages/api/src'))) {
+      const src = readFileSync(file, 'utf8');
+      for (const m of src.matchAll(/logger\s*\.\s*(?:warn|error|info|debug)\s*\(\s*\{([^}]*)\}/gs)) {
+        if (/(?:^|[,{\s])(email|ssn|salary|password)\s*[,:}]/.test(m[1])) {
+          violations.push(`${file.replace(ROOT + '/', '')}: ${m[1].trim().slice(0, 60)}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      'A pino logger call puts PII (email/ssn/salary/password) in its payload. Log an id or a count ' +
+        'instead — the subject is recoverable from the audit tables, which have different retention and ' +
+        'access controls than the log sink.',
+    ).toEqual([]);
   });
 
   it('should have SES email utility that does not log email content', () => {


### PR DESCRIPTION
Fixes a **live compliance defect** on the DSAR right-of-access surface. Independent of #66 — this is not a flip unblocker and does not touch ownership.

## The defect

`exportSubjectData` (`packages/api/src/routers/platform/data-requests.ts`) is the GDPR / Ley 1581/2012 right-of-access export: a cross-org, PII-bearing bundle carrying salary, date of birth, ethnicity and disability status. It had **no `logDataAccess` call and no `data_access_logs` row of any kind.**

The only audit was `db.auditLog.create` at `:136` — a **different table**, **fail-open** (`.catch(() => {})`), with no `recordId`, no IP and no user-agent.

#146's AC #2 says the §21 audit "must be **preserved**". There was nothing to preserve. **A reviewer would have ticked that box against nothing.** The AC is corrected in the issue to say _added_.

## The fix

One `data_access_logs` row per sensitive record actually exposed, keyed to that **record's own** org:

| Entity                 | Class               | Policy                                                                                                         |
| ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
| `employeeCompensation` | restricted          | **fail-CLOSED** — aborts the export                                                                            |
| `employeeDemographics` | confidential        | fail-SOFT                                                                                                      |
| `assessmentResult`     | restricted headline | fail-SOFT via the documented mixed-class override — the bundle exposes only the confidential `normalizedScore` |

These are exactly the `CLASSIFICATION` entities this surface reads at confidential-or-above. The three selects are widened with `id` + `organizationId`: `DataAccessLog.recordId` is `@db.Uuid` and `organizationId` is a required scalar, and **neither was selected**.

### Why not `logDataAccess()` — the load-bearing design decision

`logDataAccess` writes through `tenantDb`. A platform owner who **has** an org of their own flows through `runWithTenant(ownOrg)` (`trpc.ts:106-128`), so the insert runs under `SET LOCAL ROLE app_tenant` with the GUC pinned to the **operator's** org. A row carrying the **subject's** org is then rejected by the fail-closed `tenant_isolation` `WITH CHECK` (live policy at `baseline:7575`, no `IS NULL` escape). For the fail-closed compensation rows that **aborts the export**.

It would have broken for exactly the operators who have an org and silently worked for those who don't. So this writes through the privileged BYPASSRLS `db` with an explicit `organizationId` — the same shape the `audit_logs` insert already used.

The security lens attacked this claim specifically (its best shot at refuting the design was that platform routers might skip `withTenantContext` — they do not, `trpc.ts:244`) and **verified it true end to end**.

Failure policy is derived from `classification.ts`, not hardcoded, so it stays in step with `logDataAccess`.

## Second round — findings from the tier-3 panel, all fixed

The panel reviewed `dd8b47ea` and found **zero blockers** but one gap that **defeated the fix**:

- **The cache path.** `exportSubjectData` is a `.query()`, the QueryClient default is `staleTime: 300_000`, and the consumer calls `utils.*.fetch` = `queryClient.fetchQuery` — which serves a fresh entry with **no server round-trip**. Exporting the same subject twice inside five minutes re-downloaded the full PII bundle with **zero rows in either audit table**, because the procedure never ran. Fixed at the call site with `{ staleTime: 0, gcTime: 0 }`, with the reason recorded so it does not get "optimised" back. No server-side test can catch this.
- **A fail-closed abort left permanent residue.** The three audits ran concurrently; when compensation failed, the two fail-soft rows had already committed — and `data_access_logs` is append-only, so they can never be corrected. Permanent rows asserting an export that in fact threw. Compensation now runs first and alone.
- **Two audit rows naming two different actors.** The §21 rows used `impersonatorId ?? id`, the `audit_logs` row a bare `ctx.user.id`. Under impersonation one export blamed two different people. Aligned; `ipAddress`/`userAgent` backfilled onto `audit_logs` too (the columns existed and were never populated).
- **The forensic IP was attacker-controlled.** The raw left-most `x-forwarded-for` was used, while `trpc.ts:26-31` documents the opposite priority in prose. Extracted to `packages/api/src/lib/client-ip.ts` (a leaf module — `trpc.ts` bootstraps auth/env/Redis at import, so a test cannot import it to exercise the derivation for real).
- **PII in a structured log.** The doubly-org-less branch spread `...auditMeta`, writing the subject's plaintext email to the log. Now counts only.
- **`cb-1-audit-immutability.md`** said "the only writer is `db.dataAccessLog.create`". There are now two. Corrected.

## Tests — 23, the first behavioural tests this surface has ever had

Previously only source-text greps existed (`security-event-coverage.test.ts:361`). These pin behaviour: a grep-only pin ticks green against a call that never runs. 22 behavioural + 1 registry tripwire — `dataClassOf()` falls back to `'internal'` for an unregistered entity, so deleting a `CLASSIFICATION` entry would silently downgrade compensation from fail-closed to fail-soft with no `tsc` error and no runtime warning.

Notable coverage added in round 2: a subject **spanning two orgs** (the entire justification for per-row org keying, previously unproven by a single-org fixture), a candidate-only subject, a null assessment result, and the platform-owner gate — which the test header _claimed_ to keep real and never exercised.

**Six mutation proofs**, all `python3` literal replace with the occurrence count asserted, the mutated line shown before each run, and the file restored byte-identical after:

| Mutation                                                  | Result |
| --------------------------------------------------------- | ------ |
| drop the compensation audit call (the pre-fix state)      | 4 red  |
| key rows to the operator's org (threaded through `actor`) | 1 red  |
| drop `{ failClosed: false }` on `assessmentResult`        | 1 red  |
| revert compensation-first to the concurrent `Promise.all` | 1 red  |
| revert `audit_logs` `actorId` to bare `ctx.user.id`       | 1 red  |
| revert to the raw left-most `x-forwarded-for`             | 2 red  |

## Verification

**Tier that actually ran: 3 (same-model adversarial panel). This is NOT cross-model review.**

- **Tier 1 (Codex, `/gate` check 15): exit 2 — NOT RUN.** Quota-blocked; the CLI's own message names 2026-08-15. Exit 2 is not a pass. **7th consecutive exit 2.**
- **Tier 2 (OmniRoute, different-vendor): exit 2 — refused to run.** `OMNIROUTE_MODEL` unset, no default since 2026-08-05; the script refuses rather than silently downgrading to an unattributable router model.
- **Tier 3 substitute executed** against this branch's own commits: 3 lenses (security/tenant-isolation · claim auditor · coverage), each prompted to **refute**, each re-reading source at the commit blobs. Zero blockers; everything above came out of it. The claim auditor independently re-ran the mutations in an isolated worktree and corrected one under-specified description, recorded in the follow-up commit rather than quietly amended.

Per `.claude/rules/verification.md`, do not restate this as cross-model verified.

Measured on the exact tree, nothing else on the machine, redirected with `$?` checked, never piped: **`npx vitest run` exit 0, 2751 passed / 291 files**. `tsc --noEmit` exit 0 on both `@tims/api` and `apps/web`. `/gate` check-3 anchor updated to the measured number.

## ⚠️ Before merge — one prod smoke test is worth it

This is the **first fail-CLOSED privileged write to an audit table** in the codebase. Every existing one is fail-open (`security-audit.ts:56`, and this file's own `audit_logs` `.catch(() => {})`), so the codebase has never had the opportunity to observe whether these writes actually land in prod. If it fails for any reason — grants, `RLS_ENFORCED` misconfiguration — the DSAR export 500s **every time**, and the UI collapses it to generic copy so the operator cannot tell why.

The BYPASSRLS reasoning is verified from the committed baseline, not against a live database (local Prisma is P1000-broken). **Recommend one export against a subject with an `employeeCompensation` row before merge.**

## Follow-ups filed separately, not smuggled in

- `offer.salary` is exported with no §21 row — `Offer` is not in `CLASSIFICATION`, but §21 classifies Compensation/Salary as a data _type_.
- No tripwire enumerates confidential+ readers, so the _class_ of defect is unfixed even though this instance is.
- `compensation.ts:104` and `assessment.ts:52` share the IP-derivation defect.
- `tests/security/pii-protection.test.ts` only greps the console idiom, so CLAUDE.md's PII-in-logs ban is unenforceable against the pino `logger.*` calls this codebase actually uses.

Refs #146

## Issue linkage

Closes #157 — this PR carries the class-level control that issue asked for (`tests/governance/sensitive-read-audit.test.ts`, derived from `CLASSIFICATION` via the real `auditRequiredFor`, comment-stripped) **and** its "sibling gap, same shape" item: `tests/security/pii-protection.test.ts` now scans the pino idiom across lines, not just `console.log`. That content arrived here via #160, which was merged into this branch by mistake rather than into main; #160 is closed and its commit `a1f5c616` is in this PR.
