### PR TITLE
docs(access): record why Offer.salary is deliberately NOT in CLASSIFICATION (#156)

### DIFF
--- a/packages/api/src/access/classification.ts
+++ b/packages/api/src/access/classification.ts
@@ -14,6 +14,33 @@
 // Matrix rows without a model (Health/Medical, Interview Recordings, Background
 // Check, Integrity Test, free-text Coaching Notes) are tracked as follow-ons in
 // docs/REMAINING-WORK.md — deliberately NOT faked as registry entries.
+//
+// The converse also holds, and the rule above does NOT imply it, which is why it is
+// spelled out: a table can have a model AND an active reader AND a salary column and
+// still not belong here.
+//
+// `Offer.salary` is the worked case. It looks like the matrix's "Compensation /
+// Salary" row (§21, Architecture.md:2491, FULL+AUDIT) and it is NOT governed by it.
+// That row gives **recruiter = NONE** — while the same product spec grants recruiters
+// `offer: ['read','create']` at organization scope (seed-access-matrix.ts:84) and
+// `offer.create` takes `salary: z.number().positive()` as a REQUIRED input
+// (routers/offer/crud.ts:116). A recruiter cannot author an offer without setting its
+// salary, so registering Offer under that row would make `selectFor` strip the field
+// from the very role that must supply it, and offer creation would break.
+//
+// The row governs an EMPLOYEE's standing pay (`employee_compensations`,
+// `salary_adjustments`). An offer's salary is a proposed figure on a recruiting
+// artifact its author owns. The recruiter=NONE column is the proof they are different
+// data, not evidence of a gap. Investigated and closed as not-a-defect (#156); do not
+// re-open it from the shape of the column name alone.
+//
+// If a future product decision DOES bring offer salary under field-authorization, it
+// needs its own matrix row with its own role list — not a copy of this one — plus the
+// `select-for.ts` anchors, the `field-classification.json` fixture and the C#
+// `DataClassification.cs` mirror. Registering it here alone would immediately redden
+// `tests/governance/sensitive-read-audit.test.ts`, which would then demand a §21 audit
+// row from all 11 row-level Offer readers across 8 files. That is the intended alarm,
+// not an obstacle to route around.
 
 export type DataClass = 'public' | 'internal' | 'confidential' | 'restricted';
 


### PR DESCRIPTION
Closes #156 — **as not-a-defect**, with the investigation recorded at the registry so it is not rediscovered from the shape of a column name every few months.

## The finding, and why it doesn't hold

#156 came from the tier-3 security lens reviewing #155. Its argument:

> The §21 matrix classifies **"Compensation / Salary"** as a _data type_ at `FULL+AUDIT` (`Architecture.md:2491`), while `classification.ts` is only a **projection** of §21 — so justifying the absent `offer` entry with "`dataClassOf` → internal" is circular. `Offer` has a backing table and an active reader, which is exactly what the registry header says qualifies.

The circularity objection is fair in the abstract. The conclusion does not survive contact with the matrix.

**The matrix refutes it on its own terms:**

| Fact                                                                         | Source                                                          |
| ---------------------------------------------------------------------------- | --------------------------------------------------------------- |
| That row gives **recruiter = NONE**                                          | `Architecture.md:2491`                                          |
| Recruiters hold `offer: ['read','create']` at organization scope             | `seed-access-matrix.ts:84` — comment: _spec §2 "crear ofertas"_ |
| `offer.create` takes `salary: z.number().positive()` as a **required** input | `routers/offer/crud.ts:116`                                     |

A recruiter **cannot author an offer without setting its salary**. Registering `Offer` under that row would make `selectFor` strip the field from the very role obliged to supply it, and offer creation would break.

So the `recruiter = NONE` column is evidence that the row governs an **employee's standing pay** (`employee_compensations`, `salary_adjustments`) — not a proposed figure on a recruiting artifact its author owns. It is evidence the two are different data, not evidence of a coverage gap.

## Blast radius — measured, not asserted

Registering `Offer` would demand a §21 audit row from **11 row-level reader sites across 8 files**: `offer/crud`, `offer/approvals`, `offer/lifecycle`, `offer/signing`, `offer/validations`, `candidate-portal.repository`, `recruitment-analytics.repository`, and `platform/data-requests`. That is the entire offer domain — a product and legal decision, not a code fix.

If a future decision _does_ bring offer salary under field-authorization, it needs **its own matrix row with its own role list** — not a copy of this one — plus the `select-for.ts` anchors, the `field-classification.json` fixture, and the C# `DataClassification.cs` mirror.

## No test added, deliberately

The guard already exists and is stronger than a pin: registering `Offer` here alone **immediately reddens `tests/governance/sensitive-read-audit.test.ts`** (#157 / PR #160), which enumerates exactly those 11 readers and would demand an audit row from each. The alarm is the control; a comment asserting "we chose not to" would not be.

## What actually changed

The registry header explained only why matrix rows **without a model** are absent. It never said why a table **with** a model, an active reader and a salary column can still be absent — which is precisely the gap that made this look like a finding. Both directions are now stated.

## Verification

**Tier that actually ran: 3 (same-model adversarial panel). This is NOT cross-model review.** Tier 1 (Codex) exit 2 — quota-blocked to 2026-08-15. Tier 2 (OmniRoute) exit 2 — `OMNIROUTE_MODEL` unset. This branch is the _result_ of adjudicating a tier-3 finding: the panel raised it, and re-reading the source refuted it. Recording a refutation with its evidence is the same discipline as recording a confirmed defect.

`tsc --noEmit` exit 0 on `@tims/api`. `tests/access` + `tests/audit` + `tests/dei`: **73 files / 964 passed, exit 0**. Comment-only change, so no test count moves and the `/gate` check-3 anchor is deliberately untouched — it does not compete with the five PRs already editing that line.

Closes #156
