### PR TITLE
fix(security): stop trusting the caller's x-real-ip, and index audit_logs.action (#181)

### DIFF
--- a/packages/db/prisma/migrations/20260810000000_audit_logs_action_index/migration.sql
+++ b/packages/db/prisma/migrations/20260810000000_audit_logs_action_index/migration.sql
@@ -1,0 +1,30 @@
+-- #181 — index audit_logs.action.
+--
+-- WHY. #177 made the platform service write an `authz_denied` row on every staff 401/403, and #180
+-- extended that to the API-key surface. Both are queried BY ACTION (an access-review / attestation
+-- read, and every incident triage of "who was denied what"). `audit_logs` had indexes on
+-- organization_id, (organization_id, entity), (organization_id, user_id), actor_id and created_at —
+-- nothing on `action`. So the one query those rows exist to serve was a sequential scan over an
+-- append-only table that can never be pruned (the ENABLE ALWAYS trigger blocks DELETE/UPDATE/TRUNCATE
+-- and retention automation is still open). That gets worse monotonically, forever.
+--
+-- SHAPE. (organization_id, action) mirrors the existing (organization_id, entity) index: every
+-- tenant-facing read of this table is org-scoped first, so a bare `action` index would be the wrong
+-- leading column for them. `created_at` is deliberately NOT a third column here — the existing
+-- created_at index already serves time-ordering, and a three-column index would be the widest write
+-- amplification on a table that is now written on EVERY denial.
+--
+-- SAFETY. CREATE INDEX CONCURRENTLY so the write path is never blocked: this table takes an INSERT on
+-- every 401/403 across the whole service, and a plain CREATE INDEX would hold a lock against all of
+-- them for the duration of the build. CONCURRENTLY cannot run inside a transaction block, so this file
+-- must be applied on its own (psql runs each statement autocommit by default — do NOT wrap it in BEGIN).
+-- IF NOT EXISTS makes it re-runnable.
+--
+-- If this is interrupted, Postgres can leave an INVALID index behind. Check and drop before retrying:
+--   SELECT i.indisvalid FROM pg_index i
+--     JOIN pg_class c ON c.oid = i.indexrelid
+--    WHERE c.relname = 'audit_logs_organization_id_action_idx';
+--   -- if false:  DROP INDEX CONCURRENTLY audit_logs_organization_id_action_idx;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "audit_logs_organization_id_action_idx"
+  ON "audit_logs" ("organization_id", "action");

--- a/packages/db/prisma/schema/system.prisma
+++ b/packages/db/prisma/schema/system.prisma
@@ -34,6 +34,11 @@ model AuditLog {
 
   @@index([organizationId])
   @@index([organizationId, entity])
+  // #181: authz_denied / mfa_step_up_required rows are read BY ACTION (access review, incident
+  // triage). Mirrors the (organizationId, entity) shape — org is the leading column because every
+  // tenant-facing read of this table is org-scoped. Applied to prod by
+  // migrations/20260810000000_audit_logs_action_index (CONCURRENTLY).
+  @@index([organizationId, action])
   @@index([organizationId, userId])
   @@index([actorId])
   @@index([createdAt])

--- a/services/Tims.Platform/src/Tims.Api/Configuration/PlatformOptions.cs
+++ b/services/Tims.Platform/src/Tims.Api/Configuration/PlatformOptions.cs
@@ -465,4 +465,21 @@ public sealed class PlatformOptions
     /// hops would mean a leak at either end grants both.
     /// </summary>
     public string? AlertMetricsCronSecret { get; init; }
+
+    /// <summary>
+    /// #181: may the inbound <c>x-real-ip</c> header be trusted as the client address? DEFAULT (unset) is
+    /// NO — <see cref="Tims.Api.Http.TrustedProxyHeaderMiddleware"/> strips it, and
+    /// <see cref="Tims.Domain.Http.ClientIp"/> falls through to the last <c>X-Forwarded-For</c> hop, the
+    /// entry an appending proxy controls.
+    ///
+    /// This service runs on App Runner with no ALB or CloudFront in front, and App Runner does not set or
+    /// strip <c>x-real-ip</c> — so trusting it made the forensic IP on every audit row caller-chosen, and
+    /// let a caller rotate the anonymous rate-limit key. Set this to the exact string "true" ONLY if an
+    /// edge that genuinely writes AND overwrites the header is placed in front of the service.
+    ///
+    /// A STRING, not a bool, for the same reason as <see cref="MfaEnforced"/>: the configuration layer
+    /// must not be able to coerce "1"/"yes"/"TRUE" into widening a trust decision. Note the polarity is
+    /// the opposite of MfaEnforced — a garbled value here fails to the SAFE (stripping) side.
+    /// </summary>
+    public string? TrustXRealIpHeader { get; init; }
 }

