### PR TITLE
fix(security): audit API-key denials, and stop callers dropping their own rows (#180, #181)

### DIFF
--- a/services/Tims.Platform/src/Tims.Api/Authentication/MfaStepUpMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Authentication/MfaStepUpMiddleware.cs
@@ -89,7 +89,13 @@ public sealed class MfaStepUpMiddleware(RequestDelegate next)
                         Metadata: new JsonObject { ["currentLevel"] = context.User.FindFirstValue("aal") },
                         IpAddress: context.ClientIpFor(),
                         UserAgent: NullIfEmpty(context.Request.Headers.UserAgent.ToString())),
-                    context.RequestAborted).ConfigureAwait(false);
+                    // #181: CancellationToken.None, NOT context.RequestAborted. The write happens AFTER the
+                    // response has gone back to the caller, so binding it to the request's token let a client
+                    // that closed the socket cancel its own audit row — and SecurityEventWriter's fail-soft
+                    // catch swallowed the cancellation silently. A prober that disconnects on each 403 could
+                    // therefore enumerate the surface leaving no trace, which is the exact behaviour this row
+                    // exists to make visible. TS is fire-and-forget and bound to no signal; this matches it.
+                    CancellationToken.None).ConfigureAwait(false);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
@@ -62,18 +62,50 @@ public sealed class SecurityDenialAuditMiddleware(RequestDelegate next)
                 return;
             }
 
-            if (context.Items[ResolvedPrincipal.HttpContextKey] is not ResolvedPrincipal
-                { Context: { } tenant })
-            {
-                return; // resolve-or-skip: unauthenticated/unresolved has no org to attribute to
-            }
+            var code = status == StatusCodes.Status401Unauthorized ? "UNAUTHORIZED" : "FORBIDDEN";
+            Guid organizationId;
+            Guid? actor;
+            JsonObject metadata;
 
-            if (!Guid.TryParse(tenant.OrganizationId, out var organizationId))
+            if (context.Items[ResolvedPrincipal.HttpContextKey] is ResolvedPrincipal { Context: { } tenant })
             {
-                return; // org-less platform owner ("") — no FK to write against
-            }
+                if (!Guid.TryParse(tenant.OrganizationId, out organizationId))
+                {
+                    return; // org-less platform owner ("") — no FK to write against
+                }
 
-            _ = Guid.TryParse(AuditActor.ActorFor(tenant), out var actorId);
+                _ = Guid.TryParse(AuditActor.ActorFor(tenant), out var actorId);
+                actor = actorId == Guid.Empty ? null : actorId;
+                metadata = new JsonObject { ["code"] = code };
+            }
+            else if (TryApiKeyAttribution(context, out organizationId, out var apiKeyId))
+            {
+                // #180 — the API-KEY surface. PrincipalResolutionMiddleware stashes a ResolvedPrincipal
+                // only for a JWT `sub`, and ApiKeyAuthenticationHandler issues org_id/api_key_id/scope and
+                // never a `sub`. So without this branch EVERY denial on /external/* wrote nothing at all,
+                // while #177 claimed coverage of "every 401/403". TS closes the same hole with a second
+                // observer (`observeExternalDenial`); doing it here instead means an API-key endpoint added
+                // later is covered without being told to opt in — the derived-not-listed reasoning the rest
+                // of this middleware already relies on.
+                //
+                // actor is NULL by construction: the principal is a KEY, not a person. Inventing a sentinel
+                // user id would make a machine denial indistinguishable from a human one in review, and
+                // `api_key_id` is not a `users.id` so it would also break the FK.
+                actor = null;
+                metadata = new JsonObject
+                {
+                    ["code"] = code,
+                    ["principal"] = "api_key",
+                    ["apiKeyId"] = apiKeyId,
+                };
+            }
+            else
+            {
+                // Resolve-or-skip. An unauthenticated 401 has no tenant to attribute to, and
+                // `audit_logs.organization_id` is a real FK — auditing it would also hand any anonymous
+                // caller an unbounded writer into an append-only table. TS draws the same line.
+                return;
+            }
 
             var route = context.GetEndpoint() is Microsoft.AspNetCore.Routing.RouteEndpoint routeEndpoint
                 ? $"/{routeEndpoint.RoutePattern.RawText?.TrimStart('/')}"
