### PR TITLE
docs(runbook): correct the compensation read-site count and the Extract credential path

### DIFF
--- a/docs/architecture/csharp-migration/ownership-flip-runbook.md
+++ b/docs/architecture/csharp-migration/ownership-flip-runbook.md
@@ -167,8 +167,20 @@ Each reader gets exactly one disposition, decided before the PR:
 - **Repoint** — the whole procedure moves to the C# read endpoint through the
   `apps/web/lib/platform-api/*` wrapper pattern.
 - **Extract** — the read site sits **inside a procedure that must survive**. Neither "Delete" nor
-  "Repoint" applies: the surrounding procedure stays on tRPC and the one read must be served
-  server-to-server from the C# read surface. Worked counterexample the taxonomy previously had no slot
+  "Repoint" applies: the surrounding procedure stays on tRPC and the one read must be served from the
+  C# read surface.
+
+  > ⚠️ **Corrected 2026-08-07.** This bullet used to say "server-to-server". **No such credential path
+  > is wired**, so every Extract taught from it would be mis-designed. `packages/api/src/lib/platform-api-client.ts:9-11`
+  > forwards the CALLER's own `Authorization` header verbatim and never holds or issues a credential of
+  > its own — it works for the external-vendor surface only because a third-party server calls tRPC
+  > directly with its own `Bearer tims_...` key. A staff/platform-owner tRPC request carries no such
+  > header: the tRPC link (`apps/web/lib/trpc-provider.tsx:38-43`) sends none. The mechanism that
+  > **does** work is **browser-direct** via `apps/web/lib/platform-api/client.ts:73-80`, which reads the
+  > live Supabase session client-side — the pattern audit-log and access-review already use. Do not
+  > record this as "Extract is unimplementable"; that is equally wrong.
+
+  Worked counterexample the taxonomy previously had no slot
   for: `packages/api/src/routers/platform/data-requests.ts:93-97` reads
   `db.employeeCompensation.findMany({ … })` inside `exportSubjectData`, the GDPR / Ley 1581/2012
   right-of-access bundle (`:8-16`). The procedure has a live FE consumer
