### PR TITLE
fix(db): declare the 8 actionable undeclared foreign keys (#118)

### DIFF
--- a/packages/db/prisma/schema/candidate.prisma
+++ b/packages/db/prisma/schema/candidate.prisma
@@ -32,6 +32,7 @@ model Candidate {
   interviews             Interview[]     @relation("CandidateInterviews")
   offers                 Offer[]         @relation("CandidateOffers")
 
+  hirePredictions HirePrediction[]
   @@unique([organizationId, email])
   @@index([organizationId])
   @@index([organizationId, poolType])

--- a/packages/db/prisma/schema/hire-prediction.prisma
+++ b/packages/db/prisma/schema/hire-prediction.prisma
@@ -31,6 +31,24 @@ model HirePrediction {
   createdAt  DateTime @default(now())   @map("created_at")
   updatedAt  DateTime @updatedAt        @map("updated_at")
 
+  // Relations declared to MATCH PRODUCTION, which already carries all seven FKs —
+  // created by 20260713120000_add_hire_predictions/migration.sql:35-48 and never
+  // reconciled back into this model. Until now the model declared the scalar ids and
+  // ZERO @relation blocks, so `prisma db push` / `migrate dev` would DROP all seven,
+  // silently removing referential integrity from the table holding hiring decisions
+  // (#118, #115 drift class 1). No production DDL: prod is correct; this agrees with it.
+  //
+  // onDelete mirrors prod EXACTLY — read from pg_constraint, not inferred: SetNull on
+  // the two nullable columns, Cascade on the five required ones. onUpdate is Cascade
+  // throughout, which is Prisma's default for a required relation, so it stays implicit.
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User         @relation("HirePredictionSubject", fields: [userId], references: [id], onDelete: Cascade)
+  candidate    Candidate    @relation(fields: [candidateId], references: [id], onDelete: Cascade)
+  vacancy      Vacancy      @relation(fields: [vacancyId], references: [id], onDelete: Cascade)
+  offer        Offer        @relation(fields: [offerId], references: [id], onDelete: Cascade)
+  application  Application? @relation(fields: [applicationId], references: [id], onDelete: SetNull)
+  hiredBy      User?        @relation("HirePredictionHiredBy", fields: [hiredById], references: [id], onDelete: SetNull)
+
   @@index([organizationId])
   @@index([userId])
   @@index([candidateId])

--- a/packages/db/prisma/schema/offer.prisma
+++ b/packages/db/prisma/schema/offer.prisma
@@ -29,6 +29,7 @@ model Offer {
   validations PreemploymentValidation[]
   legalChecks LegalCheck[]
 
+  hirePrediction HirePrediction?
   @@index([organizationId])
   @@index([candidateId])
   @@index([vacancyId])

--- a/packages/db/prisma/schema/organization.prisma
+++ b/packages/db/prisma/schema/organization.prisma
@@ -50,6 +50,7 @@ model Organization {
   // back-relation to a deleted model is a hard P1012. Read it via the C# API.
   vacancies              Vacancy[]
   roleFamilyWeightProfiles RoleFamilyWeightProfile[]
+  hirePredictions          HirePrediction[]
   subscription           Subscription?
   invoices               Invoice[]
   billingProfile         BillingProfile?

--- a/packages/db/prisma/schema/pipeline.prisma
+++ b/packages/db/prisma/schema/pipeline.prisma
@@ -50,6 +50,7 @@ model Application {
   interviews     Interview[]     @relation("ApplicationInterviews")
   offers         Offer[]         @relation("ApplicationOffers")
 
+  hirePredictions HirePrediction[]
   @@unique([candidateId, vacancyId])
   @@index([organizationId])
   @@index([organizationId, status])

--- a/packages/db/prisma/schema/user.prisma
+++ b/packages/db/prisma/schema/user.prisma
@@ -133,6 +133,8 @@ model User {
   // still exist in the database; they are declared in
   // services/Tims.Platform/db/flip-ddl/evaluation360.sql, not here.
 
+  hirePredictions      HirePrediction[] @relation("HirePredictionSubject")
+  hirePredictionsHired HirePrediction[] @relation("HirePredictionHiredBy")
   @@unique([organizationId, email])
   @@index([organizationId])
   @@index([supabaseUserId])

--- a/packages/db/prisma/schema/vacancy.prisma
+++ b/packages/db/prisma/schema/vacancy.prisma
@@ -41,6 +41,7 @@ model Vacancy {
   fitScores             FitScore[]             @relation("VacancyFitScores")
   offers                Offer[]                @relation("VacancyOffers")
   referrals             Referral[]
+  hirePredictions       HirePrediction[]
 
   @@index([organizationId])
   @@index([organizationId, status])
@@ -80,7 +81,11 @@ model RoleFamilyWeightProfile {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  // onUpdate: NoAction is NOT a style choice — it matches production. Prisma's default
+  // for a required relation is Cascade, but 20260710140000_add_fit_engine_schema/
+  // migration.sql:26 omitted ON UPDATE, so Postgres applied its own default (NO ACTION).
+  // Verified against pg_constraint: confupdtype = 'a' here, 'c' on every sibling FK.
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([organizationId, name])
   @@index([organizationId])


### PR DESCRIPTION
Addresses #118. **8 of its 11 FKs** — the other 3 are no longer actionable, see below.

## The risk

`hire_predictions` declared seven scalar id fields and **zero** `@relation` blocks. `prisma db push` / `migrate dev` would therefore **DROP all seven FKs**, silently removing referential integrity from the table holding hiring decisions.

**No production DDL.** Prod already carries these constraints; this makes the datamodel agree with it.

## onDelete read from prod, not inferred

Verified against `pg_constraint` directly rather than guessed from the migration:

| column | onUpdate | onDelete |
| --- | --- | --- |
| `organization_id` | Cascade | Cascade |
| `user_id` | Cascade | Cascade |
| `candidate_id` | Cascade | Cascade |
| `vacancy_id` | Cascade | Cascade |
| `offer_id` | Cascade | Cascade |
| `application_id` | Cascade | **SetNull** |
| `hired_by_id` | Cascade | **SetNull** |

The two `SetNull`s are exactly the two nullable columns. `onUpdate: Cascade` is Prisma's default for a required relation, so it stays implicit.

## The eighth: an onUpdate that silently disagreed

`role_family_weight_profiles.organization_id` already declared its relation, but not `onUpdate`. Prod is `confupdtype = 'a'` (NO ACTION) because `20260710140000_add_fit_engine_schema/migration.sql:26` omitted `ON UPDATE` and Postgres applied its own default — while Prisma's default for a required relation is `Cascade`. Now explicit as `onUpdate: NoAction`. It is the only FK among these with `'a'`; every sibling is `'c'`.

## Why 8, not 11 — the issue is stale

`rater_assignments`, `rater_responses` and `review_cycles` have **no Prisma model at all**. They were ownership-flipped to EF in **#67 on 2026-08-06**, and their models were deleted along with three `User` back-relations. #118 was written against #115 (2026-08-03), *before* that flip.

You cannot add an `@relation` to a model that does not exist, and those three FKs are now EF's to hold. Their `prisma db push` exposure is the separate, already-documented flipped-table hazard (CLAUDE.md: `db push` omits flipped tables entirely), handled by `services/Tims.Platform/db/flip-ddl/evaluation360.sql`.

## On `prisma format`

I ran it once and reverted it. It reformatted **21 schema files — 357 insertions / 329 deletions** — by realigning column widths across 15 files this change never touches, which would have buried 30 lines of real change in unreviewable churn. Back-relations are placed by hand instead. The diff is **7 files, +30/−1, entirely additive**.

## Verification

- `npx prisma validate` — valid. `npx prisma generate` — clean.
- Both `tsc --noEmit` clean (missing back-relations are the usual breakage here; all six referenced models got theirs, with the two `User` relations disambiguated by name).
- `npx vitest run` from the repo root: **298 files / 2817 tests, exit 0** — unchanged, as expected for a datamodel-only change.

**AC not run:** `prisma migrate diff --from-url "$DIRECT_URL"` needs working local DB credentials, which are P1000-broken here. I verified the stronger equivalent instead — the declared relations were compared field-by-field against prod's live `pg_constraint` catalogue, which is the thing `migrate diff` would itself be reading. Worth someone re-running that AC once credentials work.

`/gate` check 16 (schema drift) is unaffected: no DB change and no baseline change.

**Tier that actually ran: 3.** Tier 1 (Codex, check 15) exit 2 — quota-blocked to 2026-08-15. Tier 2 (OmniRoute) exit 2 — `OMNIROUTE_MODEL` unset. NOT cross-model.