--- a/services/Tims.Platform/src/Tims.Api/Http/TrustedProxyHeaderMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Http/TrustedProxyHeaderMiddleware.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Options;
+using Tims.Api.Configuration;
+
+namespace Tims.Api.Http;
+
+/// <summary>
+/// Strips the client-controlled <c>x-real-ip</c> header at the very front of the pipeline, so nothing
+/// downstream can mistake a caller-supplied value for one written by a trusted edge (#181).
+///
+/// <para><b>The problem.</b> <see cref="Tims.Domain.Http.ClientIp"/> prefers <c>x-real-ip</c> over the
+/// last <c>x-forwarded-for</c> hop, documented as "written by the platform edge, not spoofable". On
+/// Vercel that holds — Vercel sets it. On THIS service it does not: the platform API is deployed to AWS
+/// App Runner (deploy/terraform/main.tf) and is reached directly, with no ALB, no CloudFront and no
+/// <c>UseForwardedHeaders</c> anywhere in the pipeline. App Runner populates <c>X-Forwarded-For</c>; it
+/// neither sets nor strips <c>x-real-ip</c>. So any caller could send <c>x-real-ip: 10.0.0.9</c> and have
+/// it recorded verbatim as the forensic address on every <c>audit_logs</c> row — and, through
+/// <see cref="Tims.Domain.RateLimiting.RateLimitIdentity"/>, rotate it to evade the anonymous quota.</para>
+///
+/// <para><b>Why the fix is here and not in <c>ClientIp</c>.</b> That derivation is a SHARED kernel, pinned
+/// byte-for-byte to the TS implementation by <c>contracts/client-ip-fixtures/cases.json</c> (#174). The
+/// rule is not wrong — it is correct for a deployment whose edge sets the header, which is exactly the TS
+/// side. What differs is the TRUST ENVIRONMENT, not the algorithm. Changing the kernel would diverge the
+/// two stacks to fix a deployment fact, so instead this removes the untrusted input before the kernel
+/// ever sees it. The goldens stay green and both stacks keep one rule.</para>
+///
+/// <para><b>This is not expected to change behaviour for real traffic.</b> App Runner sends no
+/// <c>x-real-ip</c>, so legitimate requests already fall through to the last <c>X-Forwarded-For</c> hop —
+/// the entry an appending proxy controls. All this removes is the attacker's lever.</para>
+///
+/// <para><b>Polarity note.</b> Unlike <c>Platform:MfaEnforced</c>, which fails OPEN so a garbled value can
+/// never lock operators out, this flag fails to the STRIPPING side: anything other than the exact string
+/// "true" means do not trust the header. The safe default for "is this input authentic?" is no. Set
+/// <see cref="PlatformOptions.TrustXRealIpHeader"/> to "true" only if a trusted edge that genuinely writes
+/// (and overwrites) <c>x-real-ip</c> is ever placed in front of this service.</para>
+/// </summary>
+public sealed class TrustedProxyHeaderMiddleware(RequestDelegate next)
+{
+    public const string XRealIpHeader = "x-real-ip";
+
+    private readonly RequestDelegate _next = next;
+
+    public Task InvokeAsync(HttpContext context, IOptions<PlatformOptions> platformOptions)
+    {
+        if (!IsTrusted(platformOptions.Value.TrustXRealIpHeader))
+        {
+            // Remove, do not overwrite. Leaving an empty value would still be a non-null header that a
+            // future reader might treat as meaningful; ClientIp's own null/empty handling then falls
+            // through to the X-Forwarded-For branch exactly as if the caller had never sent it.
+            context.Request.Headers.Remove(XRealIpHeader);
+        }
+
+        return _next(context);
+    }
+
+    /// <summary>Exact "true" only — see the polarity note on the class.</summary>
+    public static bool IsTrusted(string? flag) => string.Equals(flag, "true", StringComparison.Ordinal);
+}

--- a/services/Tims.Platform/src/Tims.Api/Program.cs
+++ b/services/Tims.Platform/src/Tims.Api/Program.cs
@@ -20,6 +20,7 @@ using Tims.Api.Billing;
 using Tims.Api.Compensation;
 using Tims.Api.Configuration;
 using Tims.Api.HealthChecks;
+using Tims.Api.Http;
 using Tims.Api.RateLimiting;
 using Tims.Api.Evaluation360;
 using Tims.Api.ExternalVendor;
@@ -755,8 +756,16 @@ try
 
     var app = builder.Build();
 
