### PR TITLE
refactor(tests): fold the 3 private source extractors into blockAt (#166)

### DIFF
--- a/tests/access/membership-admin-committee.test.ts
+++ b/tests/access/membership-admin-committee.test.ts
@@ -1,21 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 const ROOT = join(__dirname, '..', '..');
 const crud = () => readFileSync(join(ROOT, 'packages/api/src/routers/interview/crud.ts'), 'utf8');
-
-// Slice a single endpoint body out of a router source so multiline regexes
-// can't bleed across endpoint boundaries. Captures from the endpoint key up to
-// (but not including) the next top-level endpoint key (or EOF).
-function endpointBody(src: string, name: string): string {
-  const start = src.indexOf(`${name}:`);
-  if (start === -1) return '';
-  // The next endpoint key sits at 2-space indent: `\n  someName:`.
-  const rest = src.slice(start + name.length);
-  const next = rest.search(/\n {2}[a-zA-Z]\w*:\s*permissionProcedure/);
-  return next === -1 ? rest : rest.slice(0, next);
-}
 
 describe('interview evaluator management', () => {
   it('addEvaluator gated by interview:update', () => {
@@ -25,7 +14,7 @@ describe('interview evaluator management', () => {
     expect(crud()).toMatch(/removeEvaluator:\s*permissionProcedure\('interview',\s*'update'\)/);
   });
   it('addEvaluator org-verifies the evaluator user (IDOR)', () => {
-    const body = endpointBody(crud(), 'addEvaluator');
+    const body = blockAt(crud(), 'addEvaluator:');
     expect(body).toMatch(/user\.(findFirst|count)/);
   });
   it('addEvaluator maps duplicate to CONFLICT', () => {
@@ -38,13 +27,13 @@ describe('interview evaluator management', () => {
   // by id and self-add → both endpoints must SCOPE-probe the interview parent
   // (assertScoped), not just org-check it.
   it('addEvaluator scope-probes the interview parent (no bare org-only findFirst)', () => {
-    const body = endpointBody(crud(), 'addEvaluator');
+    const body = blockAt(crud(), 'addEvaluator:');
     expect(body).toMatch(/assertScoped\('interview'/);
     // The escalation hole was the bare org-only parent check — it must be gone.
     expect(body).not.toMatch(/interview\.findFirst/);
   });
   it('removeEvaluator scope-probes the interview parent', () => {
-    const body = endpointBody(crud(), 'removeEvaluator');
+    const body = blockAt(crud(), 'removeEvaluator:');
     expect(body).toMatch(/assertScoped\('interview'/);
     expect(body).not.toMatch(/interview\.findFirst/);
   });

--- a/tests/access/scope-wiring-employee-recognition-commitments.test.ts
+++ b/tests/access/scope-wiring-employee-recognition-commitments.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
 // Wave (role rebuild) Slice 5C — static tripwires for the two OWN-scoped
 // employee surfaces: recognition RECEIVED and the employee's own coaching
@@ -22,25 +23,13 @@ import { join } from 'path';
 //                                the own-scoped caller). Explicit select + bounded.
 
 const ROOT = join(__dirname, '..', '..');
-const readFeedback = () =>
-  readFileSync(join(ROOT, 'packages/api/src/routers/performance/feedback.ts'), 'utf8');
-const readCoaching = () =>
-  readFileSync(join(ROOT, 'packages/api/src/routers/performance/coaching.ts'), 'utf8');
+const readFeedback = () => readFileSync(join(ROOT, 'packages/api/src/routers/performance/feedback.ts'), 'utf8');
+const readCoaching = () => readFileSync(join(ROOT, 'packages/api/src/routers/performance/coaching.ts'), 'utf8');
 
 // Isolate the body of a named procedure (`name: ...` up to the next top-level
 // `procedure,`/`router` boundary) so assertions target THAT endpoint.
-function procedureBody(src: string, name: string): string {
-  const start = src.indexOf(`${name}:`);
-  expect(start, `procedure ${name} not found`).toBeGreaterThanOrEqual(0);
-  const rest = src.slice(start + name.length);
-  const next = rest.search(
-    /\n {2}[a-zA-Z]+:\s*(permissionProcedure|protectedProcedure|router)/,
-  );
-  return next >= 0 ? rest.slice(0, next) : rest;
-}
-
 describe('performance.myRecognitions — own-scoped recognition RECEIVED', () => {
-  const body = () => procedureBody(readFeedback(), 'myRecognitions');
+  const body = () => blockAt(readFeedback(), 'myRecognitions:');
 
   it('exists', () => {
     expect(readFeedback()).toMatch(/myRecognitions:/);
@@ -83,13 +72,13 @@ describe('performance.myRecognitions — own-scoped recognition RECEIVED', () =>
 });
 
 describe('performance.myCommitments — own-scoped employee commitments', () => {
-  const body = () => procedureBody(readCoaching(), 'myCommitments');
+  const body = () => blockAt(readCoaching(), 'myCommitments:');
 
   it('exists', () => {
     expect(readCoaching()).toMatch(/myCommitments:/);
   });
 
-  it('uses permissionProcedure(\'performance\', \'read\') (employee has this grant)', () => {
+  it("uses permissionProcedure('performance', 'read') (employee has this grant)", () => {
     expect(body()).toMatch(/permissionProcedure\('performance',\s*'read'\)/);
   });
 
@@ -104,10 +93,8 @@ describe('performance.myCommitments — own-scoped employee commitments', () => 
     expect(b).not.toMatch(/input\.employeeId/);
   });
 
-  it('resolves the subject via scopeWhereFor(\'commitment\', ctx.access, ctx.user.id)', () => {
-    expect(body()).toMatch(
-      /scopeWhereFor\(\s*'commitment',\s*ctx\.access,\s*ctx\.user\.id\s*\)/,
-    );
+  it("resolves the subject via scopeWhereFor('commitment', ctx.access, ctx.user.id)", () => {
+    expect(body()).toMatch(/scopeWhereFor\(\s*'commitment',\s*ctx\.access,\s*ctx\.user\.id\s*\)/);
   });
 
   it('AND-composes the scope fragment with organizationId (never spreads it)', () => {

--- a/tests/perf/s2-no-loop.test.ts
+++ b/tests/perf/s2-no-loop.test.ts
@@ -6,37 +6,14 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { blockAt } from '../helpers/source-blocks';
 
-const dashboardPath = resolve(
-  __dirname,
-  '../../packages/api/src/routers/platform/dashboard.ts',
-);
+const dashboardPath = resolve(__dirname, '../../packages/api/src/routers/platform/dashboard.ts');
 const src = readFileSync(dashboardPath, 'utf-8');
-
-// Extract the source of getUserGrowth and getMrrTrend procedures
-function extractProcedure(source: string, name: string): string {
-  const startPattern = `${name}: platformProcedure`;
-  const start = source.indexOf(startPattern);
-  if (start === -1) throw new Error(`Procedure ${name} not found`);
-  // Find the next top-level procedure or end of router by scanning for the
-  // closing brace at the same nesting depth
-  let depth = 0;
-  let i = start;
-  let firstBrace = false;
-  while (i < source.length) {
-    if (source[i] === '{') { depth++; firstBrace = true; }
-    if (source[i] === '}') {
-      depth--;
-      if (firstBrace && depth === 0) return source.slice(start, i + 1);
-    }
-    i++;
-  }
-  return source.slice(start);
-}
 
 describe('s2-no-loop tripwire: platform/dashboard.ts', () => {
   it('getUserGrowth: no await db. inside for( or .map(', () => {
-    const body = extractProcedure(src, 'getUserGrowth');
+    const body = blockAt(src, 'getUserGrowth:');
     // Must not contain a for-loop that has await db. inside it
     expect(body).not.toMatch(/for\s*\([^)]*\)[^}]*await\s+db\./s);
     // Must not contain .map( that has await db. inside it
@@ -44,20 +21,20 @@ describe('s2-no-loop tripwire: platform/dashboard.ts', () => {
   });
 
   it('getMrrTrend: no await db. inside for( or .map(', () => {
-    const body = extractProcedure(src, 'getMrrTrend');
+    const body = blockAt(src, 'getMrrTrend:');
     expect(body).not.toMatch(/for\s*\([^)]*\)[^}]*await\s+db\./s);
     expect(body).not.toMatch(/\.map\s*\([^)]*=>[^)]*await\s+db\./s);
   });
 
   it('getUserGrowth: uses $queryRaw (not $queryRawUnsafe)', () => {
-    const body = extractProcedure(src, 'getUserGrowth');
+    const body = blockAt(src, 'getUserGrowth:');
     // $queryRaw followed by the generic type or backtick (tagged template)
     expect(body).toMatch(/\$queryRaw[<`]/);
     expect(body).not.toMatch(/\$queryRawUnsafe/);
   });
 
   it('getMrrTrend: uses $queryRaw (not $queryRawUnsafe)', () => {
-    const body = extractProcedure(src, 'getMrrTrend');
+    const body = blockAt(src, 'getMrrTrend:');
     expect(body).toMatch(/\$queryRaw[<`]/);
     expect(body).not.toMatch(/\$queryRawUnsafe/);
   });
@@ -68,7 +45,7 @@ describe('s2-no-loop tripwire: platform/dashboard.ts', () => {
   // upper letter inside double-quotes) is a Prisma field name, not a DB column,
   // and will throw `column "..." does not exist` at runtime.
   it('getUserGrowth: $queryRaw SQL contains no camelCase quoted identifiers', () => {
-    const body = extractProcedure(src, 'getUserGrowth');
+    const body = blockAt(src, 'getUserGrowth:');
     // Extract the raw SQL template literal (between the backticks)
     const sqlMatch = body.match(/\$queryRaw<[^>]*>`([\s\S]*?)`/);
     if (!sqlMatch) throw new Error('Could not extract $queryRaw SQL from getUserGrowth');
@@ -78,7 +55,7 @@ describe('s2-no-loop tripwire: platform/dashboard.ts', () => {
   });
 
   it('getMrrTrend: $queryRaw SQL contains no camelCase quoted identifiers', () => {
-    const body = extractProcedure(src, 'getMrrTrend');
+    const body = blockAt(src, 'getMrrTrend:');
     const sqlMatch = body.match(/\$queryRaw<[^>]*>`([\s\S]*?)`/);
     if (!sqlMatch) throw new Error('Could not extract $queryRaw SQL from getMrrTrend');
     const sql = sqlMatch[1];


### PR DESCRIPTION
Closes #166 (partially — see "Not in this PR" below).

Deletes the three private source-extraction helpers left over after #165 gave the codebase one mechanism (`blockAt`), and points their call sites at it.

| removed | file | weakness |
| --- | --- | --- |
| `endpointBody` | `tests/access/membership-admin-committee.test.ts` | returned `''` on a missing anchor (fail-open); bounded only on `permissionProcedure` |
| `procedureBody` | `tests/access/scope-wiring-employee-recognition-commitments.test.ts` | **no comment stripping**; hardcoded builder list; literal 2-space indent |
| `extractProcedure` | `tests/perf/s2-no-loop.test.ts` | brace-matched **raw** source, so a brace in a string or comment desyncs it |

## I filed this as cleanup. Mutation says one of them was a live hole.

`procedureBody` did not strip comments, so **prose satisfied a gate**. Replacing the real hard-pin in `myRecognitions` with a comment naming it, and an attacker-controlled value in its place:

```diff
-        toUserId: ctx.user.id,
+        // hard-pinned recipient: toUserId: ctx.user.id
+        toUserId: input.someAttackerControlledId,
```

| extractor | result |
| --- | --- |
| `procedureBody` (no stripping) | regex satisfied by the **comment** → **PASSES**, green and wrong |
| `blockAt` (comment-stripped) | **RED** |

That assertion is not decorative: it is the guard that keeps the employee's own-recognition read hard-pinned to `ctx.user.id` rather than the enumerable `listRecognitions({ toUserId })` filter an employee could point at another user's id. So the prose hole sat on a real IDOR guard.

This is the **sixth** time this repo has been bitten by a source scan matching prose.

## The other two are cleanup, as filed

- `endpointBody`'s `return ''` is fail-open by construction, but **not currently exploitable** — all three call sites pair the negative assertion with a positive one, and a positive assertion over `''` fails loudly. It is one negative-only `it` away from being a silent false pass. `blockAt` throws instead. (I overstated this as "a live defect" on #147 earlier and posted a correction; restating it accurately here.)
- `extractProcedure` is replaced by an equal-or-**wider** region, which makes its negative assertions stricter rather than weaker, and `blockAt` preserves template literals so the `$queryRaw` SQL extraction still works.

## Not in this PR

#166 also lists the plan docs under `docs/` that still contain copy-pasteable examples of the banned idiom (`docs/plans/2026-06-11-…:241,248`, `…-06-12-…:690`, `docs/superpowers/plans/2026-07-29-…:1426-1479`). Left open deliberately — annotating historical plan docs is a separate judgement call from changing live test code, and I would rather it be decided than bundled. #166 stays open for it.

## Verification

`npx vitest run` from the repo root: **297 files / 2815 tests, exit 0** — unchanged from `main`, since this removes helpers and rewires call sites without adding tests. So `/gate` check 3's anchor needs no bump. Both `tsc --noEmit` clean. Prettier clean.

**Tier that actually ran: 3.** Tier 1 (Codex, check 15) exit 2 — quota-blocked until 2026-08-15, ninth consecutive failure. Tier 2 (OmniRoute) exit 2 — `OMNIROUTE_MODEL` unset. NOT cross-model.