@@ -82,20 +114,47 @@ public sealed class SecurityDenialAuditMiddleware(RequestDelegate next)
             await securityEventWriter.WriteAsync(
                 new SecurityEvent(
                     organizationId,
-                    actorId == Guid.Empty ? null : actorId,
+                    actor,
                     Action: "authz_denied",
                     Entity: $"platform:{context.Request.Method} {route}",
                     EntityId: null,
-                    Metadata: new JsonObject { ["code"] = status == StatusCodes.Status401Unauthorized ? "UNAUTHORIZED" : "FORBIDDEN" },
+                    Metadata: metadata,
                     IpAddress: context.ClientIpFor(),
                     UserAgent: NullIfEmpty(context.Request.Headers.UserAgent.ToString())),
-                context.RequestAborted).ConfigureAwait(false);
+                // #181: CancellationToken.None, NOT context.RequestAborted. The write happens AFTER the
+                // response has gone back to the caller, so binding it to the request's token let a client
+                // that closed the socket cancel its own audit row — and SecurityEventWriter's fail-soft
+                // catch swallowed the cancellation silently. A prober that disconnects on each 403 could
+                // therefore enumerate the surface leaving no trace, which is the exact behaviour this row
+                // exists to make visible. TS is fire-and-forget and bound to no signal; this matches it.
+                CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Fail-soft, exactly like TS's `safe()` wrapper: an audit-write problem must never
             // change the response the caller already received.
         }
+    }
+
+    /// <summary>
+    /// Attribute a denial to the API-KEY principal (#180), from the claims
+    /// <see cref="ApiKeyAuthenticationHandler"/> issued.
+    ///
+    /// <para>Reading <c>context.User</c> works here — and only here — because this middleware does its
+    /// work on the way OUT, after <c>UseAuthorization()</c> has run the endpoint's
+    /// <c>.RequireAuthorization(ApiKey)</c> policy and swapped the authenticated principal onto the
+    /// context. On the way IN the ApiKey scheme has not run at all (JwtBearer is the default), which is
+    /// exactly why the inbound <c>PrincipalResolutionMiddleware</c> never sees these requests.</para>
+    ///
+    /// <para>Returns false for an invalid/revoked/expired key: authentication itself failed, so there are
+    /// no claims and no authenticated org — that 401 stays unaudited, deliberately.</para>
+    /// </summary>
+    private static bool TryApiKeyAttribution(HttpContext context, out Guid organizationId, out string? apiKeyId)
+    {
+        organizationId = Guid.Empty;
+        apiKeyId = context.User.FindFirst(ApiKeyAuthenticationHandler.ApiKeyIdClaimType)?.Value;
+        var org = context.User.FindFirst(ApiKeyAuthenticationHandler.OrganizationIdClaimType)?.Value;
+        return org is not null && Guid.TryParse(org, out organizationId);
     }
 
     private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;

--- a/services/Tims.Platform/src/Tims.Api/Program.cs
+++ b/services/Tims.Platform/src/Tims.Api/Program.cs
@@ -774,16 +774,22 @@ try
     // nothing on success and never alters the response.
     app.UseMiddleware<SecurityDenialAuditMiddleware>();
 
-    // #173 — MFA step-up, the port of TS's `withMfaEnforcement`. Registered AFTER the denial
-    // observer so that observer sees this 403 and correctly SKIPS it: an MFA refusal is audited
-    // distinctly as `mfa_step_up_required`, never as a generic `authz_denied` (observeDenial's
-    // same carve-out). Fails OPEN on an unset/garbled Platform:MfaEnforced.
-    app.UseMiddleware<MfaStepUpMiddleware>();
-
     // Rate limiting runs AFTER principal resolution (so the resolved TIMS principal is available to
     // key the bucket) but BEFORE authorization/handlers. Infra + auth-probe paths are exempt inside
     // the middleware; the API-key per-key quota is enforced by ApiKeyRateLimitFilter post-auth.
     app.UseMiddleware<RateLimitMiddleware>();
