### PR TITLE
docs(parity): tsProcedure is OPTIONAL — correct the claim that gated flip #64's readers

### DIFF
--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -351,11 +351,18 @@ describe-service`; only the frontend Vercel flag was missing.)
   unavailable), while C# already maps both routes with the identical stub behind the identical gate
   (`EngagementReadEndpoints.cs:277,:297`) and the FE renders a static placeholder that never called
   them. **Kept, with written reasons (4):** `listSurveys` + `getRotationRisk` are the TS half of the
-  only two LIVE parity endpoints on this surface (`scripts/parity/surfaces.ts:261,:269`, where
-  `tsProcedure` is a REQUIRED field) and `listSurveys` also backs the invalidate-only FE consumer at
+  only two LIVE parity endpoints on this surface (`scripts/parity/surfaces.ts:261,:269`) and
+  `listSurveys` also backs the invalidate-only FE consumer at
   `launch-survey-modal.tsx:58`; `getSurveyResults` + `getResultsByArea` are the only TS callers of
   the golden-fixtured min-5 kernels and the only surviving relation reads into `survey_responses` —
-  all four are runbook §7b edits belonging to **flip #64**, not to this task. **Flip #68 is NOT
+  all four are runbook §7b edits belonging to **flip #64**, not to this task.
+  > **CORRECTED 2026-08-10.** This paragraph used to add "where `tsProcedure` is a REQUIRED field".
+  > It is not, and has not been since `efb7553f` (PR #144, 2026-08-06) made it
+  > `tsProcedure?: string` (`surfaces.ts:19`). An absent `tsProcedure` makes `checks/parity.ts:24-40`
+  > report `[WEAK]` with an explicit reason while the RLS and RBAC probes still run — deleting a TS
+  > procedure does NOT blind `verify engagement`. Flip #64 may therefore delete all four, provided it
+  > converts each endpoint to C#-only by omitting `tsProcedure`; deleting the ENDPOINT or SURFACE is
+  > the security-coverage regression (`surfaces.ts:8-18`), not deleting the procedure. **Flip #68 is NOT
   unblocked by this**: `action_plans` has zero TS *writers* now, but `monitoring.ts:158` still READS
   `db.actionPlan.findMany` and `access/scoped-probe.ts:79` + `entity-policies.ts:44,145` still
   register the Prisma delegate. The zero-writer invariant is pinned by

--- a/packages/api/src/routers/engagement.ts
+++ b/packages/api/src/routers/engagement.ts
@@ -32,9 +32,22 @@ import { summarizeSurveyResults, buildResultsByArea } from '@tims/shared';
 //
 //   KEPT, with reasons (4) — each is load-bearing TODAY, not inertia:
 //     listSurveys / getRotationRisk — the TS half of the only two LIVE parity endpoints left on
-//       the engagement read surface (scripts/parity/surfaces.ts:261 and :269 pin them as
-//       `tsProcedure`, a REQUIRED field — surfaces.ts:7). Deleting either turns `verify engagement`
-//       into a partial or total no-op right before the flip that most needs it. listSurveys also
+//       the engagement read surface (scripts/parity/surfaces.ts:261 and :269 register them as
+//       `tsProcedure`).
+//
+//       CORRECTED 2026-08-10: this comment used to call `tsProcedure` "a REQUIRED field —
+//       surfaces.ts:7" and conclude that deleting either procedure "turns `verify engagement` into a
+//       partial or total no-op". BOTH halves are now false. `tsProcedure` was made OPTIONAL by
+//       `efb7553f` (PR #144, 2026-08-06) and is declared `tsProcedure?: string` at surfaces.ts:19.
+//       When it is absent, checks/parity.ts:24-40 reports `[WEAK]` with an explicit
+//       "no tsProcedure registered … NO cross-stack comparison ran" reason, and the RLS Mode-A
+//       cross-tenant probe and the RBAC deny assertions still run — a did-not-run never renders as a
+//       tick. So these procedures CAN be deleted by flip #64, provided each endpoint is converted to
+//       C#-only by OMITTING `tsProcedure`. What must not happen is deleting the ENDPOINT or the
+//       SURFACE: that is what removes the IDOR probe, and surfaces.ts:8-18 calls it a
+//       security-coverage regression rather than a cleanup.
+//
+//       listSurveys also
 //       still backs a live invalidate-only FE consumer
 //       (engagement/climate/launch-survey-modal.tsx:58) and a static tripwire
 //       (tests/tier1/s2-engagement-wiring.test.ts:33). Their removal is runbook §7b edits 1b + 4,


### PR DESCRIPTION
## The false claim, in two places

`packages/api/src/routers/engagement.ts:36` and `docs/REMAINING-WORK.md:355` both said
`scripts/parity/surfaces.ts` pins `tsProcedure` as **"a REQUIRED field"**, and concluded that deleting
`listSurveys` / `getRotationRisk` *"turns `verify engagement` into a partial or total no-op"*.

Both halves are false.

`tsProcedure` was made optional by **`efb7553f` (PR #144, 2026-08-06)** and is declared
`tsProcedure?: string` at `surfaces.ts:19`. It **was** required when `bbf11c5d` created the harness —
so the comment was true when written and went stale four days later. The citation even still points at
`surfaces.ts:7`, which is no longer that line.

`checks/parity.ts:24-40` shows what actually happens when it is absent: `[WEAK]`, with an explicit
*"no tsProcedure registered … NO cross-stack comparison ran"* reason, while the **RLS Mode-A
cross-tenant probe and the RBAC deny assertions still run**. A did-not-run never renders as a tick —
that is the documented design of the field (`surfaces.ts:8-18`).

## Why this is more than a doc fix

**It changes flip #64's plan.** Those four engagement procedures are not undeletable. #64 may delete
them, provided each endpoint is converted to **C#-only by omitting `tsProcedure`**.

What must not happen is deleting the **endpoint** or the **surface** — that removes the IDOR probe,
which `surfaces.ts:8-18` explicitly calls a security-coverage regression rather than a cleanup. The
distinction is the whole point, and the stale comment obscured it.

## Provenance — I propagated this today

I relied on the in-code comment earlier today and repeated "a REQUIRED field" in **PR #188's body**
and in a comment on **#64**. Both are corrected on the issue. This PR fixes the two sources so the
next reader does not inherit it.

A stale in-code comment is load-bearing here precisely because it is the thing people trust *instead
of* re-reading the source — which is exactly what I did.

## Verification

- `pnpm --filter @tims/api exec tsc --noEmit` — exit 0
- `npx vitest run` — **3045 passed / 310 files**, exit 0 (unchanged; comments and docs only)
- gitleaks — no leaks

**Tier: same-model only.** `/gate` check 15 is exit 2 (Codex quota to 2026-08-15). Not cross-model
verified.

Refs #64