### PR TITLE
feat(security): write authz_denied for every C# 401/403 (#173, half 1 of 2)

### DIFF
--- a/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
@@ -1,0 +1,102 @@
+using System.Text.Json.Nodes;
+using Tims.Api.Http;
+using Tims.Application.Audit;
+using Tims.Domain.Identity;
+
+namespace Tims.Api.Authentication;
+
+/// <summary>
+/// Writes an <c>authz_denied</c> security event for every 401/403 the platform service returns —
+/// the C# port of TS <c>withSecurityAudit</c> + <c>observeDenial</c>
+/// (<c>packages/api/src/trpc.ts</c>, <c>packages/api/src/access/security-audit.ts</c>).
+///
+/// WHY (#173). `withSecurityAudit` is the OUTERMOST middleware on every tRPC procedure, so a
+/// denial anywhere below it lands an <c>authz_denied</c> row with actor, IP and UA. The C# gates
+/// returned bare status codes and wrote nothing. Since several domains' read flags are already live
+/// in production, that is not a latent gap: denials on those surfaces are ALREADY invisible to the
+/// access-review/attestation surface that consumes these events. A low-privilege caller
+/// enumerating endpoints leaves no trace beyond Serilog request lines, which carry no principal.
+///
+/// SHAPE — one middleware, not twelve gate edits. Every *StaffGate returns
+/// <c>Results.StatusCode(401|403)</c> rather than throwing, so there is no exception to observe;
+/// the response STATUS is the only signal that generalises across all 36 files that can deny. This
+/// also means a gate added tomorrow is covered without being told to opt in — the same
+/// derived-not-listed reasoning the TS middleware relies on.
+///
+/// PARITY with observeDenial, rule for rule:
+///   • 401 and 403 only.
+///   • RESOLVE-OR-SKIP on the org: no resolved principal ⇒ no row. An unauthenticated 401 has no
+///     tenant to attribute to, and `audit_logs.organization_id` is a real FK.
+///   • Actor is the REAL operator under impersonation (<see cref="AuditActor"/>).
+///   • Fail-soft: the writer swallows its own failures by contract, and this never rethrows —
+///     a lost audit row must not turn a 403 into a 500.
+///
+/// DELIBERATE DIVERGENCE: TS records <c>entity: `trpc:${path}`</c>. There is no procedure path
+/// here, so this records <c>platform:{METHOD} {route}</c> using the matched ROUTE PATTERN, not the
+/// raw URL — so an id in the path cannot smuggle unbounded caller-controlled text into the entity
+/// column, and rows aggregate per endpoint rather than per resource.
+/// </summary>
+public sealed class SecurityDenialAuditMiddleware(RequestDelegate next)
+{
+    private readonly RequestDelegate _next = next;
+
+    /// <summary>Mirrors observeDenial's MFA carve-out: those are audited distinctly, not as generic denials.</summary>
+    internal const string MfaStepUpHeader = "x-tims-mfa-required";
+
+    public async Task InvokeAsync(HttpContext context, ISecurityEventWriter securityEventWriter)
+    {
+        await _next(context).ConfigureAwait(false);
+
+        try
+        {
+            var status = context.Response.StatusCode;
+            if (status is not (StatusCodes.Status401Unauthorized or StatusCodes.Status403Forbidden))
+            {
+                return;
+            }
+
+            // CB-2a parity: an MFA step-up denial is audited distinctly by the enforcement path and
+            // must not ALSO appear as a generic authz_denied.
+            if (context.Response.Headers.ContainsKey(MfaStepUpHeader))
+            {
+                return;
+            }
+
+            if (context.Items[ResolvedPrincipal.HttpContextKey] is not ResolvedPrincipal
+                { Context: { } tenant })
+            {
+                return; // resolve-or-skip: unauthenticated/unresolved has no org to attribute to
+            }
+
+            if (!Guid.TryParse(tenant.OrganizationId, out var organizationId))
+            {
+                return; // org-less platform owner ("") — no FK to write against
+            }
+
+            _ = Guid.TryParse(AuditActor.ActorFor(tenant), out var actorId);
+
+            var route = context.GetEndpoint() is Microsoft.AspNetCore.Routing.RouteEndpoint routeEndpoint
+                ? $"/{routeEndpoint.RoutePattern.RawText?.TrimStart('/')}"
+                : context.Request.Path.Value ?? "/";
+
+            await securityEventWriter.WriteAsync(
+                new SecurityEvent(
+                    organizationId,
+                    actorId == Guid.Empty ? null : actorId,
+                    Action: "authz_denied",
+                    Entity: $"platform:{context.Request.Method} {route}",
+                    EntityId: null,
+                    Metadata: new JsonObject { ["code"] = status == StatusCodes.Status401Unauthorized ? "UNAUTHORIZED" : "FORBIDDEN" },
+                    IpAddress: context.ClientIpFor(),
+                    UserAgent: NullIfEmpty(context.Request.Headers.UserAgent.ToString())),
+                context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Fail-soft, exactly like TS's `safe()` wrapper: an audit-write problem must never
+            // change the response the caller already received.
+        }
+    }
+
+    private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
+}

--- a/services/Tims.Platform/src/Tims.Api/Program.cs
+++ b/services/Tims.Platform/src/Tims.Api/Program.cs
@@ -755,6 +755,13 @@ try
     // `sub` — matching the TS `ctx.user.id` surface, and the authz probes reuse it (dedupe).
     app.UseMiddleware<PrincipalResolutionMiddleware>();
 
+    // #173 — authz_denied observer, the port of TS's OUTERMOST `withSecurityAudit`. Registered
+    // immediately AFTER principal resolution and BEFORE everything that can deny, so on the way
+    // back out it sees both the resolved tenant (to attribute the row) and the final 401/403 from
+    // any gate below — including the rate limiter's own rejections and every *StaffGate. It writes
+    // nothing on success and never alters the response.
+    app.UseMiddleware<SecurityDenialAuditMiddleware>();
+
     // Rate limiting runs AFTER principal resolution (so the resolved TIMS principal is available to
     // key the bucket) but BEFORE authorization/handlers. Infra + auth-probe paths are exempt inside
     // the middleware; the API-key per-key quota is enforced by ApiKeyRateLimitFilter post-auth.

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/MonitoringReadFixture.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/MonitoringReadFixture.cs
@@ -190,6 +190,24 @@ public sealed class MonitoringReadFixture : IAsyncLifetime
         CREATE TABLE survey_responses (
             id uuid PRIMARY KEY, organization_id uuid NOT NULL, survey_id uuid NOT NULL, user_id uuid NULL,
             answers jsonb NOT NULL, submitted_at timestamp(3) NOT NULL);
+
+        -- #173: `audit_logs`, so SecurityDenialAuditMiddleware's authz_denied write can be asserted
+        -- end-to-end through the REAL pipeline (a 403 from MonitoringStaffGate must land a row).
+        -- FKs point at this fixture's real `organizations`/`users` — more faithful than the isolated
+        -- AuditWriterFixture's `users_audit` stand-in, and it means a bad actor_id fails loudly here.
+        CREATE TABLE audit_logs (
+            id uuid PRIMARY KEY,
+            organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+            user_id uuid NULL REFERENCES users (id) ON DELETE SET NULL,
+            actor_id uuid NULL REFERENCES users (id) ON DELETE SET NULL,
+            action text NOT NULL,
+            entity text NOT NULL,
+            entity_id text NULL,
+            changes jsonb NULL,
+            metadata jsonb NULL,
+            ip_address text NULL,
+            user_agent text NULL,
+            created_at timestamp NOT NULL DEFAULT now());
         """;
 
     private const string RlsSql =

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
@@ -1,0 +1,224 @@
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Npgsql;
+
+namespace Tims.IntegrationTests.Monitoring;
+
+/// <summary>
+/// #173 — proof that <c>SecurityDenialAuditMiddleware</c> actually writes, through the REAL pipeline.
+///
+/// The gap it closes: TS runs <c>withSecurityAudit</c> OUTERMOST on every procedure, so a denial
+/// lands an <c>authz_denied</c> row with actor, IP and UA. Every C# gate returned a bare status code
+/// and wrote nothing — and since several domains' read flags are ALREADY LIVE in production, denials
+/// on those surfaces were already invisible to the access-review surface that consumes these events.
+///
+/// This drives real HTTP against real Postgres and asserts on the row, rather than unit-testing the
+/// middleware over a fake: the whole defect was that a component existed and was never invoked, which
+/// is exactly the class a unit test cannot catch. It reuses the monitoring fixture because that
+/// fixture already produces all three outcomes the middleware discriminates — a 403 from
+/// <c>MonitoringStaffGate</c> (resolvable staff without the grant), a 401 (unknown sub), and a 200.
+/// </summary>
+[Collection("MonitoringRead")]
+public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
+{
+    private const string Issuer = "https://test-project.supabase.co/auth/v1";
+    private const string Audience = "authenticated";
+    private const string ExecutiveKpis = "/monitoring/executive-kpis";
+
+    private static readonly RSA SigningRsa = RSA.Create(2048);
+    private static readonly RsaSecurityKey PrivateKey = new(SigningRsa) { KeyId = "denial-audit-test-key" };
+
+    private readonly MonitoringReadFixture _fixture = fixture;
+
+    private WebApplicationFactory<Program> EnabledFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Platform:DatabaseConnectionString", _fixture.ConnectionString);
+            builder.UseSetting("Platform:MonitoringReadEnabled", "true");
+            builder.UseSetting("Platform:SupabaseJwtIssuer", Issuer);
+            builder.UseSetting("Platform:SupabaseJwtAudience", Audience);
+
+            var publicJwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(
+                new RsaSecurityKey(SigningRsa.ExportParameters(false)) { KeyId = PrivateKey.KeyId });
+            builder.ConfigureTestServices(services =>
+                services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+                {
+                    options.RequireHttpsMetadata = false;
+                    options.TokenValidationParameters.IssuerSigningKeys = [publicJwk];
+                }));
+        });
+
+    private static string Mint(string sub) =>
+        new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = Audience,
+            Subject = new ClaimsIdentity([new Claim("sub", sub)]),
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(PrivateKey, SecurityAlgorithms.RsaSha256),
+        });
+
+    private static async Task<HttpResponseMessage> Get(HttpClient client, string path, string? token, string? xff = null, string? realIp = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        if (token is not null)
+        {
+            request.Headers.Add("Authorization", $"Bearer {token}");
+        }
+
+        if (xff is not null)
+        {
+            request.Headers.Add("x-forwarded-for", xff);
+        }
+
+        if (realIp is not null)
+        {
+            request.Headers.Add("x-real-ip", realIp);
+        }
+
+        return await client.SendAsync(request);
+    }
+
+    private sealed record DenialRow(Guid OrganizationId, Guid? ActorId, string Entity, string? Metadata, string? IpAddress, string? UserAgent);
+
+    private async Task<IReadOnlyList<DenialRow>> DenialRowsAsync()
+    {
+        var rows = new List<DenialRow>();
+        await using var connection = new NpgsqlConnection(_fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT organization_id, actor_id, entity, metadata::text, ip_address, user_agent " +
+            "FROM audit_logs WHERE action = 'authz_denied' ORDER BY created_at";
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add(new DenialRow(
+                reader.GetGuid(0),
+                await reader.IsDBNullAsync(1) ? null : reader.GetGuid(1),
+                reader.GetString(2),
+                await reader.IsDBNullAsync(3) ? null : reader.GetString(3),
+                await reader.IsDBNullAsync(4) ? null : reader.GetString(4),
+                await reader.IsDBNullAsync(5) ? null : reader.GetString(5)));
+        }
+
+        return rows;
+    }
+
+    private async Task ClearDenialsAsync()
+    {
+        await using var connection = new NpgsqlConnection(_fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM audit_logs WHERE action = 'authz_denied'";
+        await command.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task A_403_from_the_staff_gate_writes_an_authz_denied_row()
+    {
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        // NoGrant is resolvable staff in OrgA WITHOUT monitoring:read — MonitoringStaffGate 403s.
+        var response = await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub),
+            xff: "1.2.3.4, 10.0.0.9");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        var rows = await DenialRowsAsync();
+        var row = Assert.Single(rows);
+        Assert.Equal(MonitoringReadFixture.OrgA, row.OrganizationId);
+        Assert.Equal(MonitoringReadFixture.NoGrantId, row.ActorId);
+        Assert.Contains("FORBIDDEN", row.Metadata);
+        // The ROUTE PATTERN, not the raw URL — so a path id cannot smuggle caller-controlled text in.
+        Assert.Equal("platform:GET /monitoring/executive-kpis", row.Entity);
+        // #174's derivation: the LAST xff hop, never the attacker-chosen first.
+        Assert.Equal("10.0.0.9", row.IpAddress);
+    }
+
+    [Fact]
+    public async Task The_audit_ip_prefers_the_platform_edge_header()
+    {
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub),
+            xff: "1.2.3.4", realIp: "10.0.0.9");
+
+        var row = Assert.Single(await DenialRowsAsync());
+        Assert.Equal("10.0.0.9", row.IpAddress);
+    }
+
+    [Fact]
+    public async Task A_200_writes_no_denial_row()
+    {
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.OrgReaderSub));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(await DenialRowsAsync());
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_401_writes_nothing_resolve_or_skip()
+    {
+        // Parity with observeDenial's resolve-or-SKIP: there is no tenant to attribute the row to,
+        // and audit_logs.organization_id is a real FK. Losing these is deliberate, not an oversight —
+        // an unauthenticated caller cannot be pinned to an org without inventing one.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ExecutiveKpis, token: null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Empty(await DenialRowsAsync());
+    }
+
+    [Fact]
+    public async Task A_valid_jwt_whose_sub_is_not_staff_also_writes_nothing()
+    {
+        // 401 from PrincipalResolver: authenticated at the JWT layer but resolved to no TIMS user, so
+        // again no org. Distinct path from the no-token case above, same skip.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ExecutiveKpis, Mint("sub-does-not-exist"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Empty(await DenialRowsAsync());
+    }
+
+    [Fact]
+    public async Task Repeated_probing_leaves_one_row_per_attempt()
+    {
+        // The scenario the gap made invisible: a low-privilege principal enumerating the surface.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        foreach (var path in new[] { ExecutiveKpis, "/monitoring/module-health", "/monitoring/alert-rules" })
+        {
+            await Get(client, path, Mint(MonitoringReadFixture.NoGrantSub));
+        }
+
+        var rows = await DenialRowsAsync();
+        Assert.Equal(3, rows.Count);
+        Assert.All(rows, r => Assert.Equal(MonitoringReadFixture.NoGrantId, r.ActorId));
+        Assert.Contains(rows, r => r.Entity.EndsWith("/monitoring/module-health", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Refs #173 — **closes the first of its two halves.** The MFA half is deliberately not in here; see the bottom.

## The gap

TS runs `withSecurityAudit` **outermost** on every procedure, so a denial anywhere below it lands an `authz_denied` row with actor, IP and UA. Every C# gate returned a bare status code and wrote nothing.

**This was not latent.** Several domains' read flags are already live in production, so denials on those surfaces have already been invisible to the access-review/attestation surface that consumes these events. A low-privilege principal enumerating endpoints left no trace beyond Serilog request lines, which carry no principal.

## One middleware, not twelve gate edits

Every `*StaffGate` **returns** `Results.StatusCode(401|403)` rather than throwing — so there is no exception to observe. The response **status** is the only signal that generalises across all 36 files that can deny. A gate added tomorrow is therefore covered without being told to opt in, which is the same derived-not-listed reasoning the TS middleware relies on.

Registered immediately after `PrincipalResolutionMiddleware` and before everything that can deny, so on the way back out it sees both the resolved tenant (to attribute the row) and the final status.

**Parity with `observeDenial`, rule for rule:** 401/403 only · **resolve-or-skip** on the org (an unauthenticated 401 has no tenant, and `organization_id` is a real FK) · actor is the **real** operator under impersonation · MFA denials carved out · fail-soft throughout, so a lost audit row can never turn a 403 into a 500.

**One deliberate divergence.** TS records `entity: trpc:${path}`. There is no procedure path here, so this records `platform:{METHOD} {route}` from the **matched route pattern**, not the raw URL — a path id can't smuggle unbounded caller-controlled text into the entity column, and rows aggregate per endpoint rather than per resource.

## Tested through the real pipeline, not over a fake

The entire defect was that *a component existed and was never invoked* — precisely what a unit test cannot catch. So these drive real HTTP against real Postgres:

- a 403 from `MonitoringStaffGate` writes exactly **one** row, with the right org, actor, entity and IP
- a 200 writes **none**
- both 401 paths (no token; valid JWT whose `sub` isn't staff) **skip**
- repeated probing leaves **one row per attempt** — the scenario the gap made invisible

`audit_logs` added to the monitoring fixture with FKs to its **real** `organizations`/`users`, so a wrong `actor_id` fails loudly rather than silently inserting.

**Mutation-proved:** unregistering the middleware fails **3 of the 6** — precisely the three asserting rows appear, while the three asserting absence still pass. That asymmetry is the point.

The IP uses #174's derivation, asserted here too: the **last** `x-forwarded-for` hop, and `x-real-ip` preferred over it.

## What this does NOT do — #173 stays open

The issue's **MFA step-up half is untouched**. No C# endpoint enforces it, so with `MFA_ENFORCED=true` a privileged `aal1` token still gets 200 from the platform service where tRPC would 403. That needs the JWT `aal` claim, a discriminable 403 body so the web client's existing `redirectToMfaIfRequired` can fire (today C# 403s carry no body, so it never can), and its own tests. Separate change — please don't let the issue auto-close on this.

## Verification

- `pnpm --filter @tims/api exec tsc --noEmit` / `cd apps/web && npx tsc --noEmit` — clean
- `npx vitest run` — **306 files / 2940 tests**
- `dotnet test tests/Tims.UnitTests` — **812 passed**
- `dotnet test tests/Tims.IntegrationTests` — **1088 passed**, the full suite rather than a filter, since a global middleware touches every endpoint

**Cross-model verification did NOT run** — check 15 exit 2 (Codex quota-blocked to 2026-08-15; tier 2 refuses with `OMNIROUTE_MODEL` unset). No tier-3 panel either. Given this adds a global middleware on a security path, a panel would be the right call before merge if you want one — say the word and I'll run it.