+
+    // #173 — MFA step-up, the port of TS's `withMfaEnforcement`. Registered AFTER the denial
+    // observer so that observer sees this 403 and correctly SKIPS it: an MFA refusal is audited
+    // distinctly as `mfa_step_up_required`, never as a generic `authz_denied` (observeDenial's
+    // same carve-out). Fails OPEN on an unset/garbled Platform:MfaEnforced.
+    //
+    // #181 — moved to AFTER the rate limiter. It short-circuits on refusal, so registering it first
+    // meant a refused caller never reached the limiter at all: a stolen aal1 super_admin token — the
+    // exact thing this gate exists to neutralise — became an unmetered amplifier, one audit_logs
+    // INSERT plus a principal-resolution DB read per request, at whatever rate the caller chose.
+    // Still inside SecurityDenialAuditMiddleware, so the carve-out above is unaffected.
+    app.UseMiddleware<MfaStepUpMiddleware>();
 
     app.UseAuthorization();
 

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalAssessmentFixture.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalAssessmentFixture.cs
@@ -62,6 +62,11 @@ public sealed class ExternalAssessmentFixture : IAsyncLifetime
     public const string ExpiredToken = "tims_ext_read_expired_00000000000000000000000000000006";
     public const string SuspendedOrgToken = "tims_ext_read_suspended_org_00000000000000000000000007";
 
+    // #180: the denial-audit rows record which KEY was denied, so revocation has a target when an
+    // org holds several. Exposed here rather than re-typed in the test — a literal could drift from
+    // the seed silently, and the assertion would then pass against the wrong key.
+    public static readonly Guid ScopeExcludesKeyId = Guid.Parse("ca000000-0000-0000-0000-000000000003");
+
     private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine")
         .WithUsername(LoginRole)
         .WithPassword(Password)
@@ -259,6 +264,24 @@ public sealed class ExternalAssessmentFixture : IAsyncLifetime
             revoked_at timestamptz NULL,
             expires_at timestamptz NULL
         );