@@ -185,9 +197,13 @@ authorization and the **same** fail-closed `logDataAccess` policy (`packages/api
 and must **re-anchor** the corresponding tripwire rather than delete it. The repo-side guard for these is
 a source-**count** tripwire (e.g. `tests/access/scope-wiring-sensitive-data.test.ts` asserting
 `entity: 'employeeCompensation'` occurrences `>= 2`), so removing readers removes the guarantee _and_ its
-alarm with a green suite. Note also that `employee_compensations` has **four** Prisma read sites, not the
+alarm with a green suite. Note also that `employee_compensations` has **five** Prisma read sites, not the
 one P3 cites: `routers/compensation.ts:30`, `routers/compensation.ts:80`,
-`services/compensation.service.ts:62`, and `routers/platform/data-requests.ts:94`.
+`services/compensation.service.ts:62`, `routers/platform/data-requests.ts:94`, and
+`access/scoped-probe.ts:76` — a bare delegate thunk (`() => tenantDb.employeeCompensation`),
+which is invisible to a `.model.method` grep and is why it kept being missed. Its sibling
+`access/scoped-probe.ts:77` is the identical construct for `salaryAdjustment`; both must be
+dispositioned via the `FlippedEntity` union, never by deleting the entity from `ScopedEntity`.
 
 **Do not** convert a Prisma read to `$queryRaw` to make `tsc` pass. `scripts/table-ownership.mjs` is
 blind to raw SQL (§1, discovery), so this silently reintroduces a second reader of an EF-owned table
@@ -195,7 +211,7 @@ with zero CI signal. It is the single easiest way to make this runbook worthless
 
 **P3 — Cross-stack relation joins identified.** A flipped table joined to a Prisma-owned table in one
 query cannot stay one query. `survey_responses ⋈ users` (§7) and `employee_compensations ⋈ salary_bands`
-(`packages/api/src/services/compensation.service.ts:71` — **one of four** `employeeCompensation` read
+(`packages/api/src/services/compensation.service.ts:71` — **one of five** `employeeCompensation` read
 sites; see the P2 note) are both real. Either flip both tables together
 or denormalize into the C# read model. Tables that are joined and _both_ flip-ready must flip in the
 same PR.


### PR DESCRIPTION
Documentation-only. Corrects claims in the ownership-flip runbook that would mis-teach the next flip. The matching issue-body corrections (#66, #59, #146) are applied directly on GitHub and summarised below.

Every claim here was **re-grepped against `origin/main` (`7d4a2298`)** before being acted on — which is how two of the proposed corrections turned out to be wrong themselves.

## Applied to the runbook

**1. `employee_compensations` has FIVE Prisma read sites, not four.**

The list omitted `access/scoped-probe.ts:76` — a bare delegate thunk (`() => tenantDb.employeeCompensation`) that is invisible to a `.model.method` grep, which is precisely why it kept being missed. Its sibling at `:77` is the identical construct for `salaryAdjustment` and was tracked by **nothing at all**. Both are now named with their disposition stated inline: handle via the `FlippedEntity` union, never by deleting the entity from `ScopedEntity` (whose scope policy is a cross-stack contract asserted by `scope-where.json` and `ScopeWhereForFixtureTests.cs`).

The dependent "one of four" in P3 moves to "one of five" in the same commit.

**2. The Extract disposition prescribed a credential path that does not exist.**

It said the surviving read "must be served **server-to-server** from the C# read surface". **No such path is wired**, so every Extract taught from that bullet would be mis-designed:

- `packages/api/src/lib/platform-api-client.ts:9-11` forwards the **caller's own** `Authorization` header verbatim and never holds or issues a credential of its own. It works for the external-vendor surface only because a third-party server calls tRPC directly with its own `Bearer tims_...` key.
- A staff / platform-owner tRPC request carries no such header — the tRPC link (`apps/web/lib/trpc-provider.tsx:38-43`) sends none.
- The mechanism that **does** work is **browser-direct** via `apps/web/lib/platform-api/client.ts:73-80`, which reads the live Supabase session client-side. Audit-log and access-review already use it.

Recorded as a dated correction note rather than a silent edit, and explicitly **not** recorded as "Extract is unimplementable" — that is equally wrong.

## NOT applied — the proposed correction was itself wrong

Recording these because a correction list that is never itself checked is how the original errors got in.

**"Runbook §7b cites `monitoring.ts:23`; `salaryAdjustment.count` is at `:22`."** The runbook **never cites `monitoring.ts` for `salaryAdjustment`** — `grep -c salaryAdjustment` over the file returns 1, and it is an unrelated registry list. Both `monitoring.ts:23` citations (`:1801`, `:1827`) are for **`survey.count`**, and on `origin/main` `monitoring.ts:23` _is_ `db.survey.count`; `:22` is the `salaryAdjustment` one. Two different tables, one conflated line number. The runbook is correct as written, and #146 is also correct in citing `:22`.

**"Any claim that `employee_demographics` is `efcore`."** Grepped `docs/` — no such claim exists in the repo. The ledger has it at `table-ownership.md:89`, inside the `efcoreReadOnly` block (`:58-91`). Nothing to fix.

## Applied to issue bodies (on GitHub, not in this diff)

**#66 — "Grep-verified: zero TS writers" was FALSE.** `seed-demo.ts:1908` (`employeeCompensation.upsert`) and `:1971` (`salaryAdjustment.create`) are Prisma **writers**; `:1968` is a `count`. Runbook §0 P1 makes seeds blocking, so **P1 is not satisfied and #66 is not startable.** The defensible version — "the prod-serving tRPC surface has zero writers" — is true but is not what was written, and the difference is the whole of P1. The body now also carries the complete 11-site blocker set, the raw-SQL parity writers that survive model deletion with zero CI signal, and the fact that both tables **are** `ScopedEntity` members — so the cross-stack fixture work calibration and evaluation360 skipped **does** apply, and deleting those fixtures makes C# CI go **silent**, not red.

**#59 — "does not block #66" was FALSE, twice over.** Its own branch's runbook addition is headed _"Flip #66 … remaining blocker set"_, and `compensation.service.ts:62` is reached from a **fourth** live procedure (`compensation.ts:198 getEmployeeComp`) that neither the issue nor its scope section names. Also flagged: that branch is 3 commits behind main and its runbook addition is headed §7d, which collides with main's §7d (flip #3) — rebase to §7f.

**#146 — AC #2's "the §21 audit must be _preserved_" was ticked against nothing.** There was no `logDataAccess` call in the file. Rewritten to "must be **ADDED**", and marked done by #155. AC #2's second clause is also restated: "the restricted-field `select` must be preserved" must **not** be read as "apply `selectFor`" — `selectFor(['platform_owner'], 'employeeCompensation')` returns **anchors only** (`platform_owner` appears in no `classification.ts` rule), so a "faithful" port would silently empty `hr.compensation` while the count still looked right. The reader table gains the missing `scoped-probe.ts:77` row.

## Verification

**Tier that actually ran: 3 (same-model adversarial panel). This is NOT cross-model review.**

- **Tier 1 (Codex, `/gate` check 15): exit 2 — NOT RUN.** Quota-blocked; the CLI's own message names 2026-08-15. **7th consecutive exit 2.**
- **Tier 2 (OmniRoute): exit 2 — refused to run.** `OMNIROUTE_MODEL` unset.
- **Tier 3:** this branch is documentation-only and every factual claim in it was independently re-grepped against `origin/main` before being written — which is what caught the two bad corrections above. The panel effort this session went to the code branch (#155), where it found six real defects.

`tests/governance/scope-fixtures.test.ts` — the only test that reads this runbook — **5 passed, exit 0**. No source files touched, so `tsc` is unaffected.

Refs #66, #59, #146
