### PR TITLE
fix(security): kill switch for the denial auditor, and stop paying for it on every request (#181)

### DIFF
--- a/services/Tims.Platform/src/Tims.Api/Authentication/MfaStepUpMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Authentication/MfaStepUpMiddleware.cs
@@ -40,10 +40,15 @@ public sealed class MfaStepUpMiddleware(RequestDelegate next)
 {
     private readonly RequestDelegate _next = next;
 
+    /// <remarks>
+    /// #181: the writer is resolved lazily (see SecurityDenialAuditMiddleware's note). This middleware
+    /// early-returns for the overwhelming majority of requests — the flag is off, or the principal is not
+    /// staff — and constructing a scoped AuditLogDbContext per request to reach that return was pure cost.
+    /// <c>IOptions</c> stays a parameter: it is a singleton, so resolving it is free.
+    /// </remarks>
     public async Task InvokeAsync(
         HttpContext context,
-        IOptions<PlatformOptions> platformOptions,
-        ISecurityEventWriter securityEventWriter)
+        IOptions<PlatformOptions> platformOptions)
     {
         // STAFF only. `Candidate` is a portal session with no staff row, and `ExternalApiKey` has no
         // Supabase session and therefore no `aal` at all — TS gates on protectedProcedure, which
@@ -79,6 +84,7 @@ public sealed class MfaStepUpMiddleware(RequestDelegate next)
             if (Guid.TryParse(tenant.OrganizationId, out var organizationId))
             {
                 _ = Guid.TryParse(AuditActor.ActorFor(tenant), out var actorId);
+                var securityEventWriter = context.RequestServices.GetRequiredService<ISecurityEventWriter>();
                 await securityEventWriter.WriteAsync(
                     new SecurityEvent(
                         organizationId,

--- a/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
+++ b/services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs
@@ -43,7 +43,24 @@ public sealed class SecurityDenialAuditMiddleware(RequestDelegate next)
     /// <summary>Mirrors observeDenial's MFA carve-out: those are audited distinctly, not as generic denials.</summary>
     internal const string MfaStepUpHeader = "x-tims-mfa-required";
 
-    public async Task InvokeAsync(HttpContext context, ISecurityEventWriter securityEventWriter)
+    /// <summary>
+    /// #181 kill switch — exact "true" only. DISABLED-phrased on purpose: this middleware is already live,
+    /// so an `Enabled`-phrased flag with the house default of false would have silently switched off a
+    /// live security control on the next deploy. An absent or garbled value keeps the control ON, which is
+    /// the safe direction for an audit control (the opposite polarity to a feature flag like MfaEnforced,
+    /// which fails OPEN so it cannot lock operators out).
+    /// </summary>
+    public static bool IsDisabled(string? flag) => string.Equals(flag, "true", StringComparison.Ordinal);
+
+    /// <remarks>
+    /// #181: <c>ISecurityEventWriter</c> is resolved from <see cref="HttpContext.RequestServices"/> at the
+    /// point of use, NOT as an <c>InvokeAsync</c> parameter. <c>UseMiddleware</c> resolves those
+    /// parameters on EVERY request, and this one is scoped over a scoped <c>AuditLogDbContext</c> — so
+    /// taking it as a parameter constructed a DbContext for 100% of traffic (every 200, /health, /ready,
+    /// OpenAPI) purely to be discarded, on a service whose stated target is thousands of concurrent
+    /// users. Denials are the rare path; pay for the writer only on that path.
+    /// </remarks>
+    public async Task InvokeAsync(HttpContext context)
     {
         await _next(context).ConfigureAwait(false);
 
@@ -111,6 +128,7 @@ public sealed class SecurityDenialAuditMiddleware(RequestDelegate next)
                 ? $"/{routeEndpoint.RoutePattern.RawText?.TrimStart('/')}"
                 : context.Request.Path.Value ?? "/";
 
+            var securityEventWriter = context.RequestServices.GetRequiredService<ISecurityEventWriter>();
             await securityEventWriter.WriteAsync(
                 new SecurityEvent(
                     organizationId,

--- a/services/Tims.Platform/src/Tims.Api/Configuration/PlatformOptions.cs
+++ b/services/Tims.Platform/src/Tims.Api/Configuration/PlatformOptions.cs
@@ -482,4 +482,25 @@ public sealed class PlatformOptions
     /// the opposite of MfaEnforced — a garbled value here fails to the SAFE (stripping) side.
     /// </summary>
     public string? TrustXRealIpHeader { get; init; }
+
+    /// <summary>
+    /// #181 — the KILL SWITCH for <see cref="Tims.Api.Authentication.SecurityDenialAuditMiddleware"/>.
+    /// Exact "true" removes it from the pipeline entirely.
+    ///
+    /// <para><b>Note the polarity, and why it is not <c>…Enabled</c> like every other surface here.</b>
+    /// Those flags gate NEW surfaces that ship dark, so `Enabled = false` is the safe default. This
+    /// middleware is ALREADY LIVE in production — it went in with #177 and is unconditional. Expressing
+    /// it as `SecurityDenialAuditEnabled` with the house default of `false` would mean the next deploy
+    /// silently switched OFF a live security control, which is exactly the class of accident the flag is
+    /// meant to protect against. So it is phrased as a disable, and the absent/garbled value keeps the
+    /// control ON.</para>
+    ///
+    /// <para><b>Why a switch at all.</b> It is a global middleware on the auth path that adds a DB write
+    /// to every 401/403. The image is deployed by immutable tag with auto-deployments off, so without
+    /// this the only way to stop it misbehaving in production is a rebuild, push, tag change and
+    /// redeploy. Turning off an audit control is itself a risk, so flipping it logs a startup WARNING
+    /// rather than passing silently — an operator who forgets to flip it back should have to explain a
+    /// log line.</para>
+    /// </summary>
+    public string? SecurityDenialAuditDisabled { get; init; }
 }

--- a/services/Tims.Platform/src/Tims.Api/Program.cs
+++ b/services/Tims.Platform/src/Tims.Api/Program.cs
@@ -781,7 +781,22 @@ try
     // back out it sees both the resolved tenant (to attribute the row) and the final 401/403 from
     // any gate below — including the rate limiter's own rejections and every *StaffGate. It writes
     // nothing on success and never alters the response.
-    app.UseMiddleware<SecurityDenialAuditMiddleware>();
+    // #181 — the one kill switch. DISABLED-phrased, not Enabled-phrased: this middleware is already
+    // live, so a default-false `Enabled` flag would have silently switched off a live security control on
+    // the next deploy. Absent or garbled ⇒ the control stays ON.
+    // Resolved here rather than reusing the `externalOptions` local below — that one is declared further
+    // down, after the middleware pipeline is built.
+    var pipelineOptions = app.Services.GetRequiredService<IOptions<PlatformOptions>>().Value;
+    if (SecurityDenialAuditMiddleware.IsDisabled(pipelineOptions.SecurityDenialAuditDisabled))
+    {
+        app.Logger.LogWarning(
+            "SECURITY: Platform:SecurityDenialAuditDisabled is set — authz_denied audit rows are NOT being "
+            + "written. This is an incident-response escape hatch, not a steady state.");
+    }
+    else
+    {
+        app.UseMiddleware<SecurityDenialAuditMiddleware>();
+    }
 
     // Rate limiting runs AFTER principal resolution (so the resolved TIMS principal is available to
     // key the bucket) but BEFORE authorization/handlers. Infra + auth-probe paths are exempt inside

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/Monitoring/SecurityDenialAuditTests.cs
@@ -37,7 +37,7 @@ public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
 
     private readonly MonitoringReadFixture _fixture = fixture;
 
-    private WebApplicationFactory<Program> EnabledFactory(bool trustXRealIp = false) =>
+    private WebApplicationFactory<Program> EnabledFactory(bool trustXRealIp = false, string? auditDisabled = null) =>
         new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.UseSetting("Platform:DatabaseConnectionString", _fixture.ConnectionString);
@@ -45,6 +45,11 @@ public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
             if (trustXRealIp)
             {
                 builder.UseSetting("Platform:TrustXRealIpHeader", "true");
+            }
+
+            if (auditDisabled is not null)
+            {
+                builder.UseSetting("Platform:SecurityDenialAuditDisabled", auditDisabled);
             }
             builder.UseSetting("Platform:SupabaseJwtIssuer", Issuer);
             builder.UseSetting("Platform:SupabaseJwtAudience", Audience);
@@ -187,6 +192,42 @@ public sealed class SecurityDenialAuditTests(MonitoringReadFixture fixture)
 
         var row = Assert.Single(await DenialRowsAsync());
         Assert.Equal("203.0.113.66", row.IpAddress);
+    }
+
+    [Fact]
+    public async Task The_kill_switch_removes_the_middleware_but_leaves_the_denial_intact()
+    {
+        // #181. A global middleware on the auth path that writes to the DB on every 401/403 needs a way
+        // OFF that is not a rebuild-and-redeploy (the image ships by immutable tag, auto-deploy off).
+        // The denial itself must be untouched — this disables the OBSERVER, never the control.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory(auditDisabled: "true");
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Empty(await DenialRowsAsync());
+    }
+
+    [Theory]
+    [InlineData("false")]
+    [InlineData("TRUE")]
+    [InlineData("1")]
+    [InlineData("yes")]
+    [InlineData("")]
+    public async Task A_garbled_kill_switch_value_leaves_the_audit_ON(string flag)
+    {
+        // The polarity that matters. This flag is DISABLED-phrased precisely because the middleware is
+        // already live: anything other than the exact string "true" must keep the control running, so a
+        // typo in configuration can never silently stop a live security control from recording denials.
+        await ClearDenialsAsync();
+        await using var factory = EnabledFactory(auditDisabled: flag);
+        using var client = factory.CreateClient();
+
+        await Get(client, ExecutiveKpis, Mint(MonitoringReadFixture.NoGrantSub));
+
+        Assert.Single(await DenialRowsAsync());
     }
 
     [Fact]


### PR DESCRIPTION
The last two **mechanical** items on #181. What remains after this is a product decision, not a fix — see the end.

## 1. A kill switch, deliberately phrased as `Disabled` and not `Enabled`

`SecurityDenialAuditMiddleware` is a global middleware on the auth path that adds a DB write to every 401/403, registered **unconditionally** since #177. Every other surface in `Program.cs` ships behind a `Platform:*Enabled` flag; this one had no flag of any kind. With `image_tag_mutability = IMMUTABLE` and `auto_deployments_enabled = false`, the only way to stop it misbehaving in production was a rebuild, push, tag change and redeploy.

**The polarity is the whole point.** Copying the house `*Enabled` shape, with its default of `false`, would mean the next deploy silently switched **off a live security control** — precisely the accident a kill switch exists to prevent. So it is `Platform:SecurityDenialAuditDisabled`, exact `"true"` only, and an absent or garbled value keeps the control **on**.

That is pinned by a theory over `"false"` / `"TRUE"` / `"1"` / `"yes"` / `""`: a configuration typo must never stop a live control from recording denials. Note this is the **opposite** polarity to `MfaEnforced`, which fails *open* so it can never lock operators out — the safe direction differs by what the flag governs, and both are now explicit.

Flipping it logs a startup **WARNING** rather than passing silently. Turning off an audit control is itself a risk; an operator who forgets to flip it back should have to explain a log line.

`MfaStepUpMiddleware` deliberately gets **no** second switch: it early-returns on `MfaGate.IsEnforced`, so `Platform:MfaEnforced` already *is* its off-switch — and #179 made that settable through terraform, which is what the original finding actually turned on.

## 2. The inert path was not free

Both middlewares took `ISecurityEventWriter` as an `InvokeAsync` parameter. `UseMiddleware` resolves those **per request**, and that writer is scoped over a scoped `AuditLogDbContext` — so a DbContext was constructed for **100% of traffic** (every 200, `/health`, `/ready`, OpenAPI) purely to be discarded, on a service whose stated target is thousands of concurrent users.

Both now resolve it from `RequestServices` at the point of use. Denials are the rare path; pay for the writer only there. `IOptions` stays a parameter — it is a singleton, so resolving it is free.

## Verification

**Cross-model verification did NOT run** — `/gate` check 15 exit 2 for the 13th consecutive time (Codex quota-blocked to 2026-08-15; tier 2 correctly refuses with `OMNIROUTE_MODEL` unset). Tier-3 same-model review only. Do not record this as cross-model-verified.

- `npx vitest run` — 3001 passing / 309 files
- `Tims.UnitTests` — 874 passing
- `Tims.IntegrationTests` — **1139 passing** (+6)
- `tsc --noEmit` clean on `@tims/api` and `@tims/web`; gitleaks clean

**2 mutations** watched go red on the intended assertion, green control either side: the polarity flipped to `Enabled`-style (8 red, including every garbled-value row), and the switch ignored so the middleware registers unconditionally again.

## What is left on #181, and why I stopped

**Nothing in the repo reads `authz_denied` rows.** `grep` finds them only at the write sites. #177's premise named "the access-review/attestation surface that consumes these events" — that consumer does not exist, and `platform/system.ts` filters a fixed action list that includes neither new action.

Building it is a feature with product questions attached (who reviews, on what cadence, what the retention story is given the append-only trigger and open retention automation). I have left it on #181 rather than inventing an answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)