### PR TITLE
fix(db): adopt nine_box_evaluations.updated_at into the datamodel (#120)

### DIFF
--- a/packages/db/prisma/schema/ninebox.prisma
+++ b/packages/db/prisma/schema/ninebox.prisma
@@ -10,6 +10,24 @@ model NineBoxEvaluation {
   axisBreakdown    Json     @map("axis_breakdown")
   evaluatedAt      DateTime @default(now()) @map("evaluated_at")
   createdAt        DateTime @default(now()) @map("created_at")
+  // ADOPTED, not introduced (#120, #115 §3a). This column exists in production and has
+  // ZERO PROVENANCE: nothing in the repo creates it, and it appears in none of the three
+  // migration-history tables — not `packages/db/prisma/migrations/**`, not
+  // `supabase_migrations.schema_migrations` (all 5 rows' SQL inspected), not
+  // `__EFMigrationsHistory`. The tell is the default: `created_at` above defaults to
+  // CURRENT_TIMESTAMP (what Prisma emits for `@default(now())`) while this one defaults to
+  // `now()` — different tools wrote them. Most probable origin is the Supabase dashboard
+  // TABLE EDITOR, which (unlike its SQL editor) records no migration row at all, i.e. a
+  // write path invisible to every provenance audit. That is the evidence base for #115's
+  // detection-over-provenance design, so it is preserved here rather than in a commit
+  // message alone.
+  //
+  // ADOPTED rather than dropped because: the table stays PRISMA-owned (flip #70 kept
+  // NineBoxEvaluation deliberately — see the note below), the column is NOT NULL DEFAULT
+  // now() so it is already populated on every insert, and prod holds 5 rows of which ZERO
+  // have ever been updated — so `@updatedAt` changes no existing behaviour. Dropping would
+  // have required prod DDL plus a baseline re-capture for no gain.
+  updatedAt        DateTime @updatedAt      @map("updated_at")
 
   user User @relation("NineBoxUser", fields: [userId], references: [id])
 

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/NineBox/NineBoxReadFixture.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/NineBox/NineBoxReadFixture.cs
@@ -146,7 +146,9 @@ public sealed class NineBoxReadFixture : IAsyncLifetime
             id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid NOT NULL, period text NOT NULL,
             potential_score double precision NOT NULL, performance_score double precision NOT NULL,
             quadrant text NOT NULL, confidence double precision NOT NULL, axis_breakdown jsonb NOT NULL,
-            evaluated_at timestamp(3) NOT NULL, created_at timestamp(3) NOT NULL);
+            evaluated_at timestamp(3) NOT NULL, created_at timestamp(3) NOT NULL,
+            -- adopted 2026-08-09 (#120): prod carries this NOT NULL DEFAULT now(); the fixture omitted it
+            updated_at timestamp(3) NOT NULL DEFAULT now());
         CREATE TABLE calibration_sessions (
             id uuid PRIMARY KEY, organization_id uuid NOT NULL, period text NOT NULL, status text NOT NULL,
             scheduled_at timestamp(3) NULL, completed_at timestamp(3) NULL, created_by_id uuid NOT NULL,

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/Succession/SuccessionReadFixture.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/Succession/SuccessionReadFixture.cs
@@ -160,7 +160,9 @@ public sealed class SuccessionReadFixture : IAsyncLifetime
         CREATE TABLE nine_box_evaluations (
             id uuid PRIMARY KEY, organization_id uuid NOT NULL, user_id uuid NOT NULL, quadrant text NOT NULL,
             potential_score double precision NOT NULL, performance_score double precision NOT NULL,
-            evaluated_at timestamp(3) NOT NULL, created_at timestamp(3) NOT NULL);
+            evaluated_at timestamp(3) NOT NULL, created_at timestamp(3) NOT NULL,
+            -- adopted 2026-08-09 (#120): prod carries this NOT NULL DEFAULT now(); the fixture omitted it
+            updated_at timestamp(3) NOT NULL DEFAULT now());
         CREATE TABLE data_access_logs (
             id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
             organization_id uuid NOT NULL, actor_id uuid NOT NULL, data_type text NOT NULL, record_id uuid NOT NULL,


### PR DESCRIPTION
Closes #120. Decision: **adopt**.

Also closes the `nine_box_evaluations` half of #122's part 1 — the two C# fixtures that hand-write this table omitted the column and so tested against a schema production does not have.

## Why adopt, on three facts #120 didn't state

#120 said *"adopting is probably right"* without the evidence that settles it:

1. **The table stays Prisma-owned.** Flip #70 deleted `CalibrationSession` / `CalibrationMember` / `CalibrationVote` from this very file and **deliberately kept** `NineBoxEvaluation` — the ledger says so explicitly: *"nine_box_evaluations is NOT flipping and stays Prisma-owned."* So the datamodel is the right home, and this is **not** the flipped-table trap that made 3 of #118's 11 FKs unactionable.
2. **The column is `NOT NULL DEFAULT now()`** — already populated on every insert.
3. **Prod has 5 rows and zero have ever been updated** (`updated_at IS DISTINCT FROM created_at` on none of them). So `@updatedAt` changes no live behaviour; it just makes Prisma maintain the column correctly from here.

Dropping would have required prod DDL, a baseline re-capture, and regenerating every `flip-ddl/*.sql` — for a column that costs nothing.

## The provenance finding is preserved in the schema file, not just here

This column has **zero provenance**: nothing in the repo creates it, and it appears in none of the three migration-history tables. The tell is the default — `created_at` is `CURRENT_TIMESTAMP` (what Prisma emits for `@default(now())`) while this one is `now()`. **Different tools wrote them.**

Most probable origin is the Supabase dashboard **table editor**, which — unlike its SQL editor — records no migration row at all. That is a write path invisible to *every* provenance audit, and it is the single strongest piece of evidence for #115's detection-over-provenance design. It belongs where someone will actually read it, so it is a comment on the field rather than only a commit message.

## No DDL, no baseline change

Prod already has the column, and `packages/db/baseline/prod-public-schema.sql:1706` already records it (`timestamp(3) DEFAULT now() NOT NULL`). This PR only makes the datamodel agree with both, so `/gate` check 16 is unaffected and no re-capture is needed.

## Verification

- `npx prisma validate` — valid; `npx prisma generate` — clean.
- Both `tsc --noEmit` clean.
- `npx vitest run` from the repo root: **298 files / 2817 tests, exit 0** — unchanged, as expected.
- Placed by hand, **not** via `prisma format` — that reformats 21 schema files by realigning column widths (see #170). Diff is 3 files, +24/−2.

**Tier that actually ran: 3.** Tier 1 (Codex, check 15) exit 2 — quota-blocked to 2026-08-15. Tier 2 (OmniRoute) exit 2 — `OMNIROUTE_MODEL` unset. NOT cross-model.
