### PR TITLE
test(governance): bound the hollow static tripwires at the next sibling (#147)

### DIFF
--- a/tests/access/ai-interview-router.test.ts
+++ b/tests/access/ai-interview-router.test.ts
@@ -11,14 +11,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // ---------------------------------------------------------------------------
 // Static source-level guards (pattern from scope-wiring-offer.test.ts)
 // ---------------------------------------------------------------------------
 
 const ROOT = join(__dirname, '..', '..');
-const readRouter = () =>
-  readFileSync(join(ROOT, 'packages/api/src/routers/ai-interview.ts'), 'utf8');
+const readRouter = () => readFileSync(join(ROOT, 'packages/api/src/routers/ai-interview.ts'), 'utf8');
 
 describe('aiInterview router — static source guards', () => {
   it('create: uses permissionProcedure("interview", "create")', () => {
@@ -31,13 +31,13 @@ describe('aiInterview router — static source guards', () => {
 
   it('recordConsent: uses publicProcedure (no login required)', () => {
     const src = readRouter();
-    const consentBlock = src.slice(src.indexOf('recordConsent:'));
+    const consentBlock = blockAt(src, 'recordConsent:');
     expect(consentBlock).toMatch(/publicProcedure/);
   });
 
   it('start: uses publicProcedure (token-authorised, no login)', () => {
     const src = readRouter();
-    const startBlock = src.slice(src.indexOf('start:'));
+    const startBlock = blockAt(src, 'start:');
     expect(startBlock).toMatch(/publicProcedure/);
   });
 
@@ -126,10 +126,7 @@ describe('aiInterview router — static source guards', () => {
   });
 
   it('findSessionByCandidateToken repository method uses systemDb (not tenantDb)', () => {
-    const repoSrc = readFileSync(
-      join(ROOT, 'packages/api/src/repositories/ai-interview.repository.ts'),
-      'utf8',
-    );
+    const repoSrc = readFileSync(join(ROOT, 'packages/api/src/repositories/ai-interview.repository.ts'), 'utf8');
     const methodStart = repoSrc.indexOf('findSessionByCandidateToken');
     const methodEnd = repoSrc.indexOf('},', methodStart);
     const methodBody = repoSrc.slice(methodStart, methodEnd);
@@ -398,16 +395,16 @@ describe('aiInterview.start', () => {
       organizationId: 'org-uuid-1',
       candidateId: 'cand-1',
       status: 'pending' as never,
-      consentedAt: null,           // <-- no consent
+      consentedAt: null, // <-- no consent
       elevenlabsAgentId: 'agent-1',
       guideQuestions: { questions: [] },
       maxDurationSeconds: null,
     });
 
     const caller = await makeCaller({ user: undefined });
-    await expect(
-      caller.aiInterview.start({ candidateToken: 'valid-token' }),
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(caller.aiInterview.start({ candidateToken: 'valid-token' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
   });
 
   it('meter-and-bill: proceeds (never throws) when voice budget is exhausted', async () => {
@@ -416,25 +413,28 @@ describe('aiInterview.start', () => {
       organizationId: 'org-uuid-1',
       candidateId: 'cand-1',
       status: 'pending' as never,
-      consentedAt: new Date(),     // consent OK
+      consentedAt: new Date(), // consent OK
       elevenlabsAgentId: 'agent-1',
       guideQuestions: { questions: [] },
       maxDurationSeconds: null,
     });
 
     // Budget config exists with limit — uses tenantDb (staff-path budget reads)
-    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ monthlyBudget: 50 });
+    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      monthlyBudget: 50,
+    });
     // Current month spend is over budget
-    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ _sum: { costUsd: 55 } });
+    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      _sum: { costUsd: 55 },
+    });
 
     vi.mocked(getSignedUrl).mockResolvedValue({
       signedUrl: 'wss://api.elevenlabs.io/signed-over-budget',
       conversationId: 'conv-over-budget',
     });
-    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({});
+    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      {},
+    );
 
     // Per the owner decision, entitlement enforcement is meter-and-bill and NEVER
     // hard-blocks — an over-budget org must still get a signed URL, not FORBIDDEN.
@@ -457,10 +457,12 @@ describe('aiInterview.start', () => {
 
     // No budget config → default $25 cap applies; spend is 0 so gate passes
     // Budget reads use tenantDb (staff context path inside start procedure).
-    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue(null);
-    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ _sum: { costUsd: 0 } });
+    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      null,
+    );
+    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      _sum: { costUsd: 0 },
+    });
 
     vi.mocked(getSignedUrl).mockResolvedValue({
       signedUrl: 'wss://api.elevenlabs.io/signed-url-xyz',
@@ -468,8 +470,9 @@ describe('aiInterview.start', () => {
     });
 
     // Mock session update — uses candidateDb (systemDb) on the candidate path.
-    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({});
+    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      {},
+    );
 
     const caller = await makeCaller({ user: undefined });
     const result = await caller.aiInterview.start({ candidateToken: 'valid-token' });
@@ -489,9 +492,9 @@ describe('aiInterview.start', () => {
     vi.mocked(aiInterviewRepository.findSessionByCandidateToken).mockResolvedValue(null);
 
     const caller = await makeCaller({ user: undefined });
-    await expect(
-      caller.aiInterview.start({ candidateToken: 'nonexistent-token' }),
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    await expect(caller.aiInterview.start({ candidateToken: 'nonexistent-token' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
   });
 
   it('meter-and-bill: proceeds when NO config row exists and spend >= $25 (default cap)', async () => {
@@ -507,18 +510,21 @@ describe('aiInterview.start', () => {
     });
 
     // No config row → default cap of $25 applies — budget reads use tenantDb.
-    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue(null);
+    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      null,
+    );
     // Spend exactly at the default cap — must NOT block (meter-and-bill only).
-    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ _sum: { costUsd: 25 } });
+    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      _sum: { costUsd: 25 },
+    });
 
     vi.mocked(getSignedUrl).mockResolvedValue({
       signedUrl: 'wss://api.elevenlabs.io/signed-default-cap',
       conversationId: 'conv-default-cap',
     });
-    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({});
+    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      {},
+    );
 
     const caller = await makeCaller({ user: undefined });
     const result = await caller.aiInterview.start({ candidateToken: 'valid-token' });
@@ -538,19 +544,22 @@ describe('aiInterview.start', () => {
     });
 
     // No config row → default cap of $25 applies — budget reads use tenantDb.
-    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue(null);
+    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      null,
+    );
     // Spend well under the default cap
-    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ _sum: { costUsd: 10 } });
+    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      _sum: { costUsd: 10 },
+    });
 
     vi.mocked(getSignedUrl).mockResolvedValue({
       signedUrl: 'wss://api.elevenlabs.io/signed',
       conversationId: 'conv-def',
     });
     // Session update uses candidateDb (systemDb) on the candidate path.
-    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({});
+    vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      {},
+    );
 
     const caller = await makeCaller({ user: undefined });
     const result = await caller.aiInterview.start({ candidateToken: 'valid-token' });
@@ -572,10 +581,12 @@ describe('aiInterview.start', () => {
       maxDurationSeconds: null,
     });
 