-    // CORS runs FIRST — an unauthenticated preflight (OPTIONS) is answered by this
-    // middleware before it can reach authentication or the fail-closed rate limiter.
+    // #181 — strip the client-controlled `x-real-ip` before ANYTHING can read it. This is deliberately
+    // the first middleware in the pipeline: both consumers of the trusted-IP rule (the rate limiter's
+    // anonymous key and every audit writer) read the raw header, so the untrusted value has to be gone
+    // before either runs. App Runner does not set or strip this header, so on this deployment it was
+    // caller-supplied. See TrustedProxyHeaderMiddleware for why the fix is here and not in the shared
+    // ClientIp kernel, which is pinned cross-stack.
+    app.UseMiddleware<TrustedProxyHeaderMiddleware>();
+
+    // CORS runs FIRST among the request-handling middlewares — an unauthenticated preflight (OPTIONS) is
+    // answered by this middleware before it can reach authentication or the fail-closed rate limiter.
     app.UseCors(BrowserCorsPolicyName);
 
     app.UseAuthentication();

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalDenialAuditTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/ExternalVendor/ExternalDenialAuditTests.cs
@@ -43,7 +43,10 @@ public sealed class ExternalDenialAuditTests(ExternalAssessmentFixture fixture)
             request.Headers.Add("Authorization", $"Bearer {token}");
         }
 
-        request.Headers.Add("x-real-ip", "203.0.113.42");
+        // #181: `x-real-ip` is stripped as untrusted on this deployment, so the address must come from
+        // the LAST X-Forwarded-For hop — the entry an appending proxy writes. The leading hop is the
+        // caller-controlled one and must never be picked.
+        request.Headers.Add("x-forwarded-for", "198.51.100.1, 203.0.113.42");
         request.Headers.UserAgent.ParseAdd("vendor-integration/2.1");
         return await client.SendAsync(request);
     }

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
@@ -37,11 +37,15 @@ public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
 
     private readonly MonitoringReadFixture _fixture = fixture;
 
-    private WebApplicationFactory<Program> EnabledFactory() =>
+    private WebApplicationFactory<Program> EnabledFactory(bool trustXRealIp = false) =>
         new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.UseSetting("Platform:DatabaseConnectionString", _fixture.ConnectionString);
             builder.UseSetting("Platform:MonitoringReadEnabled", "true");
+            if (trustXRealIp)
+            {
+                builder.UseSetting("Platform:TrustXRealIpHeader", "true");
+            }
             builder.UseSetting("Platform:SupabaseJwtIssuer", Issuer);
             builder.UseSetting("Platform:SupabaseJwtAudience", Audience);
 
@@ -141,22 +145,48 @@ public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
         Assert.Contains("FORBIDDEN", row.Metadata);
         // The ROUTE PATTERN, not the raw URL — so a path id cannot smuggle caller-controlled text in.
         Assert.Equal("platform:GET /monitoring/executive-kpis", row.Entity);
-        // #174's derivation: the LAST xff hop, never the attacker-chosen first.
+        // #174's derivation: the LAST xff hop, never the attacker-chosen first. (#181: `x-real-ip` is
+        // stripped by default on this deployment, so XFF is the only surviving source.)
         Assert.Equal("10.0.0.9", row.IpAddress);
     }
 
     [Fact]
-    public async Task The_audit_ip_prefers_the_platform_edge_header()
+    public async Task A_client_supplied_x_real_ip_is_IGNORED_by_default()
     {
+        // #181. This test previously asserted the OPPOSITE — that a caller-supplied `x-real-ip` becomes
+        // the audit row's address — under the name `The_audit_ip_prefers_the_platform_edge_header`. That
+        // name encoded an assumption from the TS deployment (Vercel does set the header) which is FALSE
+        // for this service: it runs on App Runner with no ALB/CloudFront, and App Runner neither sets nor
+        // strips `x-real-ip`. So the "platform edge header" was in fact the client, and the one forensic
+        // field a §21 obligation produces was attacker-chosen. TrustedProxyHeaderMiddleware now strips it
+        // and the derivation falls through to the last XFF hop, which an appending proxy controls.
         await ClearDenialsAsync();
         await using var factory = EnabledFactory();
         using var client = factory.CreateClient();
 
         await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub),
-            xff: "1.2.3.4", realIp: "10.0.0.9");
+            xff: "1.2.3.4, 10.0.0.9", realIp: "203.0.113.66");
 
         var row = Assert.Single(await DenialRowsAsync());
