### PR TITLE
test(config): raise the vitest timeout so a loaded machine stops faking regressions

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,26 @@ export default defineConfig({
     },
   },
   test: {
+    // Vitest's default is 5 000 ms. That is too tight for THIS suite on a developer machine,
+    // and the failure mode is corrosive rather than obvious: a slow-but-correct run reports
+    // the same red as a real regression, so every local result becomes untrustworthy exactly
+    // when you most need to trust it.
+    //
+    // Two independent reasons the default does not fit here:
+    //   - several suites SPAWN subprocesses (tsx/bash) — ~1.5 s of interpreter startup each,
+    //     and `verify-tenant-grants-failure-paths` spawns three in one `it`, so it is
+    //     marginal by construction before any load at all;
+    //   - the machine is routinely shared. Measured 2026-08-07 with an unrelated desktop app
+    //     at 479 % CPU: the same tree that CI passes green went red locally on 5 000 ms
+    //     timeouts, in DIFFERENT tests run to run — first `verify-tenant-grants`, then
+    //     `update-role-family` and `update-fit-requirements`, which spawn nothing.
+    //
+    // Raised, not removed: a genuinely hung test still fails, just not a slow correct one.
+    // If you are tempted to lower this, read the "never claim a result from a stale run"
+    // history first — phantom failures from contention have repeatedly cost more than the
+    // extra seconds this buys.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     projects: [
       {
         extends: true,


### PR DESCRIPTION
Vitest's 5 000 ms default is too tight for this suite on a developer machine, and the failure mode is corrosive rather than obvious: **a slow-but-correct run reports the same red as a real regression**, so local results become untrustworthy exactly when you most need to trust them.

**This is not a fix for a broken `main`.** CI on `main` at `87120df0` is green. This is about local runs.

## The sequence, recorded because it fooled me first

1. `main` went red locally on one test — `verify-tenant-grants-failure-paths`, a 5 000 ms timeout — **twice in a row**, ~40 s wall clock.
2. The pre-merge commit `7d4a2298` ran **green** at 37 s, so I concluded "not contention, the merges exposed something." **That inference was wrong.**
3. The next run went red on **two different tests** (`update-role-family`, `update-fit-requirements`) at **73 s** wall clock — tests that spawn no subprocesses and are unrelated to anything merged.
4. `ps -Ao pcpu` showed an unrelated desktop app at **479 % CPU** and a stray `dotnet` at 141 %. Load average 49. The control in step 2 had simply hit a quieter minute.
5. GitHub Actions on the same tree: **SUCCESS**.

So the regression was never real, and what made it look real was a control run I trusted because it agreed with the story I already had.

## Why the default doesn't fit

- Several suites **spawn subprocesses** (tsx/bash) at ~1.5 s of interpreter startup each, and `verify-tenant-grants-failure-paths` spawns **three inside one `it`** — marginal by construction before any load at all.
- The machine is routinely shared with other work, including other agent sessions.

Raised, not removed: a genuinely hung test still fails, just not a slow correct one. `hookTimeout` moves with it so a slow `beforeAll` can't reintroduce the same false red.

## Rejected alternative

Per-file timeouts on the four subprocess-spawning suites. I wrote it, then discarded it — it would **not** have covered `update-role-family` or `update-fit-requirements`, which spawn nothing and failed anyway. The problem is the global budget, not those files.

## Verification

**Tier that actually ran: 3.** Tier 1 (Codex) exit 2 — quota-blocked to 2026-08-15. Tier 2 (OmniRoute) exit 2 — `OMNIROUTE_MODEL` unset. NOT cross-model.

Verified under load average 14 **with the unrelated app still running**: `npx vitest run` exit 0, **2732 passed / 291 files**, 28.5 s. That count already matches the anchor on `main`, so `/gate` check 3 is deliberately untouched and this PR does not contend with the other open PRs.