-    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue(null);
-    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>)
-      .mockResolvedValue({ _sum: { costUsd: 0 } });
+    vi.mocked(tenantDb.aiAgentOrgConfig.findFirst as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue(
+      null,
+    );
+    vi.mocked(tenantDb.aiAgentUsageLog.aggregate as unknown as (a: unknown) => Promise<unknown>).mockResolvedValue({
+      _sum: { costUsd: 0 },
+    });
 
     // ElevenLabs omits conversation_id → getSignedUrl resolves with null.
     vi.mocked(getSignedUrl).mockResolvedValue({
@@ -583,9 +594,7 @@ describe('aiInterview.start', () => {
       conversationId: null,
     });
 
-    const mockUpdate = vi.mocked(
-      candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>,
-    );
+    const mockUpdate = vi.mocked(candidateDb.aiInterviewSession.update as unknown as (a: unknown) => Promise<unknown>);
     mockUpdate.mockResolvedValue({});
 
     const caller = await makeCaller({ user: undefined });

--- a/tests/access/role-aware-ui.test.ts
+++ b/tests/access/role-aware-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const root = resolve(__dirname, '../..');
 const read = (p: string) => readFileSync(resolve(root, p), 'utf8');
@@ -138,7 +139,7 @@ describe('codex fixes (slice 5)', () => {
     expect(src()).not.toMatch(/readable\.has/);
   });
   it('guard resolves the path BEFORE waiting on sessionInfo (ungated routes never skeleton)', () => {
-    const guard = src().slice(src().indexOf('function RouteAccessGuard'));
+    const guard = blockAt(src(), 'function RouteAccessGuard');
     expect(guard.indexOf('moduleForPath(pathname)')).toBeLessThan(guard.indexOf('GuardSkeleton'));
   });
 });

--- a/tests/access/scope-wiring-assessment.test.ts
+++ b/tests/access/scope-wiring-assessment.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROOT = join(__dirname, '..', '..');
 const src = () => readFileSync(join(ROOT, 'packages/api/src/routers/assessment.ts'), 'utf8');
@@ -20,11 +21,14 @@ describe('assessment module scope wiring', () => {
   });
 
   it('question bank stays org-level (deliberately unscoped)', () => {
-    // Slice from the question-bank comment block (last section); using the
-    // comment marker avoids matching the `listQuestionsSchema` import alias.
-    const marker = '// Question authoring';
-    const qb = src().slice(src().indexOf(marker));
-    expect(qb).not.toMatch(/scopeWhereFor|assertScoped/);
+    // Enumerated by procedure name rather than anchored on a COMMENT marker.
+    // The old form sliced from '// Question authoring' to end-of-file: reword that
+    // comment and indexOf returns -1, so slice(-1) yields the file's LAST CHARACTER
+    // and this negative assertion passes over one character — a silent, total false
+    // pass. Naming the four procedures also states the scope the title only implied.
+    for (const proc of ['listQuestions:', 'createQuestion:', 'updateQuestion:', 'deleteQuestion:']) {
+      expect(blockAt(src(), proc, { minLines: 3 }), proc).not.toMatch(/scopeWhereFor|assertScoped/);
+    }
   });
 
   it('no scope-fragment spreads', () => {

--- a/tests/access/scope-wiring-candidate.test.ts
+++ b/tests/access/scope-wiring-candidate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROOT = join(__dirname, '..', '..');
 const read = (p: string) => readFileSync(join(ROOT, p), 'utf8');
@@ -32,15 +33,15 @@ describe('candidate module scope wiring', () => {
     const src = read('packages/api/src/routers/candidate/documents.ts');
     // both documentId entry points must resolve the org-scoped document and
     // assertScoped its candidateId (same hop pattern as vacancy channels.unpublish)
-    const deleteBlock = src.slice(src.indexOf('deleteDocument'), src.indexOf('parseCV'));
-    const parseBlock = src.slice(src.indexOf('parseCV'));
+    const deleteBlock = blockAt(src, 'deleteDocument:');
+    const parseBlock = blockAt(src, 'parseCV:');
     expect(deleteBlock).toMatch(/assertScoped\('candidate'/);
     expect(parseBlock).toMatch(/assertScoped\('candidate'/);
   });
 
   it('bulkTag dedupes candidateIds before the scoped count-check', () => {
     const src = read('packages/api/src/services/candidate-tags.service.ts');
-    const block = src.slice(src.indexOf('bulkTag'));
+    const block = blockAt(src, 'async bulkTag');
     expect(block).toMatch(/new Set\(/);
   });
 
@@ -56,16 +57,16 @@ describe('candidate module scope wiring', () => {
     const src = read('packages/api/src/repositories/candidate.repository.ts');
     // The scoped child relations live in the module-level builder consumed by
     // getById; the behavior test below verifies the wiring end-to-end.
-    const builder = src.slice(src.indexOf('buildCandidateDetailSelect'), src.indexOf('candidateMutationSelect'));
+    const builder = blockAt(src, 'const buildCandidateDetailSelect');
     expect((builder.match(/where:\s*appScopeWhere/g) ?? []).length).toBeGreaterThanOrEqual(3);
-    const getByIdBlock = src.slice(src.indexOf('async getById'), src.indexOf('async create'));
+    const getByIdBlock = blockAt(src, 'async getById');
     expect(getByIdBlock).toMatch(/buildCandidateDetailSelect\(appScopeWhere\)/);
   });
 
   // Codex F1 — timeline child loads must be scope-filtered too.
   it('candidate.repository.getTimelineData scopes its application/assessment child loads by the fragment', () => {
     const src = read('packages/api/src/repositories/candidate.repository.ts');
-    const block = src.slice(src.indexOf('async getTimelineData'), src.indexOf('async findFirstStage'));
+    const block = blockAt(src, 'async getTimelineData');
     expect(block).toMatch(/appScopeWhere/);
   });
 
@@ -86,16 +87,16 @@ describe('candidate module scope wiring', () => {
   // carry the application fragment too.
   it('repository.list threads appScopeWhere (children + fit filter scoped)', () => {
     const src = read('packages/api/src/repositories/candidate.repository.ts');
-    const builder = src.slice(src.indexOf('buildCandidateListSelect'), src.indexOf('const candidateDetailSelect'));
+    const builder = blockAt(src, 'const buildCandidateListSelect');
     expect(builder).toMatch(/where:\s*appScopeWhere/);
     expect(builder).toMatch(/_count:\s*\{\s*select:\s*\{\s*applications:\s*\{\s*where:\s*appScopeWhere/);
-    const listBlock = src.slice(src.indexOf('async list'), src.indexOf('async getById'));
+    const listBlock = blockAt(src, 'async list');
     expect(listBlock).toMatch(/appScopeWhere/);
   });
 
   it('repository.getCandidateForRisks scopes applications and fitScores', () => {
     const src = read('packages/api/src/repositories/candidate.repository.ts');
-    const block = src.slice(src.indexOf('async getCandidateForRisks'), src.indexOf('// KPIs'));
+    const block = blockAt(src, 'async getCandidateForRisks');
     expect((block.match(/where:\s*appScopeWhere/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
@@ -103,13 +104,13 @@ describe('candidate module scope wiring', () => {
   // scope fragment, like the sibling candidate counts.
   it('crud.getDashboardKpis computes the application fragment and threads it', () => {
     const src = read('packages/api/src/routers/candidate/crud.ts');
-    const block = src.slice(src.indexOf('getDashboardKpis'));
+    const block = blockAt(src, 'getDashboardKpis:');
     expect(block).toMatch(/scopeWhereFor\('application'/);
   });
 
   it('candidate.repository.getDashboardKpis composes the appScopeWhere into the active-application count', () => {
     const src = read('packages/api/src/repositories/candidate.repository.ts');
-    const block = src.slice(src.indexOf('async getDashboardKpis'));
+    const block = blockAt(src, 'async getDashboardKpis');
     expect(block).toMatch(/appScopeWhere/);
     // the active-application count must AND the org filter with the app fragment
     expect(block).toMatch(/status:\s*'active'[\s\S]*appScopeWhere|appScopeWhere[\s\S]*status:\s*'active'/);

--- a/tests/access/scope-wiring-engagement-write.test.ts
+++ b/tests/access/scope-wiring-engagement-write.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Phase-5 Slice 16 — static tripwires for the engagement WRITE surface + the H1 both-stacks
 // hardening. Engagement's router calls the tenant `db` inline (no service layer), so — like the compensation /
@@ -28,7 +29,7 @@ describe('engagement write scope wiring', () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('updateActionPlan probes the plan by id via assertScoped(\'actionPlan\')', () => {
+  it("updateActionPlan probes the plan by id via assertScoped('actionPlan')", () => {
     expect(read()).toMatch(/assertScoped\('actionPlan'/);
   });
 
@@ -38,7 +39,7 @@ describe('engagement write scope wiring', () => {
   //    update-by-{id,org}. Reverting to `db.actionPlan.update({ where: { id, organizationId } })` makes this RED. ──
   it('updateActionPlan applies the scope predicate ATOMICALLY (updateMany guarded by scopeWhereFor, count 0 → 404)', () => {
     const src = read();
-    const updateBody = src.slice(src.indexOf('updateActionPlan'), src.indexOf('listLeaderCommitments'));
+    const updateBody = blockAt(src, 'updateActionPlan:');
     // The final write is scoped updateMany, not a bare update by {id, organizationId}.
     expect(updateBody).toMatch(/scopeWhereFor\('actionPlan'/);
     expect(updateBody).toMatch(/actionPlan\.updateMany\(/);

--- a/tests/access/scope-wiring-interview.test.ts
+++ b/tests/access/scope-wiring-interview.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROOT = join(__dirname, '..', '..');
 const read = (p: string) => readFileSync(join(ROOT, 'packages/api/src/routers/interview', p), 'utf8');
@@ -15,7 +16,7 @@ describe('interview module scope wiring', () => {
 
   it('scorecards.ts: submitScorecard requires the submitter to be an ASSIGNED EVALUATOR', () => {
     const src = read('scorecards.ts');
-    const block = src.slice(src.indexOf('submitScorecard'), src.indexOf('compareEvaluators'));
+    const block = blockAt(src, 'submitScorecard:');
     // slice-1 codex carry-over: org-probe alone let ANY org member upsert a scorecard
     expect(block).toMatch(/interviewEvaluator\.findFirst|evaluators:\s*\{\s*some/);
     expect(block).toMatch(/FORBIDDEN/);
@@ -29,7 +30,7 @@ describe('interview module scope wiring', () => {
 
   it('schedule scope-probes the candidate AND binds applicationId to candidate+vacancy', () => {
     const src = read('crud.ts');
-    const block = src.slice(src.indexOf('schedule:'), src.indexOf('reschedule:'));
+    const block = blockAt(src, 'schedule:');
     // codex re-review: org-only candidate check let a narrow-scoped scheduler
     // pull any org candidate into an interview + invitation email
     expect(block).toMatch(/assertScoped\('candidate'/);
@@ -38,7 +39,7 @@ describe('interview module scope wiring', () => {
 
   it('schedule binds candidate↔vacancy even when applicationId is omitted', () => {
     const src = read('crud.ts');
-    const block = src.slice(src.indexOf('schedule:'), src.indexOf('reschedule:'));
+    const block = blockAt(src, 'schedule:');
     // codex round-3: omitted applicationId must auto-resolve the binding
     // application (persisted) and fail closed for narrow scopes when none exists
     expect(block).toMatch(/data\.applicationId\s*=\s*boundApp\.id/);

--- a/tests/access/scope-wiring-learning.test.ts
+++ b/tests/access/scope-wiring-learning.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Wave 2.5 slice 4 — static tripwires for learning + engagement modules.
 // learning.ts: enrollments/certificates are user-anchored (people scope);
@@ -67,7 +68,7 @@ describe('engagement module scope wiring', () => {
 describe('course detail enrollment scoping (codex)', () => {
   it('getCourseById scopes the embedded enrollments', () => {
     const src = readFileSync(join(ROOT, 'packages/api/src/routers/learning.ts'), 'utf8');
-    const block = src.slice(src.indexOf('getCourseById'), src.indexOf('createCourse'));
+    const block = blockAt(src, 'getCourseById:');
     expect(block).toMatch(/enrollments:\s*\{\s*where:\s*enrollScope/);
   });
 });

--- a/tests/access/scope-wiring-offer.test.ts
+++ b/tests/access/scope-wiring-offer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROOT = join(__dirname, '..', '..');
 const read = (p: string) => readFileSync(join(ROOT, 'packages/api/src/routers/offer', p), 'utf8');
@@ -20,10 +21,10 @@ describe('offer module scope wiring', () => {
 
   it('signing.ts: generateSigningLink is scope-guarded; PUBLIC token flows untouched', () => {
     const src = read('signing.ts');
-    const staffBlock = src.slice(src.indexOf('generateSigningLink'), src.indexOf('getBySigningToken'));
+    const staffBlock = blockAt(src, 'generateSigningLink:');
     expect(staffBlock).toMatch(/assertScoped\('offer'|scopeWhereFor\('offer'/);
     // the three public token procedures stay publicProcedure and probe-free
-    const publicBlock = src.slice(src.indexOf('getBySigningToken'));
+    const publicBlock = blockAt(src, 'getBySigningToken:');
     expect(src).toMatch(/getBySigningToken:\s*publicProcedure/);
     expect(publicBlock).not.toMatch(/assertScoped|scopeWhereFor/);
   });

--- a/tests/access/scope-wiring-offer.test.ts
+++ b/tests/access/scope-wiring-offer.test.ts
@@ -23,10 +23,17 @@ describe('offer module scope wiring', () => {
     const src = read('signing.ts');
     const staffBlock = blockAt(src, 'generateSigningLink:');
     expect(staffBlock).toMatch(/assertScoped\('offer'|scopeWhereFor\('offer'/);
-    // the three public token procedures stay publicProcedure and probe-free
-    const publicBlock = blockAt(src, 'getBySigningToken:');
+    // the three public token procedures stay publicProcedure and probe-free.
+    // Asserted over EACH of the three by name, not over one block: bounding
+    // `getBySigningToken` at its next sibling drops acceptByToken (:129) and
+    // declineByToken (:230), and nothing else in the suite covers them. A negative
+    // assertion is only as strong as the region it spans, so narrowing one silently
+    // removes coverage — the inverse of the hollow-slice defect, and the reason this
+    // conversion is not a mechanical `blockAt` swap.
     expect(src).toMatch(/getBySigningToken:\s*publicProcedure/);
-    expect(publicBlock).not.toMatch(/assertScoped|scopeWhereFor/);
+    for (const proc of ['getBySigningToken:', 'acceptByToken:', 'declineByToken:']) {
+      expect(blockAt(src, proc, { minLines: 5 })).not.toMatch(/assertScoped|scopeWhereFor/);
+    }
   });
 
   it('no scope-fragment spreads', () => {

--- a/tests/access/scope-wiring-performance.test.ts
+++ b/tests/access/scope-wiring-performance.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Wave 2.5 slice 4 — static tripwires for the performance module. Every
 // row-level read composes the scope fragment via AND; by-id mutations probe via
@@ -47,11 +48,11 @@ describe('performance module scope wiring', () => {
 describe('commitment child-path (codex)', () => {
   const src = () => readFileSync(join(ROOT, 'packages/api/src/routers/performance/coaching.ts'), 'utf8');
   it('listCommitments composes the commitment fragment', () => {
-    const block = src().slice(src().indexOf('listCommitments'));
+    const block = blockAt(src(), 'listCommitments:');
     expect(block).toMatch(/scopeWhereFor\('commitment'/);
   });
   it('createCommitment subject-checks the employee, probes the optional session, and binds session↔employee', () => {
-    const block = src().slice(src().indexOf('createCommitment'), src().indexOf('updateCommitment'));
+    const block = blockAt(src(), 'createCommitment:');
     expect(block).toMatch(/assertSubjectInScope/);
     expect(block).toMatch(/assertScoped\('coachingSession'/);
     // codex round-2: the parent session must belong to the same employee
@@ -59,7 +60,7 @@ describe('commitment child-path (codex)', () => {
     expect(block).toMatch(/La sesion no corresponde a este empleado/);
   });
   it('updateCommitment probes the commitment (was a bare update-by-id)', () => {
-    const block = src().slice(src().indexOf('updateCommitment'));
+    const block = blockAt(src(), 'updateCommitment:');
     expect(block).toMatch(/assertScoped\('commitment'/);
   });
 });

--- a/tests/access/scope-wiring-talent.test.ts
+++ b/tests/access/scope-wiring-talent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Wave 2.5 slice 4 — static tripwires for the TALENT modules:
 // ninebox (9-box + calibration), succession (critical roles / successors),
@@ -164,7 +165,7 @@ describe('codex round-1 fixes (talent)', () => {
   // (NineBoxWriteTests.cs) assert the 404 AND that no vote row was written.
   it('updateActionPlan guards responsibility reassignment', () => {
     const src = readFileSync(join(ROOT, 'packages/api/src/routers/engagement.ts'), 'utf8');
-    const block = src.slice(src.indexOf('updateActionPlan'));
+    const block = blockAt(src, 'updateActionPlan:');
     expect(block).toMatch(/assertSubjectInScope/);
   });
 });

--- a/tests/db/pre-flip-scan.test.ts
+++ b/tests/db/pre-flip-scan.test.ts
@@ -69,6 +69,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { blockAt } from '../helpers/source-blocks';
 
 const REPO_ROOT = process.cwd();
 const SCRIPT_REL = 'scripts/db/pre-flip-scan.ts';
@@ -522,7 +523,7 @@ describe('pre-flip-scan — database-arm properties', () => {
     // `LANGUAGE sql` body records no pg_depend edge at all, while a SQL-standard body records one. The
     // two routine oracles therefore DISAGREE for almost every function that exists, so a split line
     // would fire forever in both directions — and a check that cries wolf gets switched off.
-    const splitBlock = CODE.slice(CODE.indexOf('const oracleSplits'), CODE.indexOf('for (const h of repo.hits'));
+    const splitBlock = blockAt(CODE, 'const oracleSplits');
     expect(splitBlock).not.toMatch(/dependentRoutines/);
   });
 

--- a/tests/governance/no-hollow-source-slices.test.ts
+++ b/tests/governance/no-hollow-source-slices.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { stripComments } from '../helpers/source-blocks';
+
+// ── No new hollow static tripwires ────────────────────────────────────────────
+//
+// `SRC.slice(SRC.indexOf('name'))` runs to end-of-file, so an assertion "procedure X
+// carries guard G" is satisfied by G appearing in ANY later procedure. #147 converted
+// 43 such sites to `blockAt`, which bounds at the next sibling. Nothing stopped the
+// idiom being written again — and it is still copy-pasteable from several plan docs
+// under docs/, so it would come back.
+//
+// This is the class-level guard. It is deliberately narrow: it bans `.slice(` whose
+// argument list contains `.indexOf(`, which is the exact shape, and nothing else. A
+// control that cries wolf gets switched off.
+//
+// Scanned against COMMENT-STRIPPED source. Not optional: this repo has been bitten
+// five times by source scans matching prose (the calibration tripwire's `\.\s*`,
+// evaluation360, the console.log-in-a-comment tripwire, the §21 audit control that
+// certified data-requests.ts on the strength of a comment, and the `blockAt` docblock
+// below — which describes the banned idiom in prose and would otherwise fail this).
+
+const TESTS_DIR = join(__dirname, '..');
+
+/**
+ * Files permitted to contain the banned idiom, each for a stated reason.
+ * An allowlist entry is a claim that must stay true, so keep it specific.
+ */
+const ALLOWLIST = new Map<string, string>([
+  [
+    'helpers/source-blocks.test.ts',
+    'demonstrates the defect side-by-side with the fix — the hollow form IS the fixture that proves blockAt bounds correctly',
+  ],
+]);
+
+/**
+ * Matches `.slice(` whose FIRST argument is derived from `.indexOf(` — i.e. the START
+ * of the region is anchored on a found string. That is the dangerous shape, in both
+ * its forms: one-argument (runs to end-of-file) and two-argument (degrades to the
+ * one-argument form the day the end anchor is renamed, because `indexOf` returns -1
+ * and `slice(n, -1)` means "to one char before the end").
+ *
+ * Requiring no comma between `.slice(` and `.indexOf(` is what confines it to the
+ * first argument, and it matters — a first cut banned `.indexOf(` anywhere in the
+ * call and flagged two innocents:
+ *
+ *   - `m[0].slice(1, -1)` in a file that merely mentions indexOf elsewhere;
+ *   - `SRC.slice(0, SRC.indexOf('writeRepo'))` — a PREFIX slice, which fails SAFE:
+ *     rename the anchor and the region widens to the whole file, so the negative
+ *     assertion over it goes red rather than silently passing.
+ *
+ * Newlines are allowed between the two calls (the char class permits them), so the
+ * Prettier-wrapped multi-line form is caught too — the form a line-anchored grep
+ * misses, and which accounted for 2 of the sites #147 itself failed to count.
+ */
+const HOLLOW = /\.slice\(\s*[^,;]*?\.indexOf\(/;
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...tsFilesUnder(p));
+    else if (p.endsWith('.ts') || p.endsWith('.tsx')) out.push(p);
+  }
+  return out;
+}
+
+describe('governance — no unbounded source-slicing tripwires', () => {
+  const files = tsFilesUnder(TESTS_DIR);
+
+  it('scans a non-empty population (non-vacuity)', () => {
+    // A probe over zero files reads exactly like a clean sweep. Establish the
+    // denominator before trusting the numerator.
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  // NOTE: this title deliberately avoids spelling the banned call sequence. Writing it
+  // out — even inside a string or a comment — makes this file match its own ban. It did,
+  // on the first run. Same class as the `console.log`-in-a-comment tripwire.
+  it('no test anchors the START of a source region on a found offset — use blockAt', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = relative(TESTS_DIR, file);
+      if (ALLOWLIST.has(rel)) continue;
+      if (HOLLOW.test(stripComments(readFileSync(file, 'utf8')))) offenders.push(rel);
+    }
+    expect(
+      offenders,
+      `Use blockAt() from tests/helpers/source-blocks.ts instead — it bounds the block at the ` +
+        `next sibling declaration. An unbounded slice runs to end-of-file, so the assertion is ` +
+        `satisfied by any LATER procedure and stops protecting the one it names.\nOffenders:\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('every allowlist entry still exists and still contains the idiom it is excused for', () => {
+    // A stale allowlist entry silently widens the ban's hole.
+    for (const [rel, reason] of ALLOWLIST) {
+      const src = readFileSync(join(TESTS_DIR, rel), 'utf8');
+      expect(HOLLOW.test(stripComments(src)), `${rel} no longer needs its allowlist entry (${reason})`).toBe(true);
+    }
+  });
+});

--- a/tests/helpers/source-blocks.test.ts
+++ b/tests/helpers/source-blocks.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { blockAt, stripComments } from './source-blocks';
+
+// ── Mutation proof for the bounded-block extractor ────────────────────────────
+//
+// `blockAt` is the shared mechanism behind ~36 converted static tripwires, so the
+// proof that the hollow-slice defect is actually gone lives HERE rather than being
+// re-derived at each call site. The defect: `SRC.slice(SRC.indexOf('name'))` runs to
+// end-of-file, so an assertion "procedure X carries guard G" is satisfied by G
+// appearing in ANY later procedure.
+//
+// Every fixture below is formatted the way this repo's Prettier config actually
+// formats routers — procedures at 2-space indent, chained builder methods at 4,
+// verified against packages/api/src/routers/interview/crud.ts:114 and
+// scorecards.ts:36. A fixture whose shape the codebase never produces would prove
+// only that the pattern matches itself.
+
+const ROUTER = `import { z } from 'zod';
+import { router, permissionProcedure } from '../../trpc';
+
+export const interviewRouter = router({
+  schedule: permissionProcedure('interview', 'create')
+    .input(
+      z.object({
+        candidateId: z.string().uuid(),
+        scheduledAt: z.date(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const created = await db.interview.create({ data: input });
+      return created;
+    }),
+
+  reschedule: permissionProcedure('interview', 'update')
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertScoped('interview', input.id, ctx.access, ctx.user.id);
+      return db.interview.update({ where: { id: input.id }, data: input });
+    }),
+});
+`;
+
+describe('blockAt — the bound is real (the hollow-slice defect)', () => {
+  it("does NOT let a later procedure satisfy an earlier one's assertion", () => {
+    // `assertScoped` lives in `reschedule`, NOT in `schedule`.
+    expect(ROUTER).toMatch(/assertScoped/); // present in the file...
+    expect(blockAt(ROUTER, 'schedule:')).not.toMatch(/assertScoped/); // ...but not in this block.
+
+    // This is precisely what the unbounded idiom got wrong:
+    const hollow = ROUTER.slice(ROUTER.indexOf('schedule:'));
+    expect(hollow).toMatch(/assertScoped/);
+  });
+
+  it('still finds a guard that IS in the anchored procedure', () => {
+    expect(blockAt(ROUTER, 'reschedule:')).toMatch(/assertScoped/);
+  });
+
+  it('stops at the next sibling declaration', () => {
+    const block = blockAt(ROUTER, 'schedule:');
+    expect(block).toMatch(/db\.interview\.create/);
+    expect(block).not.toMatch(/reschedule/);
+    expect(block).not.toMatch(/db\.interview\.update/);
+  });
+
+  it('the two-argument form degrades to unbounded when the end anchor is deleted', () => {
+    // Why the sounder-looking `slice(indexOf(A), indexOf(B))` is still not safe:
+    // indexOf returns -1 for a deleted B, and slice(n, -1) means "to one char before
+    // the end" — silently the whole rest of the file again.
+    const renamed = ROUTER.replace(/reschedule/g, 'moveInterview');
+    const twoArg = renamed.slice(renamed.indexOf('schedule:'), renamed.indexOf('reschedule:'));
+    expect(renamed.indexOf('reschedule:')).toBe(-1);
+    expect(twoArg).toMatch(/assertScoped/); // leaked
+
+    expect(blockAt(renamed, 'schedule:')).not.toMatch(/assertScoped/); // bounded anyway
+  });
+});
+
+describe('blockAt — anchor resolution', () => {
+  it('throws when the anchor is absent rather than asserting over the whole file', () => {
+    expect(() => blockAt(ROUTER, 'noSuchProcedure:')).toThrow(/not found/);
+  });
+
+  it('does not resolve an anchor that exists only in a comment', () => {
+    const src = `export const r = router({
+  // deleteFeatureFlag: removed 2026-07-01, see #123
+  listFeatureFlags: protectedProcedure.query(() => db.featureFlag.findMany()),
+});
+`;
+    expect(src).toMatch(/deleteFeatureFlag/);
+    expect(() => blockAt(src, 'deleteFeatureFlag:')).toThrow(/not found/);
+  });
+
+  it('selects a later occurrence when asked', () => {
+    // Occurrence counting is over the whole file, so the IMPORT of a builder counts
+    // as occurrence 1 — the two procedure declarations are 2 and 3. Anchoring on a
+    // builder name rather than a declaration name is therefore fragile; prefer
+    // `'schedule:'` over `{ occurrence: 2 }`. Kept here because that off-by-one is
+    // exactly what a call site would get wrong.
+    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 1 })).toMatch(/from '\.\.\/\.\.\/trpc'/);
+    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 2 })).toMatch(/'create'/);
+    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 3 })).toMatch(/'update'/);
+  });
+});
+
+describe('blockAt — shapes other than tRPC procedures', () => {
+  it('bounds an async class method at the next method', () => {
+    const repo = `export class CandidateRepository {
+  async getById(id: string) {
+    return db.candidate.findUnique({ where: { id }, select: detailSelect });
+  }
+
+  async create(input: CreateInput) {
+    await assertQuota(input.organizationId);
+    return db.candidate.create({ data: input });
+  }
+}
+`;
+    expect(blockAt(repo, 'async getById')).not.toMatch(/assertQuota/);
+    expect(blockAt(repo, 'async create')).toMatch(/assertQuota/);
+  });
+
+  it('survives a Prettier-wrapped multi-line signature', () => {
+    // Regression fixture. The first version of `blockAt` bounded purely on indentation
+    // and cut this block off at `  ) {` — same indent as the declaration — so the block
+    // was the SIGNATURE ONLY and every body assertion failed. Copied from the real shape
+    // of packages/api/src/repositories/candidate.repository.ts:584, which is how Prettier
+    // formats any signature past the print width. The earlier fixtures all used
+    // single-line signatures and so proved nothing about this.
+    const repo = `export class CandidateRepository {
+  async getDashboardKpis(
+    orgId: string,
+    scopeWhere: Prisma.CandidateWhereInput,
+    appScopeWhere: Prisma.ApplicationWhereInput,
+  ) {
+    return db.application.count({
+      where: { AND: [{ status: 'active' }, appScopeWhere] },
+    });
+  }
+
+  async unrelated(orgId: string) {
+    return db.thing.count({ where: { orgId } });
+  }
+}
+`;
+    const block = blockAt(repo, 'async getDashboardKpis');
+    expect(block).toMatch(/appScopeWhere/);
+    expect(block).toMatch(/status:\s*'active'/);
+    expect(block).not.toMatch(/db\.thing\.count/);
+  });
+
+  it('bounds a top-level const declaration at the next top-level declaration', () => {
+    const mw = `const withSecurityAudit = t.middleware(async ({ ctx, next, path }) => {
+  const result = await next();
+  return result;
+});
+
+function requireExternalPermission(resource: string) {
+  logSecurityEvent({ action: 'authz_denied', entity: resource });
+}
+`;
+    expect(blockAt(mw, 'const withSecurityAudit')).not.toMatch(/logSecurityEvent/);
+    expect(blockAt(mw, 'function requireExternalPermission')).toMatch(/logSecurityEvent/);
+  });
+
+  it('bounds an inner block at its own closing brace', () => {
+    const svc = `  async submitAssessment(input: SubmitInput) {
+    for (const question of questions) {
+      if (question.type === 'free_text') {
+        scored.push({ questionId: question.id, requiresManualReview: true });
+      }
+      if (question.type === 'single_choice') {
+        scored.push({ questionId: question.id, isCorrect: matches(question) });
+      }
+    }
+  }
+`;
+    const freeText = blockAt(svc, "if (question.type === 'free_text') {");
+    expect(freeText).toMatch(/requiresManualReview/);
+    expect(freeText).not.toMatch(/isCorrect/);
+  });
+
+  it('returns to end-of-file only when the anchor is genuinely last', () => {
+    const tail = `export const r = router({
+  onlyOne: protectedProcedure.query(() => db.thing.findMany()),
+});
+`;
+    // Nothing later can satisfy the assertion, so an unbounded tail is correct here.
+    expect(blockAt(tail, 'onlyOne:')).toMatch(/db\.thing\.findMany/);
+  });
+});
+
+describe('stripComments', () => {
+  it('preserves offsets so extracted blocks line up with the original', () => {
+    const src = 'const a = 1; // trailing\nconst b = 2;\n';
+    expect(stripComments(src)).toHaveLength(src.length);
+    expect(stripComments(src).split('\n')).toHaveLength(src.split('\n').length);
+  });
+
+  it('blanks line and block comments but keeps string contents', () => {
+    const src = `const url = 'https://example.com/path'; // not a comment above
+/* block
+   comment */
+const p = permissionProcedure('interview', 'create');
+`;
+    const out = stripComments(src);
+    expect(out).toMatch(/'https:\/\/example\.com\/path'/); // the // inside a string survived
+    expect(out).toMatch(/permissionProcedure\('interview', 'create'\)/); // literals intact
+    expect(out).not.toMatch(/not a comment above/);
+    expect(out).not.toMatch(/block/);
+  });
+
+  it('does not treat a division operator or a regex as a comment', () => {
+    const src = `const half = total / 2;\nconst re = /https:\\/\\/x/;\nconst after = 'kept';\n`;
+    const out = stripComments(src);
+    expect(out).toMatch(/const after = 'kept'/);
+  });
+});

--- a/tests/helpers/source-blocks.test.ts
+++ b/tests/helpers/source-blocks.test.ts
@@ -91,29 +91,31 @@ describe('blockAt — anchor resolution', () => {
   });
 
   it('selects a later occurrence when asked', () => {
-    // Occurrence counting is over the whole file, so the IMPORT of a builder counts
-    // as occurrence 1 — the two procedure declarations are 2 and 3. Anchoring on a
-    // builder name rather than a declaration name is therefore fragile; prefer
-    // `'schedule:'` over `{ occurrence: 2 }`. Kept here because that off-by-one is
-    // exactly what a call site would get wrong.
-    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 1 })).toMatch(/from '\.\.\/\.\.\/trpc'/);
-    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 2 })).toMatch(/'create'/);
-    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 3 })).toMatch(/'update'/);
+    // IMPORT lines are skipped, not counted, so occurrence 1 is the first real
+    // declaration rather than `import { permissionProcedure } from '../../trpc'`.
+    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 1 })).toMatch(/'create'/);
+    expect(blockAt(ROUTER, 'permissionProcedure', { occurrence: 2 })).toMatch(/'update'/);
   });
 });
 
 describe('blockAt — shapes other than tRPC procedures', () => {
   it('bounds an async class method at the next method', () => {
-    const repo = `export class CandidateRepository {
+    // OBJECT LITERAL, not `class` — packages/api/src has only two `class`
+    // declarations and neither is a tripwire target. Every "method" anchor in the
+    // converted set is an object-literal method, e.g.
+    // packages/api/src/repositories/candidate.repository.ts:167 `export const
+    // candidateRepository = {`. An earlier fixture here used `export class`, a shape
+    // the codebase never produces.
+    const repo = `export const candidateRepository = {
   async getById(id: string) {
     return db.candidate.findUnique({ where: { id }, select: detailSelect });
-  }
+  },
 
   async create(input: CreateInput) {
     await assertQuota(input.organizationId);
     return db.candidate.create({ data: input });
-  }
-}
+  },
+};
 `;
     expect(blockAt(repo, 'async getById')).not.toMatch(/assertQuota/);
     expect(blockAt(repo, 'async create')).toMatch(/assertQuota/);
@@ -162,30 +164,58 @@ function requireExternalPermission(resource: string) {
     expect(blockAt(mw, 'function requireExternalPermission')).toMatch(/logSecurityEvent/);
   });
 
-  it('bounds an inner block at its own closing brace', () => {
-    const svc = `  async submitAssessment(input: SubmitInput) {
-    for (const question of questions) {
-      if (question.type === 'free_text') {
-        scored.push({ questionId: question.id, requiresManualReview: true });
+  it('bounds an if-branch at its own `} else {` — not at the end of the else', () => {
+    // The real site is if/ELSE (packages/api/src/services/candidate-assessment.service.ts:107),
+    // not two sibling ifs. An earlier fixture modelled siblings and so proved a bound
+    // the helper did not actually deliver: because every `}`-leading line counted as a
+    // continuation, `} else {` was skipped and the extracted "free_text branch"
+    // swallowed the whole else — 3.5x LOOSER than the `.slice(0, 400)` it replaced.
+    // A review lens caught it. `} else {` now terminates: closers are a continuation
+    // only when nothing follows them.
+    const svc = `      for (const question of questions) {
+        if (question.type === 'free_text') {
+          await repo.upsertResponseInTx(tx, { isCorrect: null, pointsAwarded: null });
+          pendingManual.push(question.id);
+        } else {
+          const { isCorrect, pointsAwarded } = scoreChoice(selected, question);
+          graded.push({ isCorrect, pointsAwarded });
+        }
       }
-      if (question.type === 'single_choice') {
-        scored.push({ questionId: question.id, isCorrect: matches(question) });
-      }
-    }
-  }
 `;
     const freeText = blockAt(svc, "if (question.type === 'free_text') {");
-    expect(freeText).toMatch(/requiresManualReview/);
-    expect(freeText).not.toMatch(/isCorrect/);
+    expect(freeText).toMatch(/pendingManual/);
+    expect(freeText).not.toMatch(/scoreChoice/);
+  });
+
+  it('does NOT treat a spread sibling as a continuation', () => {
+    // `...(cond ? {…} : {})` starts with `.`, and an earlier `isContinuationLine`
+    // matched any leading `.` — so a block ran straight past spread siblings. 119 such
+    // sites exist in packages/api/src, and it is the shape used for field-level
+    // authorization (compensation.service.ts:66-76). Chained builder calls (`.input(`)
+    // must still count as continuations, hence `.` but not `...`.
+    const sel = `  const dto = {
+    userId: true,
+    ...(canSeeVariablePay ? { variablePay: true } : {}),
+    ...(canSeeBand ? { bandId: true } : {}),
+  };
+`;
+    expect(blockAt(sel, 'userId: true')).not.toMatch(/variablePay|bandId/);
   });
 
   it('returns to end-of-file only when the anchor is genuinely last', () => {
+    // Asserts on text BELOW the anchor line. The earlier version matched
+    // `db.thing.findMany` on the anchor's OWN line, so it held for any non-empty block
+    // and survived deleting the bound entirely — it tested nothing about EOF.
     const tail = `export const r = router({
-  onlyOne: protectedProcedure.query(() => db.thing.findMany()),
+  first: protectedProcedure.query(() => db.a.findMany()),
+
+  last: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(() => db.tail.findMany()),
 });
 `;
-    // Nothing later can satisfy the assertion, so an unbounded tail is correct here.
-    expect(blockAt(tail, 'onlyOne:')).toMatch(/db\.thing\.findMany/);
+    expect(blockAt(tail, 'last:')).toMatch(/db\.tail\.findMany/);
+    expect(blockAt(tail, 'first:')).not.toMatch(/db\.tail\.findMany/);
   });
 });
 
@@ -210,8 +240,64 @@ const p = permissionProcedure('interview', 'create');
   });
 
   it('does not treat a division operator or a regex as a comment', () => {
-    const src = `const half = total / 2;\nconst re = /https:\\/\\/x/;\nconst after = 'kept';\n`;
+    // The regex literal must contain a LITERAL `//` pair, unescaped, or this test
+    // survives deleting regex detection outright — which the earlier fixture did,
+    // because its slashes were separated by backslashes. Caught by a review lens
+    // mutating the feature the test names and watching it stay green.
+    const src = ['const half = total / 2;', 'const proto = /[a-z]+:\\/\\//;', "const after = 'kept';", ''].join('\n');
     const out = stripComments(src);
     expect(out).toMatch(/const after = 'kept'/);
+    expect(out).toMatch(/const half = total \/ 2;/);
+  });
+
+  it('terminates a string at a newline so a bare apostrophe cannot swallow later comments', () => {
+    // JS string literals cannot span a raw newline, so ending them there is correct —
+    // and without it, `don't` in JSX text opens a phantom string that stays open until
+    // the next quote anywhere later, leaving every `//` comment in between un-blanked.
+    // That resurrects prose-satisfies-a-gate, the class this helper exists to prevent.
+    const src = ["return <p>don't</p>;", "// assertScoped('candidate') was removed", 'const x = 1;', ''].join('\n');
+    expect(stripComments(src)).not.toMatch(/assertScoped/);
+  });
+
+  it('strips comments from the RETURNED block, not only during anchor resolution', () => {
+    // Zero coverage before: mutating the return to slice the RAW source left every
+    // helper test and all converted tests green, because only the anchor-resolution
+    // half was asserted.
+    const src = `export const r = router({
+  target: protectedProcedure
+    // assertScoped('candidate') is deliberately NOT called here
+    .query(() => db.a.findMany()),
+
+  next: protectedProcedure.query(() => db.b.findMany()),
+});
+`;
+    expect(blockAt(src, 'target:')).not.toMatch(/assertScoped/);
+  });
+
+  it('minLines rejects a block too small for a negative assertion to mean anything', () => {
+    const src = `export const r = router({
+  tiny: protectedProcedure.query(() => db.a.findMany()),
+
+  next: protectedProcedure.query(() => db.b.findMany()),
+});
+`;
+    expect(() => blockAt(src, 'tiny:', { minLines: 5 })).toThrow(/minLines/);
+    expect(blockAt(src, 'tiny:')).toMatch(/db\.a\.findMany/);
+  });
+
+  it('skips an import specifier so a moved declaration cannot resolve vacuously', () => {
+    // The realistic refactor "extract candidateQuestionSelect to a shared module"
+    // makes the first textual occurrence an import specifier. Anchoring there returns
+    // `candidateQuestionSelect } from './selects';` and every `.not.toContain(...)`
+    // over it passes vacuously, green, forever.
+    const src = `import { candidateQuestionSelect } from './selects';
+
+export const candidateQuestionSelectLocal = {
+  id: true,
+  correctOptionIds: true,
+};
+`;
+    expect(() => blockAt(src, 'candidateQuestionSelect')).not.toThrow();
+    expect(blockAt(src, 'candidateQuestionSelect')).toMatch(/correctOptionIds/);
   });
 });

--- a/tests/helpers/source-blocks.ts
+++ b/tests/helpers/source-blocks.ts
@@ -18,7 +18,14 @@
  *
  * By INDENTATION, not by a list of builder names. The block ends at the first later
  * non-blank line indented at or shallower than the anchor's own line — i.e. the next
- * sibling declaration, or the construct's own closing brace, whichever comes first.
+ * sibling declaration, or end-of-file if the anchor is the last construct.
+ *
+ * It never stops AT a closing brace: a pure closer (`}`, `});`, `}),`) is a
+ * continuation, so the block includes its own closing brace and runs to the next
+ * sibling. An earlier version of this docblock said "or the construct's own closing
+ * brace, whichever comes first", which was simply false — flagged by an adversarial
+ * review lens. The extra trailing closer is harmless (it carries no assertable code);
+ * what matters is that no LATER sibling's body is included.
  *
  * Indentation generalises across every shape these tripwires actually anchor on,
  * which a procedure-name pattern does not:
@@ -29,9 +36,16 @@
  *   - inner blocks          `if (question.type === 'free_text') {`
  *
  * It is reliable here because the repo is Prettier-formatted, so indentation is
- * mechanical rather than a matter of taste. A malformed or hand-indented file
- * degrades to a SHORTER block, never a longer one — the safe direction, because a
- * short block can only cause a false failure, never a false pass.
+ * mechanical rather than a matter of taste.
+ *
+ * ⚠️ The safety property is CONDITIONAL on that, and the conditional half is the
+ * dangerous one. Within a consistently-indented file an anomaly yields a SHORTER
+ * block, which can only cause a false failure. But if indentation UNITS are mixed —
+ * a tab-indented anchor (width 1) followed by a space-indented sibling (width 2) —
+ * the sibling never compares `<=` and the block runs past it, which is a false PASS.
+ * An earlier version of this docblock asserted the safe direction unconditionally;
+ * that was wrong, and an adversarial review lens demonstrated the counterexample.
+ * Prettier prevents it in practice, so this is stated rather than defended in code.
  *
  * ── Comments are stripped ─────────────────────────────────────────────────────
  *
@@ -114,8 +128,14 @@ export function stripComments(src: string): string {
           break;
         }
         const closer = mode === 'single' ? "'" : mode === 'double' ? '"' : mode === 'template' ? '`' : '/';
-        // An unterminated literal must not swallow the rest of the file.
-        if (c === closer || (mode === 'regex' && c === '\n')) {
+        // An unterminated literal must not swallow the rest of the file. Only a
+        // TEMPLATE literal may legally span lines, so every other mode also ends at a
+        // newline. Without this a bare apostrophe in JSX text (`don't`) opens a phantom
+        // string that stays open until the next quote ANYWHERE later in the file, and
+        // every `//` comment in between survives un-blanked — resurrecting exactly the
+        // prose-satisfies-a-gate class this helper exists to prevent. Found by an
+        // adversarial review lens, not by reasoning.
+        if (c === closer || (mode !== 'template' && c === '\n')) {
           mode = 'code';
           prev = c;
         }
@@ -154,24 +174,57 @@ function indentOfLineAt(text: string, lineStart: number): number {
  * `candidate.repository.ts`, not by reasoning — the first fixtures here all used
  * single-line signatures, which is a shape this repo frequently does not produce.
  *
- * A closing delimiter can never begin a sibling declaration, so skipping these cannot
- * widen a block past the next real sibling.
+ * The test is deliberately "closers ONLY". An earlier version matched any line STARTING
+ * with a closing delimiter, plus `else`/`catch`/`finally`, and that was wrong twice over
+ * — both caught by an adversarial review lens, both re-introducing the hollowness this
+ * helper removes:
+ *
+ *   - `...(cond ? { a } : {})` — a SPREAD SIBLING — starts with `.`, so it read as a
+ *     continuation and the block ran straight past it. 119 such sites exist in
+ *     packages/api/src, and it is the shape the repo uses for field-level authorization
+ *     (e.g. compensation.service.ts:66-76). Hence `.` counts only when it is a chained
+ *     call (`.input(`), never when it opens a spread.
+ *   - `} else {` starts with `}` but OPENS a new block; treating it as a continuation
+ *     made an `if`-block swallow its own `else`, so a guard asserted on the `if` branch
+ *     could be satisfied by the `else` branch.
+ *
+ * So: a line is a continuation only if, after its leading closers, nothing remains (a
+ * pure closer such as `}`, `}),`, `});`) or what remains opens the construct's body
+ * (`) {`). Anything with an identifier or keyword after the closers begins something
+ * new and must end the block.
  */
 function isContinuationLine(text: string, lineStart: number): boolean {
   const lineEnd = text.indexOf('\n', lineStart);
   const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd).trim();
-  return /^[)\]},;.]/.test(line) || /^(else|catch|finally)\b/.test(line);
+  const rest = line.replace(/^[)\]}\s,;]+/, '');
+  if (rest === '' || rest.startsWith('{')) return true;
+  // A chained builder continuation (`.input(`, `.mutation(`) — but NOT a spread.
+  return rest.startsWith('.') && !rest.startsWith('...');
 }
 
 export interface BlockOptions {
   /**
-   * Occurrence to anchor on, 1-based, when the anchor text appears more than once.
+   * Occurrence to anchor on, 1-based, among NON-IMPORT occurrences (see below).
    * Defaults to the first. Passing this is preferable to lengthening the anchor
    * into something that duplicates the assertion.
    */
   occurrence?: number;
   /** Name used in the failure message. Defaults to the anchor itself. */
   label?: string;
+  /**
+   * Minimum number of lines the resolved block must span, for call sites whose
+   * assertions are NEGATIVE (`.not.toMatch`). A negative assertion over an
+   * accidentally tiny block passes vacuously and silently stops protecting —
+   * the same failure class this helper exists to remove, one layer up.
+   */
+  minLines?: number;
+}
+
+/** True if the line containing `index` is an import/re-export statement. */
+function isImportLine(code: string, lineStart: number): boolean {
+  const lineEnd = code.indexOf('\n', lineStart);
+  const line = code.slice(lineStart, lineEnd === -1 ? code.length : lineEnd);
+  return /^\s*(import|export)\b/.test(line) && /\bfrom\s*['"]/.test(line);
 }
 
 /**
@@ -183,38 +236,59 @@ export interface BlockOptions {
  * asserting over nothing is the failure mode this helper exists to remove.
  */
 export function blockAt(src: string, anchor: string, opts: BlockOptions = {}): string {
-  const { occurrence = 1, label = anchor } = opts;
+  const { occurrence = 1, label = anchor, minLines } = opts;
   const code = stripComments(src);
 
+  // Import/re-export lines are skipped, not counted. Two reasons, both real:
+  //   - A realistic refactor ("extract `candidateQuestionSelect` to a shared module")
+  //     turns the first textual occurrence into an IMPORT SPECIFIER. `blockAt` would
+  //     then happily return `candidateQuestionSelect } from './selects';` and every
+  //     `.not.toContain(...)` over it would pass vacuously, green, forever.
+  //   - It removes the off-by-one where occurrence 1 of a builder name is its import.
   let start = -1;
-  for (let n = 0; n < occurrence; n++) {
+  let found = 0;
+  while (found < occurrence) {
     start = code.indexOf(anchor, start + 1);
     if (start === -1) {
       throw new Error(
         `blockAt: anchor ${JSON.stringify(label)} not found` +
-          (occurrence > 1 ? ` (occurrence ${occurrence})` : '') +
+          (occurrence > 1 ? ` (non-import occurrence ${occurrence})` : '') +
           ' in comment-stripped source. The tripwire is anchored on something that no longer exists.',
       );
     }
+    if (!isImportLine(code, code.lastIndexOf('\n', start) + 1)) found++;
   }
 
   const lineStart = code.lastIndexOf('\n', start) + 1;
   const anchorIndent = indentOfLineAt(code, lineStart);
 
+  const checked = (block: string): string => {
+    if (minLines !== undefined) {
+      const lines = block.split('\n').filter((l) => l.trim() !== '').length;
+      if (lines < minLines) {
+        throw new Error(
+          `blockAt: block for ${JSON.stringify(label)} is ${lines} line(s), below the required ` +
+            `minLines=${minLines}. A negative assertion over a block this small would pass vacuously.`,
+        );
+      }
+    }
+    return block;
+  };
+
   // Scan forward line by line for the first non-blank line at or shallower than the
-  // anchor's indentation — the next sibling, or this construct's own closing brace.
+  // anchor's indentation — the next sibling declaration, or EOF. Never a closing brace.
   let cursor = code.indexOf('\n', start);
   while (cursor !== -1) {
     const nextLineStart = cursor + 1;
     if (nextLineStart >= code.length) break;
     const indent = indentOfLineAt(code, nextLineStart);
     if (indent !== -1 && indent <= anchorIndent && !isContinuationLine(code, nextLineStart)) {
-      return code.slice(start, nextLineStart);
+      return checked(code.slice(start, nextLineStart));
     }
     cursor = code.indexOf('\n', nextLineStart);
   }
 
   // Anchor is the last construct in the file: end-of-file IS the correct bound,
   // because there is no later sibling whose code could satisfy the assertion.
-  return code.slice(start);
+  return checked(code.slice(start));
 }

--- a/tests/helpers/source-blocks.ts
+++ b/tests/helpers/source-blocks.ts
@@ -1,0 +1,220 @@
+/**
+ * Bounded, comment-free extraction of a named block from source, for static tripwires.
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────────
+ *
+ * The idiom this replaces is `SRC.slice(SRC.indexOf('procedureName'))` — a slice with
+ * no end bound, running to end-of-file. An assertion over such a slice does not prove
+ * what its title claims: `expect(block).toMatch(/guard/)` proves only that SOME
+ * occurrence of `guard` appears somewhere AFTER the anchor, not that the anchored
+ * procedure carries it. Any later procedure in the same file satisfies it, so the
+ * tripwire stays green after the guard is moved out of the thing it names.
+ *
+ * The two-argument form `slice(indexOf(A), indexOf(B))` is sounder but still brittle:
+ * it silently degrades to the unbounded form when `B` is deleted, because `indexOf`
+ * returns `-1` and `slice(n, -1)` means "to one character before the end".
+ *
+ * ── How the bound is derived ──────────────────────────────────────────────────
+ *
+ * By INDENTATION, not by a list of builder names. The block ends at the first later
+ * non-blank line indented at or shallower than the anchor's own line — i.e. the next
+ * sibling declaration, or the construct's own closing brace, whichever comes first.
+ *
+ * Indentation generalises across every shape these tripwires actually anchor on,
+ * which a procedure-name pattern does not:
+ *
+ *   - tRPC procedures      `schedule: permissionProcedure('interview', 'create')`
+ *   - class/service methods `async submitAssessment(...) {`
+ *   - top-level declarations `const withSecurityAudit = t.middleware(...)`
+ *   - inner blocks          `if (question.type === 'free_text') {`
+ *
+ * It is reliable here because the repo is Prettier-formatted, so indentation is
+ * mechanical rather than a matter of taste. A malformed or hand-indented file
+ * degrades to a SHORTER block, never a longer one — the safe direction, because a
+ * short block can only cause a false failure, never a false pass.
+ *
+ * ── Comments are stripped ─────────────────────────────────────────────────────
+ *
+ * Returned blocks have comments blanked, so a prose mention cannot satisfy a gate.
+ * This repo has been bitten by prose-matching four separate times (the calibration
+ * tripwire's `\.\s*`, evaluation360, the `console.log`-in-a-comment tripwire, and the
+ * §21 audit control that certified `data-requests.ts` on the strength of a comment
+ * explaining why it does NOT call the helper). Anchors are searched against the same
+ * comment-stripped text, so an anchor named only in prose does not resolve either.
+ *
+ * String CONTENTS are preserved — assertions here legitimately match on literals such
+ * as `permissionProcedure('interview', 'create')`.
+ */
+
+/**
+ * Blanks comment bodies, preserving every offset and newline so the result indexes
+ * identically to the input.
+ *
+ * Tracks string, template and regex literals only so that `//` and other comment
+ * openers appearing INSIDE them are not mistaken for comments — e.g. the `//` in a
+ * URL literal. Regex detection uses the standard "previous significant token"
+ * heuristic; a false negative there can only mis-blank a comment-looking sequence
+ * inside a regex, which would shrink a block rather than widen it.
+ */
+export function stripComments(src: string): string {
+  const out = src.split('');
+  type Mode = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex';
+  let mode: Mode = 'code';
+  // The last non-whitespace character of real code, used to decide whether a `/`
+  // opens a regex literal or is a division operator.
+  let prev = '';
+
+  const blank = (i: number) => {
+    if (out[i] !== '\n') out[i] = ' ';
+  };
+
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    switch (mode) {
+      case 'code':
+        if (c === '/' && next === '/') {
+          mode = 'line';
+          blank(i);
+          blank(i + 1);
+          i++;
+        } else if (c === '/' && next === '*') {
+          mode = 'block';
+          blank(i);
+          blank(i + 1);
+          i++;
+        } else if (c === "'") mode = 'single';
+        else if (c === '"') mode = 'double';
+        else if (c === '`') mode = 'template';
+        else if (c === '/' && /[(,=:[!&|?{};+\-*%<>~^]|^$/.test(prev)) mode = 'regex';
+        if (mode === 'code' && !/\s/.test(c)) prev = c;
+        break;
+
+      case 'line':
+        if (c === '\n') mode = 'code';
+        else blank(i);
+        break;
+
+      case 'block':
+        blank(i);
+        if (c === '*' && next === '/') {
+          blank(i + 1);
+          i++;
+          mode = 'code';
+        }
+        break;
+
+      case 'single':
+      case 'double':
+      case 'template':
+      case 'regex': {
+        if (c === '\\') {
+          i++; // skip the escaped character
+          break;
+        }
+        const closer = mode === 'single' ? "'" : mode === 'double' ? '"' : mode === 'template' ? '`' : '/';
+        // An unterminated literal must not swallow the rest of the file.
+        if (c === closer || (mode === 'regex' && c === '\n')) {
+          mode = 'code';
+          prev = c;
+        }
+        break;
+      }
+    }
+  }
+
+  return out.join('');
+}
+
+/** Indentation width of the line containing `index`, or -1 for a blank line. */
+function indentOfLineAt(text: string, lineStart: number): number {
+  const lineEnd = text.indexOf('\n', lineStart);
+  const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
+  if (line.trim() === '') return -1;
+  return line.length - line.trimStart().length;
+}
+
+/**
+ * True for a line that CONTINUES or CLOSES the current construct rather than starting
+ * a sibling — so it must not end the block even though it sits at the anchor's own
+ * indentation.
+ *
+ * Needed because Prettier wraps a long signature with the closing paren back at the
+ * declaration's indent:
+ *
+ *     async getDashboardKpis(
+ *       orgId: string,
+ *       appScopeWhere: Prisma.ApplicationWhereInput,
+ *     ) {                     // <- same indent as `async getDashboardKpis(`
+ *
+ * Without this, the block is cut off at `) {` and contains only the signature. That is
+ * a false-FAILURE rather than a false-pass, but it makes the helper unusable on the
+ * many real methods formatted this way. Caught by running against the real
+ * `candidate.repository.ts`, not by reasoning — the first fixtures here all used
+ * single-line signatures, which is a shape this repo frequently does not produce.
+ *
+ * A closing delimiter can never begin a sibling declaration, so skipping these cannot
+ * widen a block past the next real sibling.
+ */
+function isContinuationLine(text: string, lineStart: number): boolean {
+  const lineEnd = text.indexOf('\n', lineStart);
+  const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd).trim();
+  return /^[)\]},;.]/.test(line) || /^(else|catch|finally)\b/.test(line);
+}
+
+export interface BlockOptions {
+  /**
+   * Occurrence to anchor on, 1-based, when the anchor text appears more than once.
+   * Defaults to the first. Passing this is preferable to lengthening the anchor
+   * into something that duplicates the assertion.
+   */
+  occurrence?: number;
+  /** Name used in the failure message. Defaults to the anchor itself. */
+  label?: string;
+}
+
+/**
+ * Returns the comment-stripped source of the block introduced by `anchor`, bounded at
+ * the next sibling declaration (see the module docblock).
+ *
+ * Throws — rather than returning the whole file, or an empty string — when the anchor
+ * is absent. A tripwire whose anchor has been renamed away must fail loudly; silently
+ * asserting over nothing is the failure mode this helper exists to remove.
+ */
+export function blockAt(src: string, anchor: string, opts: BlockOptions = {}): string {
+  const { occurrence = 1, label = anchor } = opts;
+  const code = stripComments(src);
+
+  let start = -1;
+  for (let n = 0; n < occurrence; n++) {
+    start = code.indexOf(anchor, start + 1);
+    if (start === -1) {
+      throw new Error(
+        `blockAt: anchor ${JSON.stringify(label)} not found` +
+          (occurrence > 1 ? ` (occurrence ${occurrence})` : '') +
+          ' in comment-stripped source. The tripwire is anchored on something that no longer exists.',
+      );
+    }
+  }
+
+  const lineStart = code.lastIndexOf('\n', start) + 1;
+  const anchorIndent = indentOfLineAt(code, lineStart);
+
+  // Scan forward line by line for the first non-blank line at or shallower than the
+  // anchor's indentation — the next sibling, or this construct's own closing brace.
+  let cursor = code.indexOf('\n', start);
+  while (cursor !== -1) {
+    const nextLineStart = cursor + 1;
+    if (nextLineStart >= code.length) break;
+    const indent = indentOfLineAt(code, nextLineStart);
+    if (indent !== -1 && indent <= anchorIndent && !isContinuationLine(code, nextLineStart)) {
+      return code.slice(start, nextLineStart);
+    }
+    cursor = code.indexOf('\n', nextLineStart);
+  }
+
+  // Anchor is the last construct in the file: end-of-file IS the correct bound,
+  // because there is no later sibling whose code could satisfy the assertion.
+  return code.slice(start);
+}

--- a/tests/portal/candidate-procedure.test.ts
+++ b/tests/portal/candidate-procedure.test.ts
@@ -192,28 +192,32 @@ describe('candidate FAQ rate limiting', () => {
 });
 
 describe('candidate assessment take-flow — security invariants (Wave 1.5a slice 2)', () => {
+  // Shared by both assertions below so they cannot drift apart — one of them is the
+  // IDOR guard, and it previously covered whichever endpoints happened to fall inside
+  // one unbounded slice.
+  const ASSESSMENT_ENDPOINTS = ['getMyAssessments', 'startAssessment', 'getAssessmentQuestions', 'submitAssessment'];
+
   it('every new candidate-portal assessment endpoint uses candidateProcedure', () => {
-    // Bound each endpoint's slice to end at the START of the NEXT endpoint (in
-    // real router order) so each slice contains ONLY that one endpoint's own
-    // procedure definition — a plain end-of-file slice would let earlier
-    // endpoints "pass" merely because a LATER endpoint still uses
-    // candidateProcedure, even if the earlier one were changed to publicProcedure.
-    const ASSESSMENT_ENDPOINTS = ['getMyAssessments', 'startAssessment', 'getAssessmentQuestions', 'submitAssessment'];
-    for (let i = 0; i < ASSESSMENT_ENDPOINTS.length; i++) {
-      const name = ASSESSMENT_ENDPOINTS[i];
-      const start = ROUTER.indexOf(`${name}:`);
-      expect(start).toBeGreaterThan(-1);
-      const nextName = ASSESSMENT_ENDPOINTS[i + 1];
-      const end = nextName ? ROUTER.indexOf(`${nextName}:`) : ROUTER.length;
-      const slice = ROUTER.slice(start, end);
-      expect(slice).toMatch(/candidateProcedure/);
+    // Each endpoint is bounded at its own next sibling, so an endpoint cannot "pass"
+    // because a LATER one still uses candidateProcedure.
+    for (const name of ASSESSMENT_ENDPOINTS) {
+      expect(blockAt(ROUTER, `${name}:`)).toMatch(/candidateProcedure/);
     }
   });
 
   it('never accepts a client-supplied candidateId or email on the assessment endpoints', () => {
-    const slice = blockAt(ROUTER, 'getMyAssessments:');
-    expect(slice).not.toMatch(/candidateId:\s*z\./);
-    expect(slice).not.toMatch(/email:\s*z\./);
+    // EVERY assessment endpoint, not just the first. This previously ran as one
+    // unbounded slice from `getMyAssessments:` to end-of-file, which happened to span
+    // all four; bounding it to a single procedure left `startAssessment`,
+    // `getAssessmentQuestions` and `submitAssessment` unguarded, and no whole-file
+    // assertion covers `candidateId` (the one at the top of this file covers `email`
+    // only). A client-supplied candidateId on submitAssessment is precisely the IDOR
+    // this block exists to prevent.
+    for (const name of ASSESSMENT_ENDPOINTS) {
+      const slice = blockAt(ROUTER, `${name}:`, { minLines: 3 });
+      expect(slice, name).not.toMatch(/candidateId:\s*z\./);
+      expect(slice, name).not.toMatch(/email:\s*z\./);
+    }
   });
 
   it('getAssessmentQuestions repo select never includes correctOptionIds', () => {

--- a/tests/portal/candidate-procedure.test.ts
+++ b/tests/portal/candidate-procedure.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Wave 1 Slice 2 introduces a NEW procedure type — `candidateProcedure` — for the
 // authenticated candidate portal. Candidates are NOT staff: they have a Supabase
@@ -67,7 +68,7 @@ describe('candidate-portal router', () => {
   });
 
   it('askFaq accepts only orgSlug/question/optional application focus (never candidateId/email)', () => {
-    const askFaq = ROUTER.slice(ROUTER.indexOf('askFaq:'));
+    const askFaq = blockAt(ROUTER, 'askFaq:');
     expect(askFaq).toMatch(/candidateProcedure/);
     expect(askFaq).toMatch(/question:\s*faqQuestion/);
     expect(askFaq).toMatch(/applicationId:\s*z\.string\(\)\.uuid\(\)\.optional\(\)/);
@@ -144,7 +145,7 @@ describe('candidate-portal repository — scoping', () => {
   });
 
   it('FAQ profile lookup uses explicit select and avoids internal candidate fields', () => {
-    const method = REPO.slice(REPO.indexOf('findActiveCandidateProfile'));
+    const method = blockAt(REPO, 'findActiveCandidateProfile');
     expect(method).toMatch(/select:\s*\{\s*id:\s*true,\s*firstName:\s*true,\s*lastName:\s*true/s);
     expect(method).not.toMatch(/notes:\s*true|tags:\s*true|fitScores|assessmentAssignments|documents/);
   });
@@ -210,24 +211,21 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
   });
 
   it('never accepts a client-supplied candidateId or email on the assessment endpoints', () => {
-    const slice = ROUTER.slice(ROUTER.indexOf('getMyAssessments:'));
+    const slice = blockAt(ROUTER, 'getMyAssessments:');
     expect(slice).not.toMatch(/candidateId:\s*z\./);
     expect(slice).not.toMatch(/email:\s*z\./);
   });
 
   it('getAssessmentQuestions repo select never includes correctOptionIds', () => {
-    const candidateSelect = ASSESSMENT_REPO.slice(
-      ASSESSMENT_REPO.indexOf('candidateQuestionSelect'),
-      ASSESSMENT_REPO.indexOf('assignmentSummarySelect'),
-    );
+    const candidateSelect = blockAt(ASSESSMENT_REPO, 'candidateQuestionSelect');
     expect(candidateSelect).not.toContain('correctOptionIds');
   });
 
   it('the answer-key select is confined to the *InTx helpers (never returned to the candidate)', () => {
     expect(ASSESSMENT_REPO).toContain('findQuestionsWithAnswerKeyInTx');
     // Only the tx-bound (write-path) function may select correctOptionIds.
-    const answerKeySlice = ASSESSMENT_REPO.slice(ASSESSMENT_REPO.indexOf('findQuestionsWithAnswerKeyInTx'));
-    expect(answerKeySlice.slice(0, 300)).toContain('correctOptionIds');
+    const answerKeySlice = blockAt(ASSESSMENT_REPO, 'findQuestionsWithAnswerKeyInTx');
+    expect(answerKeySlice).toContain('correctOptionIds');
   });
 
   it('correctOptionIds never appears anywhere in the read-only candidateAssessmentRepo section', () => {
@@ -267,7 +265,7 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
     // This confirms ownership/status is re-verified early in the tx, before any
     // write happens — a real, still-valid property. It does NOT by itself close
     // the double-submit race (see the next test for the mechanism that does).
-    const submitSlice = ASSESSMENT_SERVICE.slice(ASSESSMENT_SERVICE.indexOf('async submitAssessment'));
+    const submitSlice = blockAt(ASSESSMENT_SERVICE, 'async submitAssessment');
     expect(submitSlice).toContain('findAssignmentInTx');
     expect(submitSlice).toMatch(/assignment_already_completed/);
   });
@@ -279,7 +277,7 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
     expect(ASSESSMENT_REPO).toMatch(
       /completeAssignmentInTx\([^)]*\)\s*\{\s*return\s+tx\.assessmentAssignment\.updateMany\(\{\s*where:\s*\{[^}]*status:\s*'in_progress'/s,
     );
-    const submitSlice = ASSESSMENT_SERVICE.slice(ASSESSMENT_SERVICE.indexOf('async submitAssessment'));
+    const submitSlice = blockAt(ASSESSMENT_SERVICE, 'async submitAssessment');
     // Search for 'completeAssignmentInTx(' rather than 'completeAssignmentInTx(tx'
     // — prettier may wrap the call's argument list (tx, org.id, candidate.id,
     // assignmentId) across multiple lines, so the arguments don't necessarily
@@ -292,7 +290,7 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
   });
 
   it('completeAssignmentInTx is called with both org.id AND candidate.id (final review finding #3 — independently IDOR-safe, not merely correct-by-surrounding-context)', () => {
-    const submitSlice = ASSESSMENT_SERVICE.slice(ASSESSMENT_SERVICE.indexOf('async submitAssessment'));
+    const submitSlice = blockAt(ASSESSMENT_SERVICE, 'async submitAssessment');
     const completionIdx = submitSlice.indexOf('completeAssignmentInTx(');
     expect(completionIdx).toBeGreaterThan(0);
     const callSite = submitSlice.slice(completionIdx, completionIdx + 150);
@@ -306,7 +304,7 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
   });
 
   it("submitAssessment validates every questionId belongs to the assignment's assessmentTypeId before writing", () => {
-    const submitSlice = ASSESSMENT_SERVICE.slice(ASSESSMENT_SERVICE.indexOf('async submitAssessment'));
+    const submitSlice = blockAt(ASSESSMENT_SERVICE, 'async submitAssessment');
     const validateIdx = submitSlice.indexOf('question_not_in_assessment');
     const firstWriteIdx = submitSlice.indexOf('upsertResponseInTx(tx');
     expect(validateIdx).toBeGreaterThan(0);
@@ -314,10 +312,10 @@ describe('candidate assessment take-flow — security invariants (Wave 1.5a slic
   });
 
   it('free_text answers are never auto-graded (no fabricated AI/auto score — rule #4)', () => {
-    const submitSlice = ASSESSMENT_SERVICE.slice(ASSESSMENT_SERVICE.indexOf('async submitAssessment'));
-    const freeTextBranch = submitSlice.slice(submitSlice.indexOf("if (question.type === 'free_text') {"));
-    expect(freeTextBranch.slice(0, 400)).toMatch(/isCorrect:\s*null/);
-    expect(freeTextBranch.slice(0, 400)).toMatch(/pointsAwarded:\s*null/);
+    const submitSlice = blockAt(ASSESSMENT_SERVICE, 'async submitAssessment');
+    const freeTextBranch = blockAt(submitSlice, "if (question.type === 'free_text') {");
+    expect(freeTextBranch).toMatch(/isCorrect:\s*null/);
+    expect(freeTextBranch).toMatch(/pointsAwarded:\s*null/);
   });
 
   it('all submitAssessment inputs are bounded (answers array + freeText + selectedOptionIds)', () => {

--- a/tests/security/auth-authorization.test.ts
+++ b/tests/security/auth-authorization.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROUTERS_DIR = join(__dirname, '../../packages/api/src/routers');
 const TRPC_FILE = join(__dirname, '../../packages/api/src/trpc.ts');
@@ -78,10 +79,7 @@ describe('Authentication & Authorization', () => {
   it('should verify organizationId in user mutation WHERE clauses', () => {
     const userRouter = readFileSync(join(ROUTERS_DIR, 'user.ts'), 'utf8');
     // The deactivate mutation must check organizationId
-    const deactivateSection = userRouter.slice(
-      userRouter.indexOf('deactivate:'),
-      userRouter.indexOf('deactivate:') + 500,
-    );
+    const deactivateSection = blockAt(userRouter, 'deactivate:');
     expect(deactivateSection).toContain('organizationId');
   });
 

--- a/tests/security/mfa-enforcement.test.ts
+++ b/tests/security/mfa-enforcement.test.ts
@@ -17,13 +17,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { initTRPC, TRPCError } from '@trpc/server';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import {
-  isMfaPrivileged,
-  isMfaEnforced,
-  isMfaSatisfied,
-  isMfaGateBlocking,
-  MFA_REQUIRED,
-} from '@tims/shared';
+import { blockAt } from '../helpers/source-blocks';
+import { isMfaPrivileged, isMfaEnforced, isMfaSatisfied, isMfaGateBlocking, MFA_REQUIRED } from '@tims/shared';
 
 const createMock = vi.fn();
 vi.mock('@tims/db', () => ({
@@ -58,7 +53,13 @@ describe('isMfaPrivileged — mirrors the (admin) page gate + trpc.ts privileged
 // ---------------------------------------------------------------------------
 describe('withMfaEnforcement — API-layer gate', () => {
   type Ctx = {
-    user: { id: string; organizationId: string; roles: string[]; isPlatformOwner: boolean; impersonatorId?: string } | null;
+    user: {
+      id: string;
+      organizationId: string;
+      roles: string[];
+      isPlatformOwner: boolean;
+      impersonatorId?: string;
+    } | null;
     aal?: string | null;
     headers: Headers;
   };
@@ -88,7 +89,9 @@ describe('withMfaEnforcement — API-layer gate', () => {
   const priv = { id: 'u1', organizationId: 'org1', roles: ['super_admin'], isPlatformOwner: false };
   const plain = { id: 'u2', organizationId: 'org1', roles: ['recruiter'], isPlatformOwner: false };
 
-  afterEach(() => { delete process.env.MFA_ENFORCED; });
+  afterEach(() => {
+    delete process.env.MFA_ENFORCED;
+  });
 
   it('BLOCKS a privileged aal1 session with MFA_REQUIRED when enforced', async () => {
     process.env.MFA_ENFORCED = 'true';
@@ -171,7 +174,7 @@ describe('wiring — MFA enforcement is composed and transported end to end', ()
     expect(src).toMatch(/\.use\(withMfaEnforcement\)/);
     expect(src).toMatch(/isMfaPrivileged/);
     expect(src).toMatch(/isMfaEnforced\(process\.env\.MFA_ENFORCED\)/);
-    const block = src.slice(src.indexOf('withMfaEnforcement ='));
+    const block = blockAt(src, 'withMfaEnforcement =');
     expect(block).toMatch(/MFA_REQUIRED/);
     expect(block).toMatch(/mfa_step_up_required/);
     // Impersonation is treated as privileged (real operator is always an owner).

--- a/tests/security/security-event-coverage.test.ts
+++ b/tests/security/security-event-coverage.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { initTRPC, TRPCError } from '@trpc/server';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const createMock = vi.fn();
 vi.mock('@tims/db', () => ({
@@ -308,21 +309,21 @@ describe('wiring — security events are instrumented at their sites', () => {
     // outermost = applied before withRateLimit on the base procedure
     expect(src).toMatch(/t\.procedure\.use\(withSecurityAudit\)\.use\(withRateLimit\)/);
     // the wrapper must observe on failure and return the result UNCHANGED (transparent)
-    const block = src.slice(src.indexOf('const withSecurityAudit'));
+    const block = blockAt(src, 'const withSecurityAudit');
     expect(block).toMatch(/if \(!result\.ok\) observeDenial/);
     expect(block).toMatch(/return result/);
   });
 
   it('trpc.ts: external API-key denials are observed at both requireExternalPermission throw sites', () => {
     const src = read('packages/api/src/trpc.ts');
-    const block = src.slice(src.indexOf('function requireExternalPermission'));
+    const block = blockAt(src, 'function requireExternalPermission');
     expect(block).toMatch(/observeExternalDenial\(\{[^}]*reason: 'scope'/);
     expect(block).toMatch(/observeExternalDenial\(\{[^}]*reason: 'grant'/);
   });
 
   it('system.ts: single-org feature-flag deletion logs feature_flag_changed', () => {
     const src = read('packages/api/src/routers/platform/system.ts');
-    const block = src.slice(src.indexOf('deleteFeatureFlag:'));
+    const block = blockAt(src, 'deleteFeatureFlag:');
     expect(block).toMatch(/logSecurityEvent/);
     expect(block).toMatch(/feature_flag_changed/);
   });


### PR DESCRIPTION
Closes #147.

Replaces the unbounded `SRC.slice(SRC.indexOf('name'))` static-tripwire idiom with a shared `blockAt` helper that bounds each extracted block at the next sibling declaration, and adds a governance tripwire so the idiom cannot come back.

## The defect

An unbounded slice runs to end-of-file, so "procedure X carries guard G" is satisfied by G appearing in **any later procedure**. The tripwire stays green after the guard is moved out of the thing it names.

## Mutation proof, on real source

`packages/api/src/routers/performance/coaching.ts` — `scopeWhereFor('commitment')` appears at `:131` inside `listCommitments` **and at `:183` inside `myCommitments`**, declared later. Deleting only the first:

| idiom | result |
| --- | --- |
| `src().slice(src().indexOf('listCommitments'))` — **the code that was on main** | matches → stays **GREEN** |
| `blockAt(src(), 'listCommitments:')` | **RED** |

This was a live, exploitable hollow tripwire, not a hypothetical one.

Second proof, for the restored IDOR guard: injecting `candidateId: z.string().uuid()` into `submitAssessment`'s input is **missed** by a single `getMyAssessments:` block and **caught** by the per-endpoint loop.

## Scope

44 converted call sites across 16 files. Zero of the idiom remain in `tests/` outside the helper's own demonstration fixtures.

## What the tier-3 panel changed

Three adversarial lenses reviewed the first commit (`bc35d826`) and it did not survive intact. `20c15809` fixes what they found.

**Two conversions had narrowed security controls** — the serious class, because the hollow-slice defect applies to *positive* assertions only. A negative assertion over an unbounded tail is sound, and bounding it silently removes coverage:

- `scope-wiring-offer.test.ts` — bounding `getBySigningToken` dropped `acceptByToken` and `declineByToken` from the probe-free assertion, and nothing else in the suite covers them. The inline comment still said "the three public token procedures". Now asserted per procedure.
- `candidate-procedure.test.ts` — the IDOR guard went from 4 assessment endpoints to 1. No whole-file assertion covers `candidateId`.

**Two false-pass paths in the helper:**

- `isContinuationLine` treated any `.`-leading line as a continuation, so **spread siblings** (`...(cond ? {…} : {})`) were swallowed — 119 such sites exist in `packages/api/src`, and it is the shape used for field-level authorization. It also treated any `}`-leading line as a continuation, so `} else {` was skipped and an `if`-branch swallowed its own `else`; that one conversion was **3.5× looser** than the `.slice(0, 400)` it replaced.
- `stripComments` did not end a string at a newline, so a bare apostrophe in JSX text (`don't`) opened a phantom string and left later `//` comments un-blanked — resurrecting prose-satisfies-a-gate, the class this helper exists to prevent.

Also added: import specifiers are skipped during anchor resolution (a realistic "extract to a shared module" refactor otherwise makes an anchor resolve to the import and every negative assertion over it pass vacuously), and a `minLines` option for negative assertions.

**Five sites were missed**, because my grep assumed a `\w+` receiver and these use the `src()` thunk convention. One of them is the live `listCommitments` case above.

**Two claims in the first commit message were wrong**, corrected in `20c15809`:

- The mutation proof named `interview/crud.ts`, but that site was **already two-arg bounded** on main, so the old code would also have gone red. It demonstrated the class, not an improvement over the deleted line. Replaced with `listCommitments`, which was genuinely unbounded.
- "38 hollow" overstated: 22 were unbounded, 16 were already the two-argument form (brittle — it degrades to unbounded when the end anchor is renamed — but not hollow). The 33→38 delta was also mis-attributed: +1 from main moving, +2 multi-line forms, +2 that the issue's own grep found but its table omitted.

## Governance tripwire

`tests/governance/no-hollow-source-slices.test.ts` bans the shape, scanned against **comment-stripped** source, with a non-vacuity assertion on the file population and a staleness check on its one allowlist entry.

It earned its keep twice on first run: it found a file **three review lenses had missed**, and it matched its own `it(...)` title until the banned sequence was removed from the title text — the fifth time this repo has been bitten by a source scan matching prose.

It is mutation-proved: reintroducing the idiom in `scope-wiring-learning.test.ts` turns it red.

## Verification

`npx vitest run` from the repo root: **297 files / 2815 tests, exit 0.** Both `tsc --noEmit` clean. Prettier clean on all changed files.

The `/gate` check-3 anchor is deliberately **not** touched: #164 is still open and carries the measured re-anchor, and six PRs each editing that line is what caused the conflict cascade last session. A stale-low anchor never fires ("more is fine, fewer is a failure"), so it cannot break — re-anchor once this and #164 have both landed.

Note: `mfa-enforcement.test.ts` and `ai-interview-router.test.ts` carry incidental Prettier reformatting; both files were non-compliant before and are compliant now.

## Verification tier

**Tier 3 — same-model adversarial panel.** NOT cross-model.

- Tier 1 (Codex, `/gate` check 15): **exit 2**, quota-blocked until 2026-08-15. Eighth consecutive failure.
- Tier 2 (OmniRoute): **exit 2**, correctly refusing — `OMNIROUTE_MODEL` unset, so the reviewer could not be attributed to a vendor.
- Tier 3: three lenses (security/tenant-isolation, claim auditor, coverage), each prompted to refute and to re-read source rather than trust the implementer's summary. Findings above.