+        -- #180: SecurityEventWriter's target. Without this table the writer's fail-SOFT catch swallows
+        -- every insert and a denial-audit test passes while writing nothing — the exact blindness that
+        -- let the API-key gap ship unnoticed. No users FK on actor_id/user_id: this fixture has no
+        -- `users` table, and an API-key denial is attributed with a NULL actor by design (the principal
+        -- is a key, not a person), so there is nothing to point at.
+        CREATE TABLE audit_logs (
+            id uuid PRIMARY KEY,
+            organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+            user_id uuid NULL,
+            actor_id uuid NULL,
+            action text NOT NULL,
+            entity text NOT NULL,
+            entity_id text NULL,
+            changes jsonb NULL,
+            metadata jsonb NULL,
+            ip_address text NULL,
+            user_agent text NULL,
+            created_at timestamp NOT NULL DEFAULT now());
         """;
 
     // OrgA active + `external`→assessment:read@organization; OrgB active but NO grant; a suspended org.

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalDenialAuditTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalDenialAuditTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Npgsql;
+
+namespace Tims.IntegrationTests.ExternalVendor;
+
+/// <summary>
+/// #180 — denial auditing on the EXTERNAL (API-key) surface.
+///
+/// <para>#177 shipped <c>SecurityDenialAuditMiddleware</c> under the claim that it writes an
+/// <c>authz_denied</c> row for "every C# 401/403". It does not: the middleware attributes rows from
+/// <c>ResolvedPrincipal</c>, which <c>PrincipalResolutionMiddleware</c> stashes ONLY when the JWT carries
+/// a <c>sub</c> claim. <c>ApiKeyAuthenticationHandler</c> issues <c>org_id</c>, <c>api_key_id</c> and
+/// <c>scope</c> — never a <c>sub</c> — so every denial on <c>/external/*</c> wrote nothing at all.</para>
+///
+/// <para>TS covers exactly this case with a SECOND observer, <c>observeExternalDenial</c>
+/// (packages/api/src/access/security-audit.ts), whose own doc comment explains why it is separate: the
+/// key's org comes from the key, not from <c>ctx.user</c>. That control was never ported. This suite
+/// pins the C# equivalent, implemented as a fallback inside the one existing middleware rather than a
+/// second observer, so an API-key endpoint added later is covered without opting in.</para>
+///
+/// <para><b>What is NOT claimed:</b> a 401 from an invalid/revoked/expired key stays unaudited. That is
+/// not an oversight — such a request has no authenticated org to attribute a row to, and
+/// <c>audit_logs.organization_id</c> is a real FK. TS has the same boundary.</para>
+/// </summary>
+[Collection("ExternalAssessment")]
+public sealed class ExternalDenialAuditTests(ExternalAssessmentFixture fixture)
+{
+    private const string ListPath = "/external/assessment-results";
+
+    private WebApplicationFactory<Program> Factory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Platform:DatabaseConnectionString", fixture.ConnectionString);
+            builder.UseSetting("Platform:ExternalVendorReadEnabled", "true");
+        });
+
+    private static async Task<HttpResponseMessage> Get(HttpClient client, string path, string? token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        if (token is not null)
+        {
+            request.Headers.Add("Authorization", $"Bearer {token}");
+        }
+
+        request.Headers.Add("x-real-ip", "203.0.113.42");
+        request.Headers.UserAgent.ParseAdd("vendor-integration/2.1");
+        return await client.SendAsync(request);
+    }
+
+    private async Task<List<(Guid Org, Guid? Actor, string Action, string Entity, string? Metadata, string? Ip, string? Ua)>>
+        ReadAuditAsync()
+    {
+        var rows = new List<(Guid, Guid?, string, string, string?, string?, string?)>();
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT organization_id, actor_id, action, entity, metadata::text, ip_address, user_agent " +
+            "FROM audit_logs ORDER BY created_at";
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((
+                reader.GetGuid(0),
+                reader.IsDBNull(1) ? null : reader.GetGuid(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                reader.IsDBNull(5) ? null : reader.GetString(5),
+                reader.IsDBNull(6) ? null : reader.GetString(6)));
+        }
+
+        return rows;
+    }
+
+    private async Task ClearAuditAsync()
+    {
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM audit_logs";
+        await command.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task A_scope_denial_on_the_api_key_surface_writes_an_authz_denied_row()
+    {
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ListPath, ExternalAssessmentFixture.ScopeExcludesToken);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        var row = Assert.Single(await ReadAuditAsync());
+        Assert.Equal("authz_denied", row.Action);
+        Assert.Equal(ExternalAssessmentFixture.OrgA, row.Org);
+        Assert.Null(row.Actor); // the principal is a KEY, not a person — never a fabricated user id
+        Assert.Contains("api_key", row.Metadata!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_grant_denial_on_the_api_key_surface_writes_an_authz_denied_row()
+    {
+        // A different denial path (the org's `external` role lacks the grant) through the same gate.
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ListPath, ExternalAssessmentFixture.NoGrantOrgToken);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        var row = Assert.Single(await ReadAuditAsync());
+        Assert.Equal("authz_denied", row.Action);
+        Assert.Equal(ExternalAssessmentFixture.OrgB, row.Org);
+    }
+
+    [Fact]
+    public async Task The_row_carries_the_api_key_id_so_a_leaked_key_can_be_identified()
+    {
+        // Without this the row says "someone with a key from OrgA was denied" — useless for revocation
+        // when an org holds several keys. TS records apiKeyId for exactly this reason.
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        await Get(client, ListPath, ExternalAssessmentFixture.ScopeExcludesToken);
+
+        var row = Assert.Single(await ReadAuditAsync());
+        Assert.Contains(ExternalAssessmentFixture.ScopeExcludesKeyId.ToString(), row.Metadata!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_row_carries_the_request_ip_and_user_agent()
+    {
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        await Get(client, ListPath, ExternalAssessmentFixture.ScopeExcludesToken);
+
+        var row = Assert.Single(await ReadAuditAsync());
+        Assert.Equal("203.0.113.42", row.Ip);
+        Assert.Equal("vendor-integration/2.1", row.Ua);
+    }
+
+    [Fact]
+    public async Task The_entity_is_the_route_PATTERN_not_the_raw_url()
+    {
+        // Same discipline as the staff path: an id in the URL must not smuggle unbounded caller-controlled
+        // text into the entity column, and rows must aggregate per endpoint rather than per resource.
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        await Get(client, $"/external/assessment-results/{ExternalAssessmentFixture.AssignmentA1}",
+            ExternalAssessmentFixture.ScopeExcludesToken);
+
+        var row = Assert.Single(await ReadAuditAsync());
+        Assert.DoesNotContain(ExternalAssessmentFixture.AssignmentA1.ToString(), row.Entity, StringComparison.Ordinal);
+        Assert.Contains("{", row.Entity, StringComparison.Ordinal); // the route parameter, unexpanded
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_401_writes_nothing_and_that_is_deliberate()
+    {
+        // A missing/garbage key has no authenticated org, and organization_id is a real FK. Auditing it
+        // would also hand any anonymous caller an unbounded writer into an append-only table. TS draws the
+        // same line. Asserted so the boundary is a decision on the record, not an accident.
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ListPath, "tims_not_a_real_key");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        Assert.Empty(await ReadAuditAsync());
+    }
+
+    [Fact]
+    public async Task A_SUCCESSFUL_request_writes_no_denial_row()
+    {
+        await ClearAuditAsync();
+        using var factory = Factory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ListPath, ExternalAssessmentFixture.ValidEmptyScopeToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.DoesNotContain(await ReadAuditAsync(), r => r.Action == "authz_denied");
+    }
+}


### PR DESCRIPTION
Closes #180. Partially addresses #181.

#177 shipped `SecurityDenialAuditMiddleware` under the claim that it writes an `authz_denied` row for **every** C# 401/403. It missed the entire external API-key surface — and that surface's read flag is **live in production today**, so this was not a latent gap.

## Why it missed

The middleware attributes rows from `ResolvedPrincipal`, which `PrincipalResolutionMiddleware` stashes **only when a JWT carries a `sub`**. `ApiKeyAuthenticationHandler` issues `org_id`, `api_key_id` and `scope` — never a `sub`. So every 403 out of `ExternalAssessmentEndpoints` and `ExternalValidationEndpoints` wrote nothing at all.

TS closes exactly this with a **second observer**, `observeExternalDenial`, whose own doc comment explains why it must be separate: the key's org comes from the key, not from `ctx.user`. That control was never ported.

## The fix, and why it is a fallback rather than a second observer

Implemented inside the **one** existing middleware, so an API-key endpoint added later is covered without being told to opt in — the same derived-not-listed reasoning the rest of that middleware already relies on.

Reading `context.User` works here, and only here, because the middleware does its work on the way **out**, after `UseAuthorization()` has run the endpoint's `.RequireAuthorization(ApiKey)` policy and swapped the authenticated principal onto the context. On the way *in*, the ApiKey scheme has not run at all (JwtBearer is the default) — which is precisely why the inbound principal resolver never sees these requests.

The row carries `principal: api_key` and the `apiKeyId`, matching TS. **Actor is NULL by construction**: the principal is a key, not a person, and `api_key_id` is not a `users.id`, so a sentinel would also break the FK.

### What is deliberately still not audited

An invalid / revoked / expired key writes nothing. Authentication itself failed, so there is no authenticated org, and `organization_id` is a real FK — auditing it would also hand any anonymous caller an unbounded writer into an append-only table. TS draws the same line. This is now **asserted**, so the boundary is a decision on the record rather than an accident.

## Two #181 one-liners folded in

1. **Both audit writes move off `context.RequestAborted` to `CancellationToken.None`.** The write happens *after* the response is returned, so binding it to the request token let a client that closed the socket cancel its own audit row — swallowed silently by the writer's fail-soft catch. A prober disconnecting on each 403 could enumerate the surface leaving no trace, which is exactly what the row exists to make visible. (The 403 **body** write correctly keeps `RequestAborted` — that one *is* the response.)
2. **`MfaStepUpMiddleware` moves to after `RateLimitMiddleware`.** It short-circuits on refusal, so registering it first meant a refused caller never reached the limiter: a stolen `aal1` super_admin token — the thing the gate exists to neutralise — was an unmetered amplifier. It still sits inside the denial observer, so the `mfa_step_up_required` carve-out is unaffected.

Pipeline order is now: principal → denial-audit → rate limit → MFA → authorization.

## A fixture bug worth naming

The external fixture had **no `audit_logs` table**, so `SecurityEventWriter`'s fail-soft catch would have swallowed every insert and any test here would have passed while writing nothing — the same blindness that let this gap ship in the first place. Added.

## Verification

**Cross-model verification did NOT run** — `/gate` check 15 has exited 2 for the 13th consecutive time (Codex quota-blocked to 2026-08-15; tier 2 correctly refuses with `OMNIROUTE_MODEL` unset). Tier-3 same-model review only. Do not record this as cross-model-verified.

- `npx vitest run` — 3001 passing / 309 files
- `Tims.UnitTests` — 874 passing
- `Tims.IntegrationTests` — **1132 passing** (+7 new)
- `tsc --noEmit` clean on `@tims/api` and `@tims/web`; gitleaks clean

**Red-then-green, proven honestly.** Disabling *only* the new attribution branch — with the `audit_logs` table present — turns exactly the **5** attribution tests red and leaves the two boundary tests green. An earlier "6 of 7 red" reading was confounded by the missing table; that is not the number to quote, and I am recording the correction rather than the flattering figure.

## Still open on #181

The spoofable `x-real-ip` (App Runner has no proxy stripping it), the missing index on `audit_logs.action`, the absent consumer for these rows, and the missing kill switch on both global middlewares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)