-        Assert.Equal("10.0.0.9", row.IpAddress);
+        Assert.Equal("10.0.0.9", row.IpAddress);          // last XFF hop
+        Assert.NotEqual("203.0.113.66", row.IpAddress);   // the spoofed value never lands
+    }
+
+    [Fact]
+    public async Task An_explicitly_TRUSTED_x_real_ip_is_honoured()
+    {
+        // The escape hatch, so putting a real edge in front later does not require a code change. Pinned
+        // so the flag is proven to do something — an inert opt-in would be worse than none, since the
+        // operator would believe the header is being honoured when it is silently dropped.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory(trustXRealIp: true);
+        using var client = factory.CreateClient();
+
+        await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub),
+            xff: "1.2.3.4, 10.0.0.9", realIp: "203.0.113.66");
+
+        var row = Assert.Single(await DenialRowsAsync());
+        Assert.Equal("203.0.113.66", row.IpAddress);
     }
 
     [Fact]


### PR DESCRIPTION
Two more #181 items, both concerning the rows #177/#180 made this service write on every denial.

## 1. The audit IP was attacker-chosen

`ClientIp` prefers `x-real-ip` over the last XFF hop, documented as *"written by the platform edge, not spoofable"*. That holds on Vercel, which sets it. It is **false for this service**: the platform API runs on **App Runner**, reached directly, with no ALB, no CloudFront and no `UseForwardedHeaders` anywhere in the pipeline. App Runner populates `X-Forwarded-For`; it neither sets nor strips `x-real-ip`.

So any caller could send `x-real-ip: 10.0.0.9` and have it stored verbatim as the forensic address on every `audit_logs` row — and, through `RateLimitIdentity`, rotate it to evade the anonymous quota.

**Two existing tests asserted exactly that as expected behaviour**, one named `The_audit_ip_prefers_the_platform_edge_header`. The name encoded the assumption; the "platform edge" was the client. Both rewritten.

### The fix is deliberately *not* in `ClientIp`

That derivation is a shared kernel, pinned byte-for-byte to TS by `contracts/client-ip-fixtures/cases.json` (#174), and the rule is **correct** for a deployment whose edge sets the header. What differs is the *trust environment*, not the algorithm — changing the kernel would diverge the two stacks to fix a deployment fact. `TrustedProxyHeaderMiddleware` instead removes the untrusted input before the kernel sees it, registered as the **first** middleware because both consumers (the limiter's anonymous key, every audit writer) read the raw header.

**No behaviour change for real traffic.** App Runner sends no `x-real-ip`, so legitimate requests already fall through to the last XFF hop. This removes only the lever.

`Platform:TrustXRealIpHeader` is the escape hatch if a real edge is ever placed in front — exact `"true"` only. Note the polarity is the **opposite** of `MfaEnforced`: a garbled value here fails to the *stripping* side, because the safe default for "is this input authentic?" is no.

## 2. `audit_logs` had no index on `action`

Existing indexes: `organization_id`, `(organization_id, entity)`, `(organization_id, user_id)`, `actor_id`, `created_at`. Nothing on `action` — so the one query these rows exist to serve (access review; incident triage of "who was denied what") was a **sequential scan over an append-only table that can never be pruned**. The `ENABLE ALWAYS` trigger blocks DELETE/UPDATE/TRUNCATE and retention automation is still open, so it degrades monotonically, forever.

Adds `(organization_id, action)`, mirroring the existing `(organization_id, entity)`: every tenant-facing read of this table is org-scoped, so a bare `action` index would have the wrong leading column. `created_at` is deliberately *not* a third column — the existing `created_at` index serves ordering, and this table now takes an INSERT on every denial, so write amplification is a real cost.

The migration uses `CREATE INDEX CONCURRENTLY` (a plain `CREATE INDEX` would lock out every denial write for the duration) and therefore **must be applied on its own, outside a transaction block**. Per DDL governance, **applying to prod is Federico's** — this PR only prepares the reviewed SQL and the Prisma model. The file documents the INVALID-index recovery path if it is interrupted.

## Verification

**Cross-model verification did NOT run** — `/gate` check 15 exit 2 for the 13th consecutive time (Codex quota-blocked to 2026-08-15; tier 2 correctly refuses with `OMNIROUTE_MODEL` unset). Tier-3 same-model review only. Do not record this as cross-model-verified.

- `npx vitest run` — 3001 passing / 309 files
- `Tims.UnitTests` — 874 passing
- `Tims.IntegrationTests` — **1133 passing** (+1)
- `tsc --noEmit` clean on `@tims/api` and `@tims/web`; `prisma validate` clean; gitleaks clean

**2 mutations** watched go red on the intended assertion, green control either side: the strip removed (the spoofed value lands again), and the flag loosened to `!= "false"`.

One note on diff hygiene: `prisma format` reformatted 21 unrelated schema files (337/329 lines). That churn was backed out — this PR touches `system.prisma` only.

## Still open on #181

No consumer reads `authz_denied` rows anywhere in the repo, and neither global middleware has a kill switch. Both are design questions rather than fixes, so I left them on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)