### PR TITLE
docs(csharp): audit/compliance + pipeline state-machine design docs (#102, #103)

### DIFF
--- a/docs/architecture/csharp-migration/audit-compliance-domain.md
+++ b/docs/architecture/csharp-migration/audit-compliance-domain.md
@@ -1,0 +1,676 @@
+# Audit / Compliance — domain characterization (Phase-5 domain #4)
+
+Date: 2026-08-10 · Issue: #102 · Branch: `docs/102-103-design-spikes`
+
+This is the **domain characterization** that has to exist before anyone can plan the port. It is not a
+slice plan. Every number below was re-derived from source on this branch; nothing is carried over from
+the issue body, from `REMAINING-WORK.md`, or from the CB-series docs. Where I contradict one of those,
+the contradiction is stated with both citations.
+
+**Filename note.** #102's acceptance criteria asks for `phase-5-slice-19-audit-compliance.md`. This file
+is deliberately named `audit-compliance-domain.md` instead: §5 concludes the port is **four slices**, not
+one, so a `slice-19` filename would encode a scoping claim the evidence does not support. That deviation
+does not make #102's AC1 satisfied — see §8, which states exactly which of #102's and #61's acceptance
+criteria this document does and does not close.
+
+---
+
+## 0. Corrections to the issue and to existing docs
+
+| #   | Claim                                                        | Source                                                                                                                                                                                     | Reality                                                                                                              |
+| --- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| C1  | "**17** TS `auditLog.create` sites"                          | #102 comment (2026-08-10)                                                                                                                                                                  | **23** non-test sites. See §1.1.                                                                                     |
+| C2  | "~20 TS `db.auditLog.create` call sites"                     | #102 body                                                                                                                                                                                  | 23. Same miss as C1.                                                                                                 |
+| C3  | "all 20 `db.auditLog.create` sites"                          | `docs/architecture/compliance/cb-1b-audit-logs-immutability.md:9`; repeated at `docs/REMAINING-WORK.md:438` and at `packages/db/prisma/manual/2026-07-17-audit-logs-immutable.sql:3`       | 23.                                                                                                                  |
+| C4  | "**5** `ISecurityEventWriter` call sites"                    | #102 comment                                                                                                                                                                               | **6** `WriteAsync` invocations. See §1.3.                                                                            |
+| C5  | "**3** C# writers"                                           | #102 comment                                                                                                                                                                               | Confirmed — 3 concrete writer classes. See §1.3.                                                                     |
+| C6  | `routers/audit.ts` is "dead code", "zero frontend consumers" | `docs/superpowers/plans/2026-07-25-phase5-slice17-audit-log-read.md:17,1466`; `docs/architecture/csharp-migration/phase-5-slice-17-audit-log-read.md:12` (calls `exportLogs` a "`[stub]`") | **False as of `863b62f4`.** `exportLogs` is live at `apps/web/app/(admin)/settings/audit-log/page.tsx:28`. See §2.3. |
+| C7  | "`withAudit` middleware is wired but DEAD (never applied)"   | `cb-1b-audit-logs-immutability.md:48-49`                                                                                                                                                   | **Still true today** — and it has a live consequence nobody has recorded. See §4.4.                                  |
+
+**On C1/C2/C3 — why the count was wrong three times.** The naive grep `auditLog\.create` misses **6** of
+the 23 sites, because those break the line between the delegate and the method:
+
+```
+packages/api/src/trpc.ts:160                          await db.auditLog
+packages/api/src/repositories/billing.repository.ts:56    await tenantDb.auditLog
+packages/api/src/routers/platform/ai-agents.ts:134        await db.auditLog
+packages/api/src/routers/platform/system.ts:103           await db.auditLog
+packages/api/src/routers/platform/system.ts:312           await db.auditLog
+packages/api/src/routers/platform/data-requests.ts:264        db.auditLog
+```
+
+A multiline-aware scan (`auditLog\s*\.\s*create`) over `.ts`/`.tsx` returns 34 hits, of which 11 are in
+`tests/` — leaving **23** product sites. Any inventory that reuses the single-line pattern will
+under-count by the same 6, and `packages/api/src/trpc.ts:160` — the one global writer — is among them.
+
+**On C6.** The slice-17 doc was written 2026-07-25 (`e44b3a22`); the export page landed 2026-07-31 in
+`863b62f4` _feat(audit): tenant-scoped audit-log CSV/JSON export (#7)_. The claim was **true when written
+and has been false since**. This is doc drift, not an authoring error — but the two files still assert it,
+and #102's plan should not inherit it. #61 AC3 asks for the correction to land in
+`docs/architecture/csharp-migration/phase-5-slice-17-audit-log-read.md`; that file is corrected on this
+branch (see §8). `docs/superpowers/plans/2026-07-25-phase5-slice17-audit-log-read.md` is deliberately left
+untouched: it is a dated plan artifact recording what was believed on 2026-07-25, and rewriting history in
+it would destroy the evidence that this is drift rather than an authoring error.
+
+**Where C3's wrong "20" also lives.** The same count is baked into the header comment of
+`packages/db/prisma/manual/2026-07-17-audit-logs-immutable.sql:3` ("All 20 admin/security writers use
+`db.auditLog.create`"). That file carries a standing operational requirement — re-run after any Prisma
+migration that recreates `audit_logs` (§6.1) — so it is the copy most likely to be re-read during an
+incident, by someone deciding whether the guard still covers every writer. It does not need to be edited
+for the guard to be correct (the guard is table-scoped, not writer-scoped), but the number is wrong by 3
+and should be fixed the next time that file is touched.
+
+---
+
+## 1. Writer census
+
+Two physical tables carry this domain: `audit_logs` (admin/security events) and `data_access_logs`
+(sensitive-read/export evidence). Both are `efcoreAppendOnly` in the ownership ledger —
+`docs/architecture/table-ownership.md:93` — i.e. Prisma owns the DDL, both stacks may INSERT, neither may
+UPDATE or DELETE.
+
+### 1.1 TS → `audit_logs`: 23 sites
+
+Everything routes through the Prisma `auditLog.create` delegate; there is no raw-SQL writer
+(`$queryRaw`/`$executeRaw` against `audit_logs`: zero hits repo-wide).
+
+| #     | Site                                                             | `action`                                                                                                  | Failure mode                    | `actorId`              |
+| ----- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------- | ---------------------- |
+| 1     | `packages/api/src/access/security-audit.ts:44`                   | caller-supplied                                                                                           | try/catch, fail-soft (`:57-59`) | caller-supplied        |
+| 2     | `packages/api/src/trpc.ts:160`                                   | `'access'`                                                                                                | `.catch`                        | `impersonatorId ?? id` |
+| 3     | `apps/web/app/api/impersonate/start/route.ts:61`                 | `impersonation_started`                                                                                   | `.catch`                        | `owner.id`             |
+| 4     | `apps/web/app/api/impersonate/stop/route.ts:32`                  | `impersonation_stopped`                                                                                   | `.catch`                        | `owner.id`             |
+| 5     | `packages/api/src/repositories/billing.repository.ts:56`         | caller-supplied                                                                                           | `.catch`                        | caller-supplied        |
+| 6     | `packages/api/src/routers/platform/ai-agents.ts:134`             | `ai_agent_status_*`                                                                                       | `.catch`                        | **missing**            |
+| 7     | `packages/api/src/routers/platform/data-requests.ts:264`         | `data_subject_export`                                                                                     | `.catch` (`:283`)               | `impersonatorId ?? id` |
+| 8–9   | `packages/api/src/routers/platform/entitlements.ts:57,79`        | `entitlement_set`, `entitlement_plan_assigned`                                                            | `.catch`                        | `ctx.user.id`          |
+| 10    | `packages/api/src/routers/platform/invoices.ts:205`              | `invoice_status_*`                                                                                        | **uncaught**                    | **missing**            |
+| 11    | `packages/api/src/routers/platform/invoices.ts:264`              | `payment_reminder_sent`                                                                                   | **uncaught**                    | **missing**            |
+| 12–14 | `packages/api/src/routers/platform/organizations.ts:157,198,230` | `org_created/updated/suspended/activated`                                                                 | `.catch`                        | `ctx.user.id`          |
+| 15    | `packages/api/src/routers/platform/subscriptions.ts:291`         | `dunning_reminder_sent`                                                                                   | **uncaught**                    | **missing**            |
+| 16    | `packages/api/src/routers/platform/system.ts:103`                | `bulk_notification_sent`                                                                                  | `.catch`                        | `ctx.user.id`          |
+| 17    | `packages/api/src/routers/platform/system.ts:312`                | `feature_flag_enabled/disabled`                                                                           | `.catch`                        | `ctx.user.id`          |
+| 18    | `packages/api/src/routers/platform/usage-billing.ts:76`          | `entitlement_usage_invoiced`                                                                              | `.catch`                        | `ctx.user.id`          |
+| 19–23 | `packages/api/src/routers/platform/users.ts:157,183,232,281,326` | `user_deactivated`, `user_activated`, `password_reset_requested`, `sessions_revoked`, `user_role_changed` | `.catch`                        | `ctx.user.id`          |
+
+Three consistency defects fall straight out of the table, and all three are **portability hazards** — a
+naive port would carry them across:
+
+- **Three writers are uncaught** (#10, #11, #15). Every other site is best-effort. **Two of the three**
+  (#10, #11) throw a 500 _after_ the state change has already committed: the invoice status is written at
+  `invoices.ts:199` before the audit at `:205`, and the reminder email is dispatched at `invoices.ts:250`
+  (`const sent = await sendEmail(...)`, guarded at `:262`) before the audit at `:264`. So an audit outage
+  there turns a succeeded action into a reported failure, and the caller retries a send that already
+  happened.
+
+  > **Corrected 2026-08-10.** That consequence does **not** apply to #15. `subscriptions.ts:291` sits inside
+  > `sendDunningReminder` (`subscriptions.ts:269-310`), which does a `findUnique`, two guard throws, the
+  > audit row, then `return { sent: true }` — there is no state change and **no `sendEmail` call anywhere in
+  > the procedure**. For #15 the uncaught write is harmless-to-correct: a 500 there leaves nothing
+  > inconsistent, because nothing happened. So the port must decide the fail-closed question deliberately
+  > for #10 and #11; #15 is a consistency cleanup, not a correctness one.
+
+- **Four writers set no `actorId`** (#6, #10, #11, #15) — the rows are unattributable. `audit_logs.actorId`
+  is nullable (`packages/db/prisma/schema/system.prisma:21`), so nothing catches it.
+- **Only 3 of 23 populate `ipAddress`/`userAgent`** — the `security-audit.ts` helper (#1, `:53-54`), the
+  global `access` writer (#2, `trpc.ts:168-169`) and the DSAR export (#7, `data-requests.ts:279-280`). The
+  columns exist (`system.prisma:27-28`) and the tenant CSV export ships them
+  (`packages/api/src/repositories/audit.repository.ts:58-59`), so **20** writers produce rows whose forensic
+  columns are permanently null and un-backfillable (append-only).
+
+  > **Corrected 2026-08-10** from "2 of 23 / 21 writers". Site #2 (`trpc.ts:160`) does populate both columns.
+  > Note the interaction with §4.4: #2 is the writer inside the dead `withAudit` middleware, so among
+  > **live** writers it is 2 of 22 — `access/security-audit.ts:53-54` and
+  > `routers/platform/data-requests.ts:279-280`. Wiring `withAudit` would move live writers 22 → 23 and
+  > IP-populating ones 2 → 3. The remediation size is **20 either way**, which is the number that matters.
+
+Additionally, `packages/api/src/routers/platform/ai-agents.ts:140` hardcodes
+`organizationId: '00000000-0000-0000-0000-000000000000'`. `audit_logs.organization_id` is a NOT-NULL FK to
+`organizations` (`system.prisma:19,31`). Unless a row with that id exists, the insert violates the FK and
+the `.catch(() => {})` at `:144` swallows it — AI-agent status changes would be **silently unaudited**. I
+could not verify prod's `organizations` contents from this environment; this is the one item in this
+document that needs a live query before it is stated as fact.
+
+**Impersonation attribution.** **13** of the 23 sites use bare `ctx.user.id`, not the `impersonatorId ?? id`
+form that CB-1c introduced at `data-requests.ts:273`. The 13 are exactly the rows the table above marks
+`ctx.user.id`: `entitlements.ts:57,79` · `organizations.ts:157,198,230` · `system.ts:103,312` ·
+`usage-billing.ts:76` · `users.ts:157,183,232,281,326`. The other 10 split as 4 `actorId`-missing (#6, #10,
+#11, #15) and 6 already-correct forms (`trpc.ts` and `data-requests.ts` use `impersonatorId ?? id`,
+`security-audit.ts` and `billing.repository.ts` take a caller-supplied actor, the two impersonate routes use
+`owner.id`).
+
+> **Corrected 2026-08-10** from "15 sites". 15 was never derived from the table two paragraphs above, which
+> lists 13. The count sizes the Slice-C attribution remediation, so it is 13 sites to change, not 15.
+
+On `platformProcedure` surfaces the blast radius is narrow:
+during impersonation `ctx.user` is the target, and `packages/api/src/routers/platform/_common.ts:6-8`
+403s a non-owner target. It bites only when a platform owner impersonates another platform owner.
+
+### 1.2 TS → `data_access_logs`: 2 write sites, 5 call paths
+
+| Write site                                                                     | Client                    | Policy                                                                              | Reached from                                                                                                                                  |
+| ------------------------------------------------------------------------------ | ------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/api/src/access/audit.ts:49` (`logDataAccess`)                        | `tenantDb` (`audit.ts:2`) | fail-CLOSED if `dataClassOf(entity) === 'restricted'`, else fail-soft (`:46,60-69`) | `routers/compensation.ts:97`, `routers/assessment.ts:58`, `services/compensation.service.ts:80`, `services/external-validation.service.ts:67` |
+| `packages/api/src/routers/platform/data-requests.ts:47` (`auditSensitiveRead`) | privileged `db`           | same registry, same polarity (`:45,59-65`)                                          | `exportSubjectData` only                                                                                                                      |
+
+`auditSensitiveRead` is a **deliberate** second writer, not a duplicate: `data-requests.ts:22-32` records
+why `logDataAccess` cannot be substituted (it writes through `tenantDb`, so a platform owner who has an
+org of their own runs under `SET LOCAL ROLE app_tenant` with the GUC pinned to the _operator's_ org, and
+the fail-closed `tenant_isolation` `WITH CHECK` — `packages/db/baseline/prod-public-schema.sql:7575` —
+rejects a row carrying the _subject's_ org). That reasoning survives the port verbatim and must be
+carried into the C# design, because C#'s `DataAccessAuditWriter` has exactly the same `TenantScope`
+coupling (§1.3).
+
+### 1.3 C# writers: 3 classes, 14 invocation sites
+
+Three concrete writer classes, confirming #102's C5:
+
+| Class                                                                              | Table              | Interface              | Policy                                                                                      |
+| ---------------------------------------------------------------------------------- | ------------------ | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `services/Tims.Platform/src/Tims.Infrastructure/Audit/DataAccessAuditWriter.cs:22` | `data_access_logs` | `IDataAccessAuditor`   | fail-CLOSED or fail-soft by data class (`:29-30,56-64`); writes under `TenantScope` (`:39`) |
+| `services/Tims.Platform/src/Tims.Infrastructure/Audit/BillingAuditWriter.cs:15`    | `audit_logs`       | `IBillingAuditWriter`  | fail-soft; entity hardcoded `'billing'`; under `TenantScope`                                |
+| `services/Tims.Platform/src/Tims.Infrastructure/Audit/SecurityEventWriter.cs:12`   | `audit_logs`       | `ISecurityEventWriter` | fail-soft (`:36-42`); **no** `TenantScope` — cross-org/pre-tenant by design (`:8-10`)       |
+
+**`ISecurityEventWriter.WriteAsync` — 6 call sites, not 5** (correction C4):
+
+1. `services/Tims.Platform/src/Tims.Api/AccessReview/AccessReviewEndpoints.cs:50` — `access_review_viewed`
+2. `services/Tims.Platform/src/Tims.Api/AccessReview/AccessReviewEndpoints.cs:91` — export
+3. `services/Tims.Platform/src/Tims.Api/AccessReview/AccessReviewEndpoints.cs:157` — `access_recertified`
+4. `services/Tims.Platform/src/Tims.Api/Authentication/SecurityDenialAuditMiddleware.cs:132` — **global**, `authz_denied` on every 401/403 (#177/#178/#180/#181)
+5. `services/Tims.Platform/src/Tims.Api/Authentication/MfaStepUpMiddleware.cs:88` — **global**, `mfa_step_up_required`
+6. `services/Tims.Platform/src/Tims.Application/AlertMetrics/AlertMetricsReadUseCase.cs:71` — `alert_metric_cron_read` (#172)
+
+The issue comment is right that (4) and (5) are the easy-to-miss ones — they live under
+`Tims.Api/Authentication/`, in no domain folder, and they are wired as pipeline middleware at
+`services/Tims.Platform/src/Tims.Api/Program.cs:803` and `:821` rather than as endpoint dependencies. The
+comment's count of 5 appears to have collapsed the three `AccessReviewEndpoints` sites into two.
+
+`IBillingAuditWriter.WriteAsync`: injected once, at
+`services/Tims.Platform/src/Tims.Application/Billing/BillingSelfServeUseCase.cs:17`.
+
+`IDataAccessAuditor.LogAsync`: **7** invocation sites —
+`Tims.Api/Compensation/CompensationFxReadEndpoints.cs:195`,
+`Tims.Api/Compensation/CompensationReadEndpoints.cs:395`,
+`Tims.Api/Succession/SuccessionReadEndpoints.cs:309`,
+`Tims.Application/Compensation/CompensationWriteUseCase.cs:89`,
+`Tims.Application/ExternalVendor/ExternalAssessmentReadUseCase.cs:88`,
+`Tims.Application/ExternalVendor/ExternalValidationSubmitUseCase.cs:66`,
+`Tims.Application/Hris/RunHrisSyncUseCase.cs:347`. Registered twice — API host
+(`Tims.Api/Program.cs:180`) and worker host (`Tims.Workers/Program.cs:100`).
+
+### 1.4 Writer census — totals
+
+| Stack | `audit_logs`                    | `data_access_logs`            |
+| ----- | ------------------------------- | ----------------------------- |
+| TS    | 23 sites, 1 delegate            | 2 sites, 2 helpers            |
+| C#    | 2 writer classes, 7 invocations | 1 writer class, 7 invocations |
+
+**There is no single owning module on either stack.** That is the gap #102 names, and it is real.
+
+---
+
+## 2. Reader census
+
+### 2.1 `audit_logs` — TS
+
+| Surface                            | Reader                                                    | Client            | Scope                                                         |
+| ---------------------------------- | --------------------------------------------------------- | ----------------- | ------------------------------------------------------------- |
+| `audit.listLogs`                   | `packages/api/src/repositories/audit.repository.ts:79`    | `tenantDb` (`:1`) | org                                                           |
+| `audit.getLogDetail`               | `audit.repository.ts:109`                                 | `tenantDb`        | org                                                           |
+| `audit.exportLogs`                 | `audit.repository.ts:46`                                  | `tenantDb`        | org, `EXPORT_LIMIT = 10_000` (`services/audit.service.ts:13`) |
+| `audit.getAccessReport`            | `audit.repository.ts:140` (`groupBy`, `action: 'access'`) | `tenantDb`        | org                                                           |
+| `audit.getChangesByEntity`         | `audit.repository.ts:153`                                 | `tenantDb`        | org                                                           |
+| `platform.getSystemHealth`         | `routers/platform/system.ts:41,43,46`                     | privileged `db`   | **cross-org**                                                 |
+| `platform.getRecentPlatformEvents` | `routers/platform/system.ts:119`                          | privileged `db`   | **cross-org**                                                 |
+| `platform.getOrgAuditLogs`         | `routers/platform/system.ts:265`                          | privileged `db`   | single org by input                                           |
+| `platform.getRecentActivity`       | `routers/platform/dashboard.ts:354` (read at `:358`)      | privileged `db`   | **cross-org**                                                 |
+
+> **Corrected 2026-08-10.** The last row previously read `platform.getPlatformDashboard`. No procedure of
+> that name exists anywhere in the repo (`grep -rn getPlatformDashboard packages apps` → zero hits); the
+> cross-org `audit_logs` read at `dashboard.ts:358` belongs to `getRecentActivity`, declared at `:354`.
+> §3 and §5 Slice B are corrected to the same name.
+
+`platform.getCrossOrgAuditLogs` and `platform.exportAuditLogsCsv` **no longer exist in TS** — deleted at
+the Slice-17 cutover; the FE now calls C# unconditionally (`apps/web/lib/platform-api/audit-log.ts:1-8`).
+Verified by grep: zero occurrences of either name under `packages/`.
+
+### 2.2 `audit_logs` — C#
+
+`services/Tims.Platform/src/Tims.Api/Audit/AuditReadEndpoints.cs` — `GET /audit/logs` (`:32`) and
+`GET /audit/logs/export` (`:63`), both behind `PlatformOwnerGate` and mapped when
+`PlatformOptions.AuditLogReadEnabled` is set **or** during OpenAPI-doc generation — the guard is
+`if (externalOptions.AuditLogReadEnabled || isOpenApiDocGeneration)` at `Tims.Api/Program.cs:1118`, with the
+carve-out stated on the option itself (`Tims.Api/Configuration/PlatformOptions.cs:253-258`). A port that
+reads the flag alone will mis-model when the surface is reachable. Backed by `AuditReadRepository` /
+`AuditReadDbContext` — never wrapped in `TenantScope` (`Program.cs:445-450`).
+
+### 2.3 User-facing readers (and correction C6)
+
+| Page                                                                                | Calls                                        | Reaches                                                         |
+| ----------------------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------- |
+| `apps/web/app/(admin)/platform/audit/page.tsx:9`                                    | `useAuditLogs` / `useAuditLogsExport`        | **C#** `/audit/logs` (`apps/web/lib/platform-api/audit-log.ts`) |
+| **`apps/web/app/(admin)/settings/audit-log/page.tsx:28`**                           | **`trpc.audit.exportLogs`**                  | **TS** `auditService.exportLogs`                                |
+| `apps/web/app/(admin)/platform/organizations/[id]/sections/activity-section.tsx:50` | `trpc.platform.getOrgAuditLogs`              | TS                                                              |
+| `apps/web/app/(admin)/platform/health/page.tsx:16`                                  | `trpc.platform.getSystemHealth`              | TS                                                              |
+| `apps/web/app/(admin)/platform/support/system-info.tsx:10-11`                       | `getSystemHealth`, `getRecentPlatformEvents` | TS                                                              |
+| `apps/web/app/(admin)/dashboard/activity-feed.tsx:43`                               | `trpc.platform.getSystemHealth`              | TS                                                              |
+
+**Correction C6, restated concretely.** `audit.exportLogs` is a real, reachable, permission-gated tenant
+surface: router `packages/api/src/routers/audit.ts:28` (`permissionProcedure('audit','export')`) → service
+`packages/api/src/services/audit.service.ts:50` (a full CSV/JSON builder, not a stub) → repository
+`packages/api/src/repositories/audit.repository.ts:46` → nav entry
+`apps/web/lib/nav/manifest.ts:93` (`module: 'audit'`) → page
+`apps/web/app/(admin)/settings/audit-log/page.tsx:28`. It also emits its own `platform_export` audit row
+(`routers/audit.ts:41-46`). Any port plan that treats `routers/audit.ts` as deletable dead code will
+remove a live customer-facing export.
+
+The other four `auditRouter` procedures (`listLogs`, `getLogDetail`, `getAccessReport`,
+`getChangesByEntity`) genuinely have **zero** frontend consumers — grep across `apps/web` returns only the
+`exportLogs` line above. So the original doc was right about 4 of 5 and wrong about the one that matters.
+
+Reader base is narrow by grant: `audit` is granted **only to `super_admin`** —
+`packages/db/prisma/seed-access-matrix.ts:35` (read/create/update/delete) and `:40` (export). No other
+role in `MATRIX` carries an `audit` entry.
+
+### 2.4 `data_access_logs` — **zero readers, on either stack**
+
+Grep for `dataAccessLog.` across `packages`, `apps`, `workers`, `scripts` returns **three** hits: two writes
+(`access/audit.ts:49`, `platform/data-requests.ts:47`) and one prose mention in a SQL comment
+(`packages/db/prisma/manual/2026-07-17-data-access-logs-immutable.sql:7`). **Zero reads.** C# has no read
+context and no endpoint for it either — the only `DataAccessLogEntity` `DbSet` is the writer's
+(`DataAccessAuditDbContext.cs:23`).
+
+The §21 sensitive-read trail is therefore **write-only**: evidence is accruing that nobody — including an
+auditor, including an incident responder — can retrieve through the product. Retrieval today means direct
+psql. That is a genuine control gap and it belongs in this domain's scope, not in a footnote.
+
+---
+
+## 3. C# surface: what exists vs what is missing
+
+**Exists.**
+
+- Cross-org audit **read** (Slice 17): `Tims.Api/Audit/AuditReadEndpoints.cs`, `AuditReadRepository`,
+  `AuditReadDbContext`, `PlatformOwnerGate`. Flipped and live in prod 2026-07-31
+  (`docs/REMAINING-WORK.md:202-205`); TS counterpart deleted.
+- Three writers (§1.3) with Testcontainers proofs: `tests/Tims.IntegrationTests/Audit/`
+  (`SecurityEventWriterTests`, `AuditReadRepositoryTests`, `AuditReadCrossOrgTests`,
+  `AuditReadEndpointAuthTests`), plus `DataAccessAuditWriterTests.cs`,
+  `Billing/BillingAuditWriterTests.cs`, and the immutability pins `AuditImmutabilityTests.cs` /
+  `AuditLogsImmutabilityTests.cs`.
+- Two global security-event middlewares (`SecurityDenialAuditMiddleware`, `MfaStepUpMiddleware`) —
+  coverage TS reaches through observers instead.
+
+**Missing.**
+
+| Gap                                                                          | Evidence                                                                                                                                        |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| The whole **tenant-scoped** `auditRouter` — all 5 procedures                 | no C# equivalent of `packages/api/src/routers/audit.ts`; this is #61, which #102 absorbs. Only `exportLogs` is proposed for a port — §5 Slice A |
+| `platform.getOrgAuditLogs`                                                   | `routers/platform/system.ts:264`, no C# counterpart                                                                                             |
+| `platform.getSystemHealth` / `getRecentPlatformEvents` / `getRecentActivity` | `system.ts:41,43,46,119`, `dashboard.ts:354`                                                                                                    |
+| Any `data_access_logs` **read** surface                                      | §2.4 — missing on both stacks                                                                                                                   |
+| A C# home for the 23 TS `audit_logs` writers                                 | `SecurityEventWriter` is the right shape (§1.3) but has 6 callers, none of them a port of the 18 platform-router writers                        |
+| Retention / purge                                                            | **zero** matches in `workers/` and `services/Tims.Platform/src/`; the 6 elsewhere are all prose — see §4.5                                      |
+
+> **Corrected 2026-08-10, two rows.**
+>
+> - "21 platform-router writers" → **18**. Counting the §1.1 table's rows under
+>   `packages/api/src/routers/platform/`: ai-agents 1, data-requests 1, entitlements 2, invoices 2,
+>   organizations 3, subscriptions 1, system 2, usage-billing 1, users 5 = 18. The other 5 of the 23 live
+>   outside that directory (`trpc.ts`, `access/security-audit.ts`, `repositories/billing.repository.ts`, and
+>   the two `apps/web/app/api/impersonate/*` routes). "21" was the (also wrong) `ipAddress` figure reused in
+>   a context it does not describe.
+> - "zero matches for `purge`/`retention`" → a case-insensitive scan of those four trees returns **6**:
+>   `packages/api/src/routers/dei.ts:46`, `packages/api/src/routers/platform/data-requests.ts:17,296`,
+>   `packages/db/prisma/migrations/20260810000000_audit_logs_action_index/migration.sql:9`,
+>   `packages/db/prisma/schema/access.prisma:3` and `scripts/parity/surfaces.test.ts:150`. Every one is a
+>   comment or an unrelated use of the word; `workers/` and `services/Tims.Platform/src/` are genuinely 0.
+>   **The finding survives intact** — no purge job exists — but §4.5's phrasing ("no job, no scheduler
+>   entry, no SQL") is the accurate one, and this row now matches it.
+
+---
+
+## 4. Compliance obligations — and where each is actually enforced
+
+### 4.1 Append-only (CB-1 / CB-1b) — **enforced in the database**
+
+Trigger + REVOKE, applied to prod and present in the committed baseline:
+
+- `packages/db/baseline/prod-public-schema.sql:5531` `audit_logs_append_only` (BEFORE DELETE OR UPDATE, row)
+- `:5539` `audit_logs_append_only_truncate` (BEFORE TRUNCATE, statement)
+- `:5547`, `:5555` — the same pair on `data_access_logs`
+- `:5533`, `:5541`, `:5549`, `:5557` — all four are `ENABLE ALWAYS` (fire under
+  `session_replication_role='replica'`)
+- `:269` `tims_append_only_guard()` — `RAISE EXCEPTION` with `ERRCODE = 'insufficient_privilege'` (42501)
+- `packages/db/prisma/manual/2026-07-17-audit-logs-immutable.sql:24-25` — `REVOKE UPDATE, DELETE, TRUNCATE`
+  from `PUBLIC` and `app_tenant`; the `data_access_logs` twin is
+  `packages/db/prisma/manual/2026-07-17-data-access-logs-immutable.sql`
+
+Residual grants confirm the shape: `GRANT SELECT,INSERT ... TO app_tenant` on both tables
+(`baseline:8150`, `:8264`).
+
+**Caveat that survives the port (CB-1b FK cascade).** `audit_logs.organizationId` is NOT-NULL with
+`onDelete: Cascade` (`packages/db/prisma/schema/system.prisma:19,31`); `userId`/`actorId` are optional FKs
+(`:20-21,32-33`). Once the guard is installed, a hard delete of an org (cascade → DELETE) or a user
+(SET NULL → UPDATE) is blocked with 42501. `data_access_logs` is FK-less by design and unaffected.
+
+### 4.2 Tenant isolation — enforced, with a documented BYPASSRLS carve-out
+
+`ENABLE` + `FORCE ROW LEVEL SECURITY` on both tables (`baseline:689,1096,6883,6997`) with a fail-closed
+`tenant_isolation` policy (`:7453`, `:7575`). But per
+`~/.claude/.../reference_prod_db_roles_and_rls_facts.md`, the app connects as `postgres`, which is
+BYPASSRLS — **FORCE RLS removes only the owner's exemption, not BYPASSRLS**. So the privileged `db`
+readers in §2.1 are cross-org by construction, and the isolation guarantee for tenant surfaces rests on
+`tenantDb`/`TenantScope` issuing `SET LOCAL ROLE app_tenant`. The port must not "simplify" a
+`TenantScope`-wrapped writer into a privileged one.
+
+### 4.3 §21 min-5 suppression — enforced, but **not by this domain**
+
+`MIN_AGGREGATE_SIZE` / `suppressBelowMin5` live at `packages/api/src/access/aggregate.ts:19-21`, exported
+via `packages/api/src/access/index.ts:15`, and are consumed by the _analytics_ surfaces —
+`routers/engagement.ts:114`, `routers/monitoring.ts:35,226`, `routers/compensation.ts:49`, and C#'s
+`DeiKernels` (`routers/dei.ts:28`). **No audit surface applies it, and none should**: audit rows are
+per-event forensic records, not cohort aggregates, and flooring them would destroy the evidence.
+
+Where §21 _does_ bind this domain is the `+AUDIT` obligation — "confidential + restricted reads must be
+logged" (`packages/api/src/access/audit.ts:15-18`, citing the matrix in `docs/TIMS ATS - Architecture.md`
+§21 lines 2472–2553). That is §1.2 + §4.6.
+
+I am flagging this explicitly because #102's framing bundles min-5 into the audit domain. It is
+enforced — just in `access/aggregate.ts`, owned by the analytics slices, and it is **not** a port
+deliverable here.
+
+### 4.4 Security-event coverage (CB-1c) — enforced with two live holes
+
+Coverage is real on the denial path: `observeDenial` at `packages/api/src/trpc.ts:191` (transparent
+outermost observer, `:189-193`), `observeExternalDenial` at `:291` and `:303`, `mfa_step_up_required` at
+`:220`, `feature_flag_changed` at `routers/platform/system.ts:360`, role changes at `routers/user.ts:190`
+and `:250`, flags at `routers/featureFlag.ts:52`, and 7 `logPlatformExport` call sites
+(`routers/audit.ts:41`, `candidate/pool.ts:39`, `platform/invoices.ts:298`, `platform/ai-agents.ts:292`,
+`platform/invitations.ts:299`, `platform/subscriptions.ts:265`, `platform/users.ts:368`).
+
+Two things asserted somewhere but **not enforced in code**:
+
+- **`withAudit` is still dead.** Defined `packages/api/src/trpc.ts:153`, composed into
+  `auditedProcedure` at `:237` — and `auditedProcedure` has **zero** consumers repo-wide. CB-1c recorded
+  this as a scope decision (`cb-1c-security-event-coverage.md:24`). The undocumented consequence:
+  `audit.getAccessReport` filters on `action: 'access'`
+  (`packages/api/src/repositories/audit.repository.ts:132`), and `'access'` is written **only** by
+  `trpc.ts:160` inside the dead middleware. **`getAccessReport` returns an empty group-by, permanently.**
+  It has no FE consumer, so nobody has noticed; it is also offered to `super_admin` as a real
+  `permissionProcedure('audit','read')` surface (`routers/audit.ts:51`). Decide it, don't port it.
+- **`login_failed` is read but never written.** `routers/platform/system.ts:43` counts it and `:47`
+  includes it in `recentErrors`. Repo-wide, the only other occurrences are **five, all in C# tests** —
+  `tests/Tims.IntegrationTests/Audit/AuditReadFixture.cs:143,145` (the seeded fixture rows),
+  `AuditReadRepositoryTests.cs:98` and `AuditReadEndpointAuthTests.cs:85,159` (assertions over those rows).
+  No product code on either stack writes it. CB-1c deferred this deliberately to CB-2 with a good reason — password login is client-side
+  via the Supabase SDK, so no server observes a wrong password
+  (`cb-1c-security-event-coverage.md:15-22`). The health dashboard's "failed logins today" tile is
+  therefore a **structural zero**, not a measurement.
+
+### 4.5 7-year retention — **asserted in docs, enforced nowhere**
+
+`docs/architecture/compliance/cb-1-audit-immutability.md:57` documents a 7-year retention for
+`data_access_logs` PII (`actor_id`, `ip_address`, `user_agent`); the roadmap repeats "7yr audit" at
+`00-compliance-by-design-roadmap.md:62` and assigns retention/erasure jobs to **CB-6**
+(`:69`). CB-6 has not been built: a case-insensitive scan for `purge|retention` across `packages/`,
+`apps/`, `workers/`, `scripts/` and `services/Tims.Platform/src/` finds **no job, no scheduler entry, no
+SQL**. `cb-1-audit-immutability.md:64` is candid about it — "Until CB-6, the table is fully immutable".
+
+Two consequences the port must own: (a) retention is currently _infinite_, which is a
+data-minimization exposure, not merely an unbuilt feature; (b) when CB-6 arrives it needs a **privileged
+exception path**, because the append-only guard blocks its own DELETEs by design — and that path is
+itself a control that must be audited.
+
+### 4.6 GDPR / Habeas Data (Ley 1581/2012) — export-only, and the erasure path is blocked
+
+`packages/api/src/routers/platform/data-requests.ts:11-17` — right-of-access is implemented
+(`exportSubjectData`, `platformProcedure`); **deletion is explicitly not**. This is consistent with
+CB-1b's cascade caveat: an erasure that hard-deletes a user or org would hit the 42501 guard.
+
+Live minimization defect, still open: `data_subject_export` writes the subject's plaintext email into
+**both** `entityId` (`data-requests.ts:276`) and `metadata.email` (`:277`, where `auditMeta = { email, … }`
+is built at `:260`), into an append-only table, readable
+by any same-org holder of `audit:read`. CB-1c flagged it and escalated it to CB-6 rather than fixing it
+(`cb-1c-security-event-coverage.md:52-58`). It is unfixable after the fact — append-only.
+
+### 4.7 Fail-closed audit writes — where they exist
+
+**Three** fail-closed paths exist — two in TS and one in C# — all three on `data_access_logs`, all three
+class-derived:
+
+- TS: `packages/api/src/access/audit.ts:46` + throw at `:60-66`.
+- TS, privileged: `packages/api/src/routers/platform/data-requests.ts:45` + throw at `:59-65` — this is
+  #155's contribution, **the first fail-closed privileged audit write in the codebase**. Its call site is
+  `:227`, and the reason it is sequenced first and alone (rather than inside the `Promise.all` at `:228`)
+  is written out at `:220-226`: `data_access_logs` is append-only, so if a concurrent fail-soft write had
+  already committed, a subsequent fail-closed abort would leave permanent, uncorrectable rows asserting
+  an export that never returned anything.
+- C#: `Tims.Infrastructure/Audit/DataAccessAuditWriter.cs:29-30,56-64`.
+
+> **Corrected 2026-08-10.** This read "Exactly **two** fail-closed paths exist" and was then refuted by its
+> own three-item list one line later. The C# writer is a third fail-closed path, not an aside — a port that
+> counts two will think it is adding one where one already exists.
+
+`audit_logs` has **no** fail-closed writer on either stack. The three uncaught TS sites (§1.1) are
+fail-closed only by omission — no comment claims it, and they sit after the state change.
+
+---
+
+## 5. Recommended slice breakdown
+
+The port is **four slices**, not one. Justification: the surfaces have three different auth models
+(tenant RBAC, platform-owner, machine/cron), two different failure polarities, and one of them
+(`data_access_logs` read) does not exist on either stack and so is new build, not a port.
+
+### Slice A — tenant-scoped `auditRouter` export (closes #61)
+
+Port **`exportLogs` only**. Reuse `AuditReadDbContext` shapes, but **wrap in `TenantScope`** — unlike
+Slice 17's platform reader, this one is org-scoped RBAC.
+
+> **Corrected 2026-08-10 — this changes the slice, not just a number.** Slice A previously scheduled a port
+> of `listLogs` / `getLogDetail` / `exportLogs` / `getChangesByEntity`. Three of those four are procedures
+> §2.3 proves have **zero consumers**, and #61 AC1 asks that unused procedures be deleted _or_ that a reason
+> they survive be recorded. Porting them silently is the opposite of that, so the recommendation is
+> corrected: **only `exportLogs` is ported**, and `listLogs`, `getLogDetail` and `getChangesByEntity` join
+> `getAccessReport` in Slice D's decide-or-delete bucket.
+>
+> The evidence for the four, re-checked today:
+> `grep -rn 'listLogs\|getLogDetail\|getChangesByEntity\|getAccessReport' packages apps scripts`
+> restricted to source (`--include='*.ts' --include='*.tsx'`, excluding `node_modules` and `.next`)
+> returns **20 hits, every one inside the implementation chain itself**: 8 in `routers/audit.ts`
+> (the declarations), 8 in `services/audit.service.ts` (the methods they call), and 4 in
+> `repositories/audit.repository.ts`. The repository four are **comments**, not call sites — the repo
+> methods are named `findLogs` / `findAccessReport` / `findChangesByEntity`, and those lines record
+> where the logic moved from.
+>
+> The load-bearing part is the negative, and it is exact: **0** hits in `apps/web`, **0** in `scripts/`,
+> **0** in `tests/`. No FE consumer, no test, no script. (Counting source files only — `apps/web/.next/`
+> contains bundled copies of the router and will match a careless grep.) There is no evidence they survive deletion, and this document
+> does not have the standing to delete them; naming the decision and its owner is what #61 asks for.
+>
+> The default should be **delete**, for a reason beyond tidiness: `getAccessReport` returns a permanently
+> empty group-by (§4.4), so at least one of the four is not merely unused but actively broken, and porting
+> a broken surface manufactures a C# parity test that pins the bug.
+
+Hazards:
+
+- `exportLogs` **is live** (§2.3, correction C6). This is a customer-visible cutover with a real FE
+  consumer, not a dark port. It needs the standard `NEXT_PUBLIC_*` wrapper + canary.
+- `EXPORT_LIMIT = 10_000` with a `take: limit + 1` truncation probe
+  (`services/audit.service.ts:13`, `repositories/audit.repository.ts:48`) and a `truncated` flag the page
+  renders (`settings/audit-log/page.tsx:49-53`). Off-by-one parity matters.
+- The export select **deliberately excludes** `changes`/`metadata`
+  (`repositories/audit.repository.ts:29-32`). Do not "complete" it.
+- Grant surface: `audit:read` / `audit:export`, `super_admin` only
+  (`seed-access-matrix.ts:35,40`). The C# port needs the same grant check, not just `PlatformOwnerGate`.
+
+### Slice B — the platform audit reads
+
+`getOrgAuditLogs` (`system.ts:264`), `getSystemHealth`'s three audit aggregates (`system.ts:41,43,46`),
+`getRecentPlatformEvents` (declared `system.ts:118`, read at `:119`), `getRecentActivity` (declared
+`dashboard.ts:354`, audit read at `:358`).
+
+Hazards:
+
+- All privileged/cross-org — `PlatformOwnerGate`, **no** `TenantScope`, same as Slice 17.
+- `getSystemHealth` is not an audit surface; it is a health surface that happens to count `audit_logs`.
+  Porting it drags `system.helpers.ts` (`buildSystemHealthServices`) along. Consider porting the
+  **counts** only and leaving the composition in TS.
+- Do not port the `login_failed` count as a working metric (§4.4) — it is structurally 0.
+- **`getRecentPlatformEvents` has no `where` clause at all.** `packages/api/src/routers/platform/system.ts:118-130`
+  is a bare `db.auditLog.findMany({ orderBy, take, select })` on the privileged client — every org's audit
+  rows, newest first, bounded only by `input.limit` (`z.number().int().min(1).max(50).default(10)`,
+  `system.schemas.ts:10-12`). It is rendered by
+  `apps/web/app/(admin)/platform/support/system-info.tsx:11`. The page bound must be carried over: it is
+  the only thing besides `PlatformOwnerGate` limiting how much cross-tenant audit history this returns, and
+  the C# port must decide deliberately whether an unfiltered cross-org tail is the intended contract.
+- **`getRecentActivity` — a different procedure — filters `action: { not: 'access' }`**
+  (`dashboard.ts:358`), and that filter only makes sense because of the dead `withAudit` (§4.4): `'access'`
+  is written solely by `trpc.ts:160`, so today it excludes nothing and would begin excluding everything the
+  moment `withAudit` is wired. Re-derive it, don't copy it.
+
+  > **Corrected 2026-08-10.** This hazard previously attached the `action: { not: 'access' }` filter to
+  > `getRecentPlatformEvents` and cited `dashboard.ts:358` for it. Both halves were wrong, and the error hid
+  > the more serious fact: the procedure it named is an **unfiltered cross-org read**, which is precisely
+  > what a porter needs to know before reimplementing it.
+
+### Slice C — consolidate the 23 `audit_logs` writers
+
+This is the slice #102 actually asks for. `SecurityEventWriter` is the correct target shape (generic,
+privileged, no `TenantScope`, caller-supplied action/entity). `BillingAuditWriter` stays separate —
+it is tenant-attributed and runs under `TenantScope` (`ISecurityEventWriter.cs:6-10`).
+
+Sequencing that de-risks it: **first** normalize the 23 TS sites onto `logSecurityEvent`
+(`access/security-audit.ts:37`) — a TS-only refactor with no cutover risk — **then** port the single
+resulting helper. Porting 23 hand-rolled sites individually multiplies the parity surface by 23.
+
+Hazards:
+
+- The four missing `actorId`s (§1.1) and the **two** uncaught writers that sit after a committed state
+  change (#10, #11) are **behavior changes** whichever way they are resolved. Resolve them in the TS
+  normalization step, where a revert is cheap. The third uncaught writer (#15, `subscriptions.ts:291`) is
+  not in that class — it precedes no state change and no send, so making it fail-soft is a pure
+  consistency fix (§1.1).
+- **20** of 23 write null `ipAddress`/`userAgent`, and the 13 bare-`ctx.user.id` sites (§1.1) need the
+  `impersonatorId ?? id` form. Adding the forensic columns is an improvement but changes the export payload
+  the tenant CSV already ships (`audit.repository.ts:58-59`).
+- `ai-agents.ts:140`'s all-zeros org id needs a live prod check before anything is ported (§1.1).
+- Metadata wire format is a known trap: TS writes a raw jsonb **object**
+  (`access/security-audit.ts:18-22,51-52`), C#'s `AuditLogEntity.Metadata` is a `string?`, so the wire
+  carries a JSON-encoded **string** and the FE re-parses (`apps/web/lib/platform-api/audit-log.ts:22-28`).
+  A consolidated writer must not silently normalize one into the other.
+- `audit_logs` is `efcoreAppendOnly` (`table-ownership.md:93`), so this slice adds a writer **without**
+  an ownership flip. Do not treat it as flip-shaped work.
+
+### Slice D — the `data_access_logs` read surface (new build) + the three policy decisions
+
+Build the §21 evidence reader that has never existed (§2.4), and land the decisions this characterization
+surfaced: (a) `withAudit`/`auditedProcedure`/`getAccessReport` — wire, delete, or redefine (§4.4); (b) the
+DSAR subject-email minimization question (§4.6); (c) **the three consumer-less `auditRouter` procedures
+moved out of Slice A** — `listLogs`, `getLogDetail`, `getChangesByEntity` — delete or record why they
+survive, per #61 AC1. (c) is cheap and should land first: it is a TS-only deletion with no cutover, and
+resolving it before Slice A starts keeps the C# surface from inheriting dead procedures.
+
+Hazards:
+
+- A reader over `data_access_logs` exposes actor IP/user-agent for confidential and restricted reads.
+  Its own grant model needs designing — `audit:read` is probably too broad.
+- Wiring `withAudit` would add **one INSERT per authenticated request** into an append-only table on a
+  platform targeting thousands of concurrent users. C# already refused the analogous cost — see the
+  `PrincipalResolutionMiddleware.cs:48` exemption note ("audit_logs INSERT per request, through a path
+  with no throttle") and `SecurityDenialAuditMiddleware.cs:56-63` (resolve the writer at point of use,
+  not per request). Deleting is the likelier right answer; either way it is a decision, not a port.
+
+**Explicitly out of scope for all four slices:** CB-6 retention/purge (§4.5) and the FK-less `audit_logs`
+follow-up (`cb-1b-audit-logs-immutability.md:36-38`). Both are prerequisites for GDPR erasure and for
+faithful attribution of global cross-org platform actions, and both are DDL-shaped work under
+`docs/architecture/ddl-governance.md`, not strangler work.
+
+---
+
+## 6. What this domain must NOT lose
+
+1. **The append-only triggers and the REVOKEs.** Four triggers, all `ENABLE ALWAYS`, plus REVOKE
+   UPDATE/DELETE/TRUNCATE from `PUBLIC` and `app_tenant`
+   (`baseline:5531,5539,5547,5555,5533,5541,5549,5557`;
+   `packages/db/prisma/manual/2026-07-17-audit-logs-immutable.sql:24-25`). Note the standing operational
+   requirement in that file's header: **re-run after any Prisma migration that recreates `audit_logs`**.
+   Pinned by `tests/Tims.IntegrationTests/AuditImmutabilityTests.cs` and `AuditLogsImmutabilityTests.cs`.
+2. **The fail-CLOSED restricted-read policy, including its ordering.**
+   `packages/api/src/access/audit.ts:46,60-66`;
+   `packages/api/src/routers/platform/data-requests.ts:45,59-65` (#155's first fail-closed privileged
+   write, called at `:227`); C# `DataAccessAuditWriter.cs:29-30,56-64`. The sequencing rationale at
+   `data-requests.ts:220-226` is load-bearing and must survive verbatim.
+3. **The `data-requests.ts:22-32` reason `logDataAccess` cannot be used on a cross-org surface.** A C#
+   port that routes the DSAR audit through `DataAccessAuditWriter` (which does wrap `TenantScope`,
+   `await using var scope = await TenantScope.BeginAsync(...)` at `DataAccessAuditWriter.cs:39`)
+   reintroduces exactly the bug that comment documents.
+4. **Transparency of the denial observer.** `packages/api/src/trpc.ts:189-193` inspects `!result.ok` and
+   returns the result **unchanged** — tRPC does not reject `next()` on a downstream error, so a
+   try/catch would never fire. C#'s equivalent never rethrows
+   (`SecurityDenialAuditMiddleware.cs:150-154`). An audit observer must never turn a 403 into a 500.
+5. **The kill-switch polarity.** `SecurityDenialAuditMiddleware.IsDisabled` matches the exact string
+   `"true"` and is **disabled**-phrased on purpose (`:53`, `:47-52`): an `Enabled`-phrased flag with the
+   house default of `false` would silently switch off a live security control on the next deploy. An
+   absent or garbled value keeps the control ON. Contrast `MfaEnforced`, which fails **open** so it
+   cannot lock operators out (`PlatformOptions.cs:436`). Two different polarities, both deliberate.
+6. **`CancellationToken.None` on the post-response audit write.**
+   `SecurityDenialAuditMiddleware.cs:142-148` — binding it to `context.RequestAborted` let a client that
+   closed the socket cancel its own audit row, and the fail-soft catch swallowed the cancellation. A
+   prober that disconnects on each 403 would have left no trace.
+7. **Audit in a `finally`, not on the success path.** `AlertMetricsReadUseCase.cs:56-62` — an earlier
+   version wrote nothing when the repository threw, so an enumerating secret-holder left no trace for any
+   erroring request. Plus the local `catch` at `:87-90` (rationale `:64-70`), which exists because a `finally`-sited write that
+   threw would **replace** the original exception.
+8. **Actor = the real operator under impersonation.** `data-requests.ts:268-272` (with the bug it fixed
+   written out), `trpc.ts:164`, and C# `AuditActor.ActorFor`. **13** TS sites still use bare `ctx.user.id`
+   (§1.1, enumerated there) — that is the direction of the fix, not a precedent to copy.
+9. **Resolve-or-skip on the org FK.** `access/security-audit.ts:38-42` centralizes it; the C# twin is
+   `SecurityDenialAuditMiddleware.cs:121-124`, which additionally refuses to audit unauthenticated 401s
+   so an anonymous caller cannot become an unbounded writer into an append-only table.
+10. **`ENABLE ALWAYS`, specifically.** It is what closes the `session_replication_role='replica'` bypass
+    (`cb-1b-audit-logs-immutability.md:19-20`). A regenerated `flip-ddl` or re-applied migration that
+    drops it silently reopens the hole.
+11. **The narrow grant.** `audit` read/export is `super_admin`-only
+    (`seed-access-matrix.ts:35,40`). A C# surface gated on `PlatformOwnerGate` alone is a **different**
+    and wider authorization model than the TS tenant surface it replaces.
+
+---
+
+## 7. Verification status
+
+Not applicable — documentation-only change, no code touched, so `tsc`/vitest/`dotnet test` are unchanged
+by it. Cross-model verification per `.claude/rules/verification.md` was **not run** for this document
+(⚠️ NOT RUN, not PASS). Every claim above is single-sourced to `file:line` on this branch so a reviewer
+can refute it directly.
+
+One claim is **not** verified and is marked as such in-line: whether an `organizations` row with id
+`00000000-0000-0000-0000-000000000000` exists in production (§1.1). It needs a live query.
+
+A claim-audit pass over every citation in this document ran 2026-08-10 and found 16 false claims and 8
+unsupported quantifiers. All are corrected above. The corrections that changed a **conclusion** rather than
+a number are marked in-line with a `> **Corrected 2026-08-10.**` note — §1.1 (the uncaught-writer
+consequence; the `ipAddress` count), §2.1 (a procedure name that does not exist), §3 (two counts), §4.7 (a
+quantifier its own list refuted), §5 Slice A (the slice's contents) and §5 Slice B (the hazard aimed at the
+wrong procedure).
+
+---
+
+## 8. Deliverable status against #102 and #61
+
+This section exists so the gap between "characterized" and "planned" is visible in the document rather than
+inferred from its absence.
+
+| AC                                                        | Status                                                                                                                                                                                                                                                                                               |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #102 AC1 — write `phase-5-slice-19-audit-compliance.md`   | **Not closed.** This file is the characterization under a different name (filename note above), and it says outright it is not a slice plan. No sub-plan file exists under either name.                                                                                                              |
+| #102 AC7 — derive the port slices from the sub-plan       | **Partially.** §5 recommends four slices with scope, sequencing and hazards, at roughly a paragraph each. No per-slice plan document was written, so the derivation stops at a recommendation and the four slices still need `phase-5-slice-*.md` files before anyone ports.                         |
+| #61 AC1 — delete the 4 unused procedures or record why    | **Resolved as a decision, not as code.** §5 Slice A removes `listLogs`/`getLogDetail`/`getChangesByEntity` from the port and moves them, with `getAccessReport`, into Slice D's decide-or-delete item (c), with the zero-consumer evidence recorded there. The deletion itself is still outstanding. |
+| #61 AC3 — document tenant vs platform in the slice-17 doc | **Closed.** `docs/architecture/csharp-migration/phase-5-slice-17-audit-log-read.md` now carries a dated correction block stating both the C6 drift and the two authorization models (`tenantDb` + `audit` grant vs privileged `db` + `PlatformOwnerGate`).                                           |
+
+**Why AC1 and AC7 are left open rather than papered over.** Writing four thin `phase-5-slice-*.md` files
+to satisfy a checkbox would produce exactly the artifact this document spent §0 correcting — a plan whose
+numbers nobody re-derived. The four slices have real open decisions in front of them (§5 Slice D items a–c,
+and the `ai-agents.ts:140` prod check in §1.1) that change their scope. They should be written after those
+land, not before.

--- a/docs/architecture/csharp-migration/candidate-pipeline-state-machine.md
+++ b/docs/architecture/csharp-migration/candidate-pipeline-state-machine.md
@@ -1,0 +1,867 @@
+# Candidate pipeline state machine — design spike (#103)
+
+> **Status**: design + inventory only. No code in scope. Written 2026-08-10 against `main` `013a86bd`
+> ("docs(parity): tsProcedure is OPTIONAL …", #194) on branch `docs/102-103-design-spikes`.
+>
+> Every claim below was re-derived from source at the cited `file:line`. Where this doc contradicts
+> issue #103, issue #88, issue #30, or `docs/REMAINING-WORK.md`, both sides are cited and the
+> contradiction is called out explicitly.
+>
+> **Corrected 2026-08-10 after a claim-audit pass.** The first draft stated the base commit as
+> `fc1770fb`, which is five commits behind `013a86bd`; at `fc1770fb` the `docs/REMAINING-WORK.md` row
+> cited in §8 sits at `:527`, not `:534`, so a verifier following the old header would have landed on
+> a blank line. Ten other claims were corrected; the ones that changed a **conclusion** rather than
+> only a line number carry an inline `> **Corrected 2026-08-10.**` note where they appear (§1.1, §1.2,
+> §2, §3, §D1). Deviations from #103's acceptance criteria are collected in §7.1 rather than left
+> implicit.
+
+---
+
+## 0. Three corrections to #103's premises
+
+#103's body is wrong on all three of its load-bearing claims. Since the issue proposes sequencing work
+around those claims, they are corrected first.
+
+### 0.1 `pipeline/movements.ts` and `pipeline/stages.ts` are NOT the scatter
+
+#103 states: _"the stage transition logic is procedural code spread across `pipeline/movements.ts`,
+`pipeline/stages.ts`, and the consuming domains."_
+
+Those two files are the **centralized, correctly layered** part of this domain. Verified:
+
+- `packages/api/src/routers/pipeline/movements.ts` is 88 lines, contains **6 procedures**, imports no
+  `db` (`:1-5`), and every mutation delegates to `pipelineService` (`:30`, `:44`, `:55`, `:79-86`).
+- `packages/api/src/routers/pipeline/stages.ts` is 92 lines, **6 procedures**, imports no `db`
+  (`:1-5`), delegates to `pipelineStagesService`.
+- Neither file writes `currentStageId` or `stage_movements`. The **only** stage-transition writes in
+  either file's call graph land in one repository: `pipeline.repository.ts:158` (movement row),
+  `:169-171` (`currentStageId` flip), `:188-197` (bulk movement rows), `:199-202` (bulk
+  `currentStageId` flip), `:209-220` (reject). Both multi-write paths are wrapped in
+  `runTenantTransaction` (`:157`, `:187`) with an in-code citation of #45 / prisma#17948.
+
+Correction on the task brief's own citation list: `pipeline.repository.ts:357` is **not** a write. It
+is the `RETURNING id, current_stage_id …` clause of the checklist-item `UPDATE` (`:343-358`), which
+touches `checklist_progress` only. It is a _read_ of the current stage, included in the response.
+
+**Verdict: `pipeline/*` is the model of what the rest of this domain should look like, not the
+problem.**
+
+### 0.2 The genuine scatter, which #103 does not name
+
+Three write paths outside `pipeline/*` set or should-have-set an application's pipeline position:
+
+| Site                                | What it does                                                   |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `candidate.service.ts:199-215`      | Sets the initial `currentStageId` (`:212`); writes no movement |
+| `routers/portal.ts:234-244`         | Sets the initial `currentStageId` (`:240`); writes no movement |
+| `routers/offer/lifecycle.ts:92-167` | Hires the person; never touches the application at all         |
+
+Each is verified in §2 and §4. `routers/portal.ts` additionally violates the repository rule in
+`.claude/rules/api-security.md` — it imports `db` directly at `portal.ts:4` and issues
+`db.application.create` at `:235`, with no service and no repository between the tRPC handler and
+Prisma.
+
+### 0.3 "Should precede #88" — there is no code dependency, in either direction
+
+#103 Dependencies says _"Should precede #88."_ #88's Hazards says the reverse framing: _"Consider
+doing #103's design work **first** and treating this port as its implementation."_
+
+Searched for an actual dependency. There is none, in either direction:
+
+- **No C# pipeline code exists.** `services/Tims.Platform/src` maps `applications`,
+  `pipeline_stages` and `stage_movements` in exactly one context — `Reporting/ReportingReadDbContext.cs`,
+  `DbSet`s at `:23,:25,:27` and `ToTable` at `:52-54`, `:70-72`, `:85-87` — which is documented
+  `AsNoTracking` / `SaveChanges` never called (`ReportingReadDbContext.cs:8-9`) — a read surface, not a
+  writer.
+- **No parity fixture exists** for this surface. `contracts/` contains 20 fixture directories; none
+  is `pipeline-fixtures`. The nearest, `contracts/reporting-fixtures/funnel-view.json`, pins the
+  _org-wide reporting_ funnel, which is a different query (§2.5).
+- **Nothing in `pipeline/*` blocks on a C# artifact**, and nothing in C# blocks on a TS change.
+
+**Verdict: #103 is a de-risking design doc, not a blocker on #88.** It can land before, during or
+after #88 without changing what either has to do. The reason to do it first is judgement, not
+sequencing: §3 and §4 identify defects that would otherwise be ported into a C# contract and then have
+to be redesigned there.
+
+One correction to the sequencing argument's _scope_, though. #103's genuine subject matter is not
+contained by #88. Of the three scattered writers in §0.2, **zero** are in #88's file list: the initial
+stage-set lives in `candidate/*` (#84) and `portal.ts` (#91), and the hire event lives in `offer/*`
+(#87). If this design constrains a port, it constrains **four** issues (#84, #87, #88, #91), not one.
+
+---
+
+## 1. The actual states
+
+There is **no state enum in the schema or in any shared package** — nothing in
+`packages/db/prisma/schema`, `packages/shared` or `packages/api` declares the set of legal values for
+either axis. Both axes of an application's position are free-form strings, and one of them is
+per-tenant, per-vacancy data.
+
+> **Corrected 2026-08-10.** The first draft said "no state enum **anywhere in this codebase**". That
+> is too strong: three frontend files enumerate the status set informally (§1.2), and one frontend
+> file enumerates stage _names_ (below). None of them is authoritative and none is imported by the
+> backend — but "anywhere" was false, and the qualifier changes what §5's proposal has to reconcile:
+> promoting `status` to an enum has to agree with **three** existing informal status enumerations in
+> `apps/web`, not zero.
+
+### 1.1 Axis A — pipeline stage (`applications.current_stage_id`)
+
+A stage is a **row**, not a constant: `PipelineStage` in
+`packages/db/prisma/schema/pipeline.prisma:1-21`. It carries `name` (`:5`, unconstrained `String`),
+`order` (`:6`, `Int`), `slaHours` (`:7`), `checklist` (`:8`, `Json?`), `isDefault` (`:9`), and a
+**required** `vacancyId` (`:4`) — every stage belongs to exactly one vacancy, so there are no
+org-level stage templates.
+
+`applications.currentStageId` is a required FK to it (`pipeline.prisma:28,48`). The DB constraint is
+`ON UPDATE CASCADE ON DELETE RESTRICT` (`packages/db/baseline/prod-public-schema.sql:5651-5655`).
+
+**Consequence: the set of states is per-vacancy, unbounded, user-defined, and renameable.** Any
+transition table keyed on stage _name_ is not sound. See §5.1.
+
+Stage rows are created at exactly **3** sites in application code:
+
+1. `routers/pipeline/stages.ts:38-50` → `pipeline.repository.ts:254-266` — the operator-facing CRUD.
+2. `routers/vacancy/crud.ts:478-490` — vacancy duplication copies the source vacancy's stages.
+3. `packages/db/prisma/seed-demo.ts:681-693` — demo seed only.
+
+Test-code carve-out, stated rather than assumed: §2 declares a grep scope that includes `services`,
+and that scope contains a **fourth** `INSERT INTO pipeline_stages`, at
+`services/Tims.Platform/tests/Tims.IntegrationTests/Reporting/ReportingReadFixture.cs:253`. It is raw
+SQL in an xUnit fixture, alongside `INSERT INTO applications` (`:259`) and `INSERT INTO stage_movements`
+(`:269`) in the same file and `INSERT INTO applications` at `AnchorProbeFixture.cs:245`. Those four
+statements are test scaffolding, so the design conclusion is unchanged — but "exactly 3" is a
+production-code-only count, and every quantifier in this doc that says "application code" or
+"production code" excludes exactly those C# integration fixtures and nothing else.
+
+`vacancy.create` (`routers/vacancy/crud.ts:244-332`) creates **no** stages, on either branch
+(`:303-325` autoPublish, `:328-331` plain). A freshly created vacancy therefore has zero stages until
+someone calls `pipeline.createStage`. See defect D3 in §4.
+
+Two hardcoded stage-name lists exist, and **they disagree with each other**:
+
+| Where                                             | Names                                                                                                    |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `seed-demo.ts:658-666` (7)                        | `Aplicado`, `Screening`, `Entrevista RRHH`, `Prueba Tecnica`, `Entrevista Final`, `Oferta`, `Contratado` |
+| `apps/web/lib/pipeline-next-actions.ts:34-41` (6) | `postulado`, `preseleccion`, `evaluaciones`, `entrevistas`, `oferta`, `contratado`                       |
+
+Neither is a domain constant: nothing in `packages/api` or `packages/shared` references either list,
+and no production tenant is bound to either. But the overlap is **2 of 7** — a database seeded by
+`seed-demo.ts` matches the frontend's table only on `Oferta` and `Contratado`, so 5 of the 7 demo
+stages fall through to the `null` branch at `pipeline-next-actions.ts:57`.
+
+> **Corrected 2026-08-10.** The first draft said the seed's list was "the only enumerable stage list
+> in the repo". It is not, and the second list is the live instance of the defect this doc's §5.1 is
+> designed around — see immediately below.
+
+**Name-keyed stage logic in application code today** (the concrete instances §5.1 proposes to
+eliminate; this inventory was missing from the first draft):
+
+1. **Live behaviour, admin pipeline.** `apps/web/app/(admin)/recruitment/pipeline/page.tsx:94` —
+   `getNextActionForStage(destinationStage.name)`, run in the `moveCandidate` `onSuccess` handler, to
+   pick the post-move "next action" toast and its deep link. The implementation
+   (`apps/web/lib/pipeline-next-actions.ts:50-57`) normalizes the name (trim, lowercase, strip
+   diacritics) and does an exact lookup in the 6-entry table at `:34-41`; an unmatched name returns
+   `null` and the UI falls back to a bare toast (`page.tsx:101-105`). The file's own header comment
+   (`:5-18`) names the hazard — `PipelineStage.name` is org-configurable and there is no `stageType`
+   column — and asks for the match to move onto a real column if one is ever added. Renaming a stage
+   (§2.7) silently switches this off; it is the FE-behaviour case §6 Step 1's risk assessment should
+   have covered and did not.
+2. **Display only, table view.** `pipeline-table-view.tsx:225` renders `→ {nextStage.name}` as the
+   advance-button label. Name-derived text, not name-derived logic — listed so the inventory is
+   complete, not because it needs changing.
+3. **Aggregation key, org-wide funnel.** `packages/shared/src/reporting.ts:43-48` keys its merge map
+   on `s.name` (`const merged = new Map<string, …>`; `merged.get(s.name)`), documented at `:33` as
+   "stages MERGED BY NAME (same-name stages across pipelines …)" and fed by
+   `recruitment-analytics.repository.ts:61-68`, whose doc comment at `:60` says the same. Two
+   vacancies whose equivalent stages are spelled differently therefore produce separate funnel rows.
+   Listed because it is a second, independent name-keyed behaviour; the org-wide funnel is otherwise
+   out of scope (§7).
+
+There is **no name-keyed logic in `packages/api`'s transition path**: `grep -n '\.name'` over
+`pipeline.service.ts` returns 0 hits, and over `pipeline.repository.ts` returns only `:258` and `:270`
+— the stage-CRUD create and update that _write_ the name. The transition code keys on ids and `order`
+only. The defect class is entirely in `apps/web` and in the analytics merge.
+
+### 1.2 Axis B — application status (`applications.status`)
+
+`status String @default("active")` — `pipeline.prisma:30`. Again no Prisma enum, contrary to
+`.claude/rules/db.md` § Schema Conventions ("Prisma enums for all status/type fields").
+
+Counted every writer of the column across `packages`, `apps` and `workers`:
+
+| Value       | Written at                                                         |
+| ----------- | ------------------------------------------------------------------ |
+| `active`    | schema default `pipeline.prisma:30`; seed `seed-demo.ts:756`       |
+| `rejected`  | `pipeline.repository.ts:213` (the single `rejectApplication` path) |
+| `hired`     | **nowhere** — 0 writers                                            |
+| `withdrawn` | **nowhere** — 0 writers                                            |
+
+`hired` and `withdrawn` are nevertheless rendered by the candidate-facing portal:
+`apps/web/app/(portal)/careers/[orgSlug]/dashboard/dashboard-applications.tsx` maps both to localized
+labels (`:25-26` `hired`, `:27-28` `withdrawn`) and to colours (`:34` `hired`, `:35`
+`rejected || withdrawn`). Those branches are dead code today; the i18n keys `statusHired` /
+`statusWithdrawn` exist for states no code can produce.
+
+`getBoard` exposes a third vocabulary — the filter enum `z.enum(['active','rejected','all'])` at
+`routers/pipeline/movements.ts:15`. It is the only place in **`packages/api`** where a status set is
+written down, and it is an _input filter_, not a domain type: it contains the non-status pseudo-value
+`'all'` and omits two real values.
+
+> **Corrected 2026-08-10.** The first draft called `movements.ts:15` "the only place in the stack
+> where the legal status set is written down". That is false, and it is refuted by a file this doc
+> cites two paragraphs earlier. Counted across `apps/web`, **three** frontend files enumerate the full
+> four-value set independently, and each is strictly more complete than the backend filter:
+>
+> | File                                                                           | Lines              | Values                                     |
+> | ------------------------------------------------------------------------------ | ------------------ | ------------------------------------------ |
+> | `apps/web/app/(portal)/careers/[orgSlug]/dashboard/dashboard-applications.tsx` | `:20-28`, `:34-35` | `active`, `rejected`, `hired`, `withdrawn` |
+> | `apps/web/app/(admin)/recruitment/pipeline/pipeline-table-view.tsx`            | `:54-59`           | `active`, `rejected`, `withdrawn`, `hired` |
+> | `apps/web/app/(admin)/recruitment/pipeline/pipeline-list-view.tsx`             | `:53-58`           | `active`, `rejected`, `withdrawn`, `hired` |
+>
+> This changes a conclusion, not just a number: the enum promotion proposed in §5.4 has three existing
+> frontend enumerations to reconcile — two of which are byte-identical duplicates of each other and
+> should collapse into one shared map as part of that work.
+
+### 1.3 What "the pipeline" therefore is, today
+
+`(stage_id ∈ stages(vacancy), status ∈ {active, rejected})`, with the two axes fully independent and
+neither one guarded against the other. §3 shows nothing constrains their product.
+
+---
+
+## 2. Every write path that moves a candidate between stages
+
+Exhaustive over application code. Derived by grepping `currentStageId` / `current_stage_id` /
+`CurrentStageId`, `stageMovement`, and `application.create|update|updateMany` across `packages`,
+`apps`, `workers` and `services` (excluding `node_modules`, `.next` build output, and
+`.claude/worktrees`), with the C# integration-fixture carve-out stated in §1.1.
+
+**Seven** application-row writers exist in application code. **Six** are listed below (§2.1, §2.2,
+§2.3, §2.4a, §2.4b, §2.6); the seventh, `pipeline.repository.ts:343-358` (`setChecklistItem`), writes
+only `checklist_progress` and is not a transition.
+
+The seven, in grep order:
+
+| #   | Site                             | Section | Writes                                                 |
+| --- | -------------------------------- | ------- | ------------------------------------------------------ |
+| 1   | `seed-demo.ts:749`               | §2.6    | row insert (demo only)                                 |
+| 2   | `routers/portal.ts:235`          | §2.4b   | row insert                                             |
+| 3   | `candidate.repository.ts:551`    | §2.4a   | row insert                                             |
+| 4   | `pipeline.repository.ts:169`     | §2.1    | `current_stage_id`                                     |
+| 5   | `pipeline.repository.ts:199`     | §2.2    | `current_stage_id` (bulk `updateMany`)                 |
+| 6   | `pipeline.repository.ts:210`     | §2.3    | `status`, `rejected_at`, `rejected_reason`, `feedback` |
+| 7   | `pipeline.repository.ts:343-358` | —       | `checklist_progress` (raw SQL `UPDATE`)                |
+
+> **Corrected 2026-08-10.** The first draft said "**Six** … in total. Five are listed below", under a
+> heading that says "Exhaustive." Both numbers were wrong by one, in the same direction: the seed
+> writer at `seed-demo.ts:749` is documented in §2.6 but was dropped from the tally, and rows 1–6 are
+> six listed subsections, not five. Rows 1–6 are the Prisma-client calls the declared grep returns;
+> row 7 is raw SQL and is found by the `current_stage_id` leg of the same grep, not the
+> `application.create|update|updateMany` leg — which is how it came to be counted separately in the
+> first place. Test scaffolding is excluded per the carve-out in §1.1 (`ReportingReadFixture.cs:259`,
+> `AnchorProbeFixture.cs:245`).
+
+### 2.1 `pipeline.moveCandidate` — the canonical transition
+
+`routers/pipeline/movements.ts:22-31` → `services/pipeline.service.ts:81-107` →
+`repositories/pipeline.repository.ts:146-175`.
+
+- Authz: `permissionProcedure('pipeline','update')` (`movements.ts:22`) +
+  `assertScoped('application', …)` (`movements.ts:29`).
+- Guards in the service: application exists in org (`pipeline.service.ts:82-83`); target stage belongs
+  to the application's vacancy (`:85-87`).
+- Writes, atomically under `runTenantTransaction` (`pipeline.repository.ts:157`): one
+  `stage_movements` row with `fromStageId`/`toStageId`/`movedBy`/`reason` (`:158-167`), then
+  `applications.current_stage_id = toStageId` (`:169-173`).
+- Returns `warnings` from the **soft** checklist gate (`pipeline.service.ts:89-93,106`).
+
+### 2.2 `pipeline.bulkMove` — same write, weaker guards, no UI
+
+`routers/pipeline/movements.ts:35-45` → `services/pipeline.service.ts:111-140` →
+`repositories/pipeline.repository.ts:178-206`.
+
+- Authz differs from 2.1: **no `assertScoped`**. Scope is enforced by composing
+  `scopeWhereFor('application', …)` in the router (`movements.ts:43`) and count-checking it in the
+  service (`pipeline.service.ts:120-123`) — a documented, equivalent pattern, not a gap.
+- Extra guard: all applications must share one vacancy (`pipeline.service.ts:128-133`).
+- Weaker than 2.1 in one respect: `findApplications` does **not select `status`**
+  (`pipeline.repository.ts:113-118`), where `findApplication` does (`:106-111`). Neither caller reads
+  it (§3), but the bulk path could not even if it wanted to.
+- Bounded `.max(50)` (`movements.ts:37`), deduped (`:42`).
+- **Zero frontend consumers.** `grep -rn bulkMove apps/web --include=*.ts --include=*.tsx` (excluding
+  the `.next` build output) returns 0 hits. It is a live, permissioned, unused mutation.
+
+### 2.3 `pipeline.rejectCandidate` — status-only, stage untouched
+
+`routers/pipeline/movements.ts:47-56` → `services/pipeline.service.ts:143-149` →
+`repositories/pipeline.repository.ts:209-220`.
+
+Sets `status='rejected'`, `rejectedAt`, `rejectedReason`, `feedback`. It does **not** change
+`currentStageId` and does **not** write a `stage_movements` row — so the rejection itself is invisible
+in the movement history that `getMovementHistory` (`pipeline.repository.ts:223-229`) and the candidate
+portal (`candidate-portal.repository.ts:144-147`) render.
+
+This is the **only** guard in the domain that reads `status`: `pipeline.service.ts:145` rejects a
+non-`active` application.
+
+### 2.4 Application creation — two entry points, both bypassing the movement log
+
+**(a) Staff-side.** `routers/candidate/timeline.ts:16-25` → `services/candidate.service.ts:199-215` →
+`repositories/candidate.repository.ts:544-562`. The initial stage is
+`findFirstStage` = lowest `order` (`candidate.repository.ts:536-542`), set at
+`candidate.service.ts:212`. `createApplication` (`candidate.repository.ts:551-561`) writes the
+`applications` row and nothing else.
+
+**(b) Public apply form.** `routers/portal.ts:149` `applyToVacancy`, a `publicProcedure` (Turnstile-
+gated, `portal.ts:14-29`). Stage resolution at `portal.ts:223-232`, create at `:235-244`. Also writes
+no movement row. Also imports `db` directly (`portal.ts:4`), bypassing the service/repository layers.
+
+Neither path is transactional with anything, because neither writes a second row.
+
+### 2.5 `offer.convertToEmployee` — the hire, which does not close the application
+
+`routers/offer/lifecycle.ts:20-168`. Inside one `runTenantTransaction` (`:92`) it creates the `User`
+(`:94-108`), an `OnboardingPlan` with default tasks (`:114-131`), an optional `UserTeam` (`:136-142`),
+sets `offers.status='converted'` (`:146-149`), and writes the hire-prediction snapshot (`:155-164`).
+
+It never reads or writes `applications`. Detailed in §4, defect D1.
+
+### 2.6 Seed
+
+`packages/db/prisma/seed-demo.ts:749-762` creates applications with an arbitrary `stageIdx`
+(`:754`) and an arbitrary `status` (`:756`) directly. Demo data only, but note it reproduces the same
+gap: no `stage_movements` rows are seeded, so a seeded database exercises the empty-audit-trail path
+on every read.
+
+### 2.7 Stage-configuration writes that change the meaning of existing rows
+
+Not transitions, but they mutate the state space under live applications and belong in any state
+machine's threat model:
+
+- `pipeline.updateStage` (`routers/pipeline/stages.ts:54-67` → `pipeline.repository.ts:268-281`) can
+  change a stage's `order` or `name` with applications sitting in it. Reordering silently rewrites
+  every historical funnel and "advance" affordance; renaming breaks any name-keyed logic (§5.1).
+- `pipeline.deleteStage` (`stages.ts:69-74` → `pipeline-stages.service.ts:46-57`) refuses only when
+  `_count.applications > 0` (`:49-54`) — i.e. when applications are _currently_ in it. History is not
+  consulted. See defect D4.
+
+### 2.8 Who reads the result
+
+- **`stage_movements` — TS.** `pipeline.repository.ts:223-229` (history), `:365-379` and `:382-397`
+  (`movements[0].movedAt` = entered-stage time for SLA), `:429-433` (funnel `everReachedCount`,
+  `distinct: ['applicationId']`); `recruitment-analytics.repository.ts:115-119`, `:163-167`.
+- **`stage_movements` — C#.** `Reporting/ReportingReadDbContext.cs:27,85-87` mapping;
+  `Reporting/ReportingReadRepository.cs:166`, `:191` (`LastMovedAt`). Read-only.
+- **Candidate portal.** `candidate-portal.repository.ts:135-150` returns `currentStage.name` plus the
+  full descending movement list to `candidatePortal.applicationStatus`
+  (`routers/candidate-portal.ts:39-43`).
+- **AI.** `pipeline.getNextBestAction` (`routers/pipeline/analytics.ts:16-21` →
+  `pipeline-analytics.service.ts:70-90`) feeds `currentStage.name`/`.order` to the
+  `pipeline-optimizer` Bedrock agent. It is a **query**, pulled on demand — not a fan-out from a move.
+
+Two ownership facts: `applications`, `pipeline_stages` and `stage_movements` are all
+`efcoreReadOnly` (`docs/architecture/table-ownership.md:78,80,81`), i.e. Prisma owns the DDL and the
+writes; C# only SELECTs.
+
+### 2.9 What does NOT happen on a transition — correcting #30
+
+#30 states: _"pipeline stage movements fan out into analytics, notifications, audit, AI agents, and
+the candidate portal."_ Two of those five are false as descriptions of the _write_ path:
+
+- **Notifications: none.** `packages/api/src/services/email.service.ts` has 6 methods
+  (`:5,:22,:41,:54,:66,:79`), all interview- or offer-related; the only callers are
+  `routers/offer/signing.ts:66,215,309` and `routers/interview/crud.ts:217,288,392`. There is no
+  `notification.create` and no `sendEmail` anywhere in the pipeline call graph.
+- **Audit: none.** `withAudit` (`trpc.ts:153-178`) is applied only by `auditedProcedure`
+  (`trpc.ts:237`), and `grep -rn auditedProcedure packages apps` (`.ts`/`.tsx`, excluding
+  `node_modules` and `.claude/worktrees`) returns **exactly one hit — its own
+  definition**. Zero routers use it. `permissionProcedure` is
+  `protectedProcedure.use(requirePermission(...))` (`trpc.ts:328-330`) with no audit middleware, so a
+  stage move writes **no `audit_logs` row**. The `stage_movements` table is the entire audit trail for
+  this domain — which is why the two gaps in §4 matter more than they look.
+
+Analytics, the AI agent and the portal do read the result (§2.8) — but all three **pull**. Nothing is
+pushed. That is a useful property for the port: there is no existing fan-out contract to preserve, so
+the event-driven-vs-direct-call decision #103 asks for is a **greenfield** choice (§5.5), not a
+migration of something live.
+
+---
+
+## 3. Headline finding — CONFIRMED: there is no legal-transition guard
+
+**Claim under test (#103 comment): _"there is no legal-transition guard at all —
+`pipeline.service.ts:82-108` only emits soft warnings. Any stage can move to any stage."_**
+
+**Confirmed, and it is broader than stage-to-stage.**
+
+`pipeline.service.ts:81-107` in full contains exactly three checks:
+
+| Line     | Check                                   | Fails how                   |
+| -------- | --------------------------------------- | --------------------------- |
+| `:82-83` | application exists in this org          | `NOT_FOUND`                 |
+| `:85-87` | `toStageId` belongs to the same vacancy | `BAD_REQUEST`               |
+| `:89-93` | source stage's checklist complete?      | **never fails** — see below |
+
+The third is explicitly non-blocking. `getIncompleteChecklistWarnings`
+(`pipeline.service.ts:39-50`) returns labels; the service attaches them to the response at `:106` and
+`:103-105`'s comment states the shape is deliberately static so tRPC infers one type. The comment at
+`:76-80` states the intent outright: _"the move still proceeds … Never throws for this."_ Wired to the
+UI as a warning toast, `apps/web/app/(admin)/recruitment/pipeline/page.tsx:83-84` (the first draft
+cited `:101-105`, which is the logical complement — the `else if (!data.warnings || …)` branch that
+fires the bare success toast when there is nothing to warn about).
+
+What is therefore **not** checked, verified by reading the whole function:
+
+1. **Order.** Nothing compares `stage.order` of source and target. `Oferta → Aplicado` is legal.
+   `Aplicado → Contratado` in one hop is legal.
+2. **Self-transition.** Nothing compares `toStageId` to `application.currentStageId`. Moving a card
+   onto its own stage writes a `from == to` movement row (`pipeline.repository.ts:158-167`), which
+   **resets the SLA clock** — `enteredStageAt` is `movements[0]?.movedAt ?? app.appliedAt`
+   (`pipeline.service.ts:70`, `pipeline-analytics.service.ts:23,39`). A recruiter can clear an overdue
+   flag by dragging a card onto its own column. The Kanban view blocks the gesture client-side
+   (`kanban-board.tsx:32`), but the mutation does not, and `bulkMove` has no equivalent check at any
+   layer.
+3. **Status.** `moveCandidate` fetches `status` (`pipeline.repository.ts:109`) and **never reads it**.
+   A `rejected` application can be moved through stages indefinitely. `bulkMove` cannot even see it
+   (`:113-118`). Only `rejectCandidate` (`pipeline.service.ts:145`) consults `status`, and only to
+   prevent double-rejection.
+4. **Terminality.** No stage is marked terminal. `isDefault` (`pipeline.prisma:9`) marks a
+   start-ish stage, is never read by any service in `packages/api/src/services/pipeline*.ts`, and has
+   no `isFinal` counterpart.
+
+**No guard exists in any other layer either.** The routers validate shape only
+(`movements.ts:23-27`, `:36-40`); the repository has no conditional logic; the DB has one FK
+(`prod-public-schema.sql:5651-5655`) and no `CHECK`.
+
+The frontend partially compensates and thereby hides the gap: the list and table views each offer a
+single forward affordance, while the Kanban board allows any drop except onto the same column
+(`kanban-board.tsx:30-34`). Three views, three different implied rule sets, none of them enforced.
+
+> **Corrected 2026-08-10.** The first draft said both views advance to `stages[stageIdx + 1]` and
+> labelled both "Avanzar →". Neither half is right, and the difference matters:
+>
+> | View                      | Next stage computed as                                                            | Button label                  |
+> | ------------------------- | --------------------------------------------------------------------------------- | ----------------------------- |
+> | `pipeline-list-view.tsx`  | `stages[stageIdx + 1]` (`:89`), button `:128-135`                                 | `Avanzar →` (`:133`)          |
+> | `pipeline-table-view.tsx` | `stageList.find(s => s.order === app.stageOrder + 1)` (`:181`), button `:223-227` | `→ {nextStage.name}` (`:225`) |
+>
+> The table view resolves the next stage by **`order` arithmetic**, not by array position. Those agree
+> only when `order` values are contiguous and unique — which nothing enforces (§5.6 Q4). On a vacancy
+> whose stages are ordered `0,1,3`, the list view's advance button still works and the table view's
+> disappears. This is a second, independent argument for Q4 that the first draft missed by collapsing
+> the two implementations into one citation.
+
+---
+
+## 4. Data-integrity defects
+
+### D1 — `convertToEmployee` hires without closing the application (CONFIRMED)
+
+`routers/offer/lifecycle.ts:92-167`. The transaction writes `users`, `onboarding_plans`,
+`onboarding_tasks`, `user_teams`, `offers.status='converted'` and `hire_predictions`. It never
+touches `applications`.
+
+The link is available and already in scope: `offer.applicationId` is passed to the snapshot writer at
+`lifecycle.ts:161`. Adding the application write would cost one statement inside the existing
+transaction.
+
+Verified consequences:
+
+- The application stays `status='active'` (§1.2 — nothing writes `hired`) and stays in whatever stage
+  it was in when the offer was signed. It remains on the Kanban board as a live candidate.
+- It keeps counting as active everywhere: `pipeline.repository.ts:423` (funnel `currentCount`),
+  `:367` and `:384` (SLA sets), `recruitment-analytics.repository.ts:75,158`,
+  `Reporting/ReportingReadRepository.cs:67`.
+- It keeps **accruing SLA overdue time forever**. `getOrgSlaOverdueCount`
+  (`pipeline-analytics.service.ts:16-27`) compares elapsed time against the stage SLA (`:21-26`); the
+  `status: 'active'` predicate that puts the row in that set is one layer down, in
+  `getActiveApplicationsForOrgSla` (`pipeline.repository.ts:367`) — the same line cited two bullets
+  above. Every hire permanently inflates the dashboard KPI strip.
+- The candidate's own portal keeps showing the application as in-progress
+  (`dashboard-applications.tsx:22`, since `hired` is unreachable).
+- Reporting counts hires from `offers.status='accepted'` instead: C#
+  `ReportingReadRepository.cs:74-75` (`_db.Offers.CountAsync(o => … o.Status == AcceptedStatus)`), TS
+  equivalent `recruitment-analytics.repository.ts:47-49` (`countOffersAcceptedAllTime`, predicate at
+  `:48`) — so the _reports_ are right and the _pipeline_ is wrong, which is exactly the shape of bug
+  that survives a long time.
+
+> **Corrected 2026-08-10.** The first draft cited `recruitment-analytics.repository.ts:100` as the TS
+> hire count. That line is `take: 10_000`, a memory cap inside `hireSources` (`:93-102`) — a function
+> that returns application _sources_, not a count, and so is not the equivalent of C#'s `totalHired` at
+> all. The correct counterpart is `countOffersAcceptedAllTime` (`:47-49`), a different function this
+> doc did not previously cite. The conclusion (reporting derives hires from `offers`, never from
+> `applications`) is unchanged and now rests on a function that actually does that.
+
+Note the asymmetry with rejection, which is handled (`pipeline.repository.ts:209-220`). The pipeline
+has a loss terminal and no win terminal.
+
+### D2 — applications are created with an empty audit trail (CONFIRMED)
+
+Both creation paths (§2.4) write `applications.current_stage_id` and **no** `stage_movements` row:
+`candidate.repository.ts:551-561` and `portal.ts:235-244`. `stage_movements.fromStageId` is nullable
+precisely for this case (`pipeline.prisma:65`) and is never used.
+
+Verified consequences:
+
+- **`pipeline.getFunnel` undercounts its own first stage.** `everReachedCount` is
+  `stage_movements.distinct(applicationId)` where `toStageId = stage.id`
+  (`pipeline.repository.ts:429-433`). An application that has never moved contributes to no stage's
+  `everReachedCount`. Since stage 0's `conversionRate` divides `everReached` by `totalApplications`
+  (`pipeline-analytics.service.ts:101-105`), a brand-new vacancy where nobody has been moved yet
+  reports **0% conversion into the stage every applicant is already in**, and every downstream stage's
+  rate is computed off that zero.
+  Scope note: this is the **per-vacancy** funnel. The org-wide reporting funnel groups on
+  `currentStageId` instead (`recruitment-analytics.repository.ts:72-78`, C#
+  `ReportingReadRepository.cs:66-70`) and is unaffected — two different funnels with two different
+  definitions of "reached", which is itself worth resolving during the port.
+- **The candidate sees an empty timeline.** `findApplicationDetail`
+  (`candidate-portal.repository.ts:135-150`) returns `currentStage.name` plus `movements[]`. Until
+  someone moves the card, the candidate is shown a current stage with no history explaining how they
+  got there.
+- **Time-in-stage silently falls back.** `movements[0]?.movedAt ?? app.appliedAt` appears at four
+  sites, all verified by grep: `pipeline.service.ts:70` (board), `pipeline-analytics.service.ts:23`
+  (org SLA count) and `:39` (per-vacancy SLA status), and
+  `alert-evaluation.repository.ts:257` (SLA-breach alert rule). This masks D2 for SLA purposes —
+  correct behaviour, but it means the missing row produces a _wrong number_ in one place and a
+  _right number_ in another, so it will not show up as a consistent symptom.
+
+  > **Corrected 2026-08-10.** The first draft cited `pipeline.repository.ts:70` for this expression,
+  > three times (here, §3 item 2, and §6 Step 4). Lines `:68-70` of that file are a
+  > `// ---` comment separator; the repository object opens at `:72`. The expression is in the
+  > **service**, `pipeline.service.ts:70`. The substance survives — the fallback is real and is now
+  > cited at four sites instead of three — but §6 Step 4's decision to ship D2's fix **without a
+  > backfill** rested entirely on this evidence, and a reviewer opening the cited line would have found
+  > a comment and been unable to check it.
+
+- **`movedBy` is the obstacle to a clean fix.** `stage_movements.movedBy` is a required FK to `users`
+  (`pipeline.prisma:67,74`; DB `ON DELETE RESTRICT`,
+  `prod-public-schema.sql:6586`). The public apply flow has **no user** — `portal.applyToVacancy` is a
+  `publicProcedure` (`portal.ts:149`). Any fix must either make `movedBy` nullable or mint a system
+  actor. This is a schema decision, and it is the reason D2 is not a one-line fix. See §5.4.
+
+### D3 — a vacancy with no stages fails two different ways (found while verifying §1.1)
+
+`vacancy.create` seeds no stages (`routers/vacancy/crud.ts:244-332`). Applying to such a vacancy:
+
+- staff path → a clean `BAD_REQUEST` with a Spanish message (`candidate.service.ts:201-206`);
+- public path → `db.pipelineStage.findFirstOrThrow` (`portal.ts:227-232`), i.e. an unhandled Prisma
+  `P2025` surfacing as a 500 on an **unauthenticated public endpoint**.
+
+Same precondition, two behaviours, one of them a stack-trace-shaped error on the public apply form.
+
+### D4 — `deleteStage` consults current occupancy but not history (found while verifying §2.7)
+
+`pipeline-stages.service.ts:46-57` blocks deletion only when `_count.applications > 0`. A stage that
+has no current occupants but appears in historical movements is deletable, and the DB then applies:
+
+- `stage_movements.from_stage_id` → `ON DELETE SET NULL` (`prod-public-schema.sql:6579`) — history is
+  silently rewritten, "moved from Screening" becomes "moved from ∅";
+- `stage_movements.to_stage_id` → `ON DELETE RESTRICT` (`prod-public-schema.sql:6593`) — so the
+  delete actually _fails_, with a raw Prisma FK error rather than the friendly guard at `:50-54`,
+  because `pipeline.repository.ts:290-292` has no error handling.
+
+The Prisma schema (`pipeline.prisma:72-73`) declares no explicit `onDelete`, so these are Prisma's
+implicit defaults (SetNull for the optional relation, Restrict for the required one) — they match the
+live DB, but they were never a decision. Contrast `.claude/rules/db.md`: _"Cascades: explicit
+`onDelete:` on every `@relation`."_
+
+Also note `stage_movements.application_id` is `ON DELETE CASCADE`
+(`prod-public-schema.sql:6572`): hard-deleting an application destroys its audit trail. No code
+hard-deletes applications today (§2 lists no delete), so this is latent, not live.
+
+---
+
+## 5. Proposed state machine
+
+Design target: **one transition kernel, two stacks, one truth.** Everything below is a proposal for
+review, not a decided architecture.
+
+### 5.1 Stages stay data; the state machine keys on `order` and role, never on `name`
+
+Given §1.1 — stages are tenant-authored rows with editable names — a hardcoded stage graph is not
+possible without a migration that would break every existing tenant. The proposal is a **stage-role
+overlay** on the existing rows:
+
+| Concept            | Where it comes from                                                  |
+| ------------------ | -------------------------------------------------------------------- |
+| Position           | `pipeline_stages.order` (exists, `pipeline.prisma:6`)                |
+| Entry stage        | `isDefault` (exists, `pipeline.prisma:9`, currently read by nothing) |
+| Terminal-win stage | **new** `isTerminalWin` — does not exist today                       |
+| Lifecycle state    | `applications.status`, promoted to a Prisma enum                     |
+
+The transition kernel then operates on `(fromOrder, toOrder, status, stageRole)` — all
+tenant-agnostic — and never sees a stage name. The three places that key on a name today are
+inventoried in §1.1; only the first of them (`page.tsx:94` → `pipeline-next-actions.ts`) is behaviour,
+and it is a display-layer nudge that already degrades to `null` on an unmatched name, so it does not
+block the kernel — it is simply the live proof that the hazard is not hypothetical.
+
+### 5.2 Proposed legal transitions
+
+**Status axis** (`applications.status`, proposed enum `ACTIVE | REJECTED | HIRED | WITHDRAWN`):
+
+```
+ACTIVE ─→ REJECTED    (pipeline.rejectCandidate — exists today)
+ACTIVE ─→ HIRED       (offer.convertToEmployee — MISSING today, defect D1)
+ACTIVE ─→ WITHDRAWN   (no writer exists today; the FE already renders it — §1.2)
+REJECTED ─→ ACTIVE    (reinstatement; needs an explicit decision, see §5.6 Q3)
+HIRED ─→ *            forbidden (terminal)
+```
+
+**Stage axis**, legal only while `status = ACTIVE`:
+
+```
+∅            ─→ entry stage           (application created; MUST write a movement — D2)
+order = n    ─→ order = n+1           forward one step        — always legal
+order = n    ─→ order > n+1           forward skip            — legal, WARN + require reason
+order = n    ─→ order < n             backward                — legal, require reason
+order = n    ─→ order = n             self                    — REJECT (currently allowed, §3.2)
+any          ─→ any                   while status ≠ ACTIVE   — REJECT (currently allowed, §3.3)
+```
+
+Rationale for keeping skips and backward moves legal: recruiting genuinely does both, and today they
+are unrestricted, so forbidding them is a behaviour change that would break live tenants. Making them
+_require a reason_ converts an invisible action into an auditable one at zero migration cost — `reason`
+already exists on the wire (`movements.ts:26`) and on the row (`pipeline.prisma:68`), it is simply
+optional.
+
+#### Side effects — what each transition WRITES
+
+_Added 2026-08-10._ #103's AC#2 asks for "states, legal transitions, guards, **and side effects**".
+The first draft delivered the first three and treated §5.5's fan-out discussion as the fourth; fan-out
+is notification, not a write contract, so the port had nothing to implement against. Every row below
+is the observed behaviour at the cited lines, followed by what the proposal changes.
+
+| Transition                        | Entry point                      | Writes TODAY                                                                                                                                                                                                                         | Atomic?                                                       | Proposal adds                                                                                                 |
+| --------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `∅ → entry stage` (staff)         | `candidate.service.ts:199-215`   | 1 `applications` row (`candidate.repository.ts:551-561`), `current_stage_id` = lowest `order` (`:536-542`)                                                                                                                           | single write, so trivially                                    | + 1 `stage_movements` row, `from_stage_id = NULL` (D2), in one tx                                             |
+| `∅ → entry stage` (public)        | `portal.ts:223-244`              | 1 `applications` row (`:235-244`); then, if `cvFileKey` is in this org's prefix, a `candidate_documents` row + CV parse (`portal.ts:255-262` → `portal-application.service.ts:45,53-54`), non-fatal on failure (`:59-68`)            | no — CV ingest is outside any tx and deliberately best-effort | + 1 `stage_movements` row (D2), which needs a `movedBy` decision (Q2)                                         |
+| `stage n → stage m` (single)      | `pipeline.service.ts:81-107`     | 1 `stage_movements` row (`pipeline.repository.ts:158-167`) + `applications.current_stage_id` (`:169-173`)                                                                                                                            | yes — `runTenantTransaction` (`:157`)                         | nothing new; guards only                                                                                      |
+| `stage n → stage m` (bulk, ≤50)   | `pipeline.service.ts:111-140`    | N `stage_movements` rows (`pipeline.repository.ts:188-197`) + N `current_stage_id` via `updateMany` (`:199-202`)                                                                                                                     | yes — `runTenantTransaction` (`:187`)                         | nothing new; guards only                                                                                      |
+| `ACTIVE → REJECTED`               | `pipeline.service.ts:143-149`    | `applications.status='rejected'`, `rejected_at`, `rejected_reason`, `feedback` (`pipeline.repository.ts:209-220`). **No movement row. No stage change.**                                                                             | single write                                                  | + a movement row, so rejection appears in the timeline it currently skips                                     |
+| `ACTIVE → HIRED`                  | `offer/lifecycle.ts:20-168`      | `users` (`:94-108`), `onboarding_plans` + default `onboarding_tasks` (`:114-131`), optional `user_teams` (`:136-142`), `offers.status='converted'` (`:146-149`), `hire_predictions` (`:155-164`). **Nothing on `applications`** (D1) | yes — `runTenantTransaction` (`:92`)                          | + `applications.status='hired'` and, if Q1 says yes, a terminal stage move + movement row, inside the same tx |
+| `ACTIVE → WITHDRAWN`              | —                                | no writer exists (§1.2)                                                                                                                                                                                                              | n/a                                                           | whole transition is new                                                                                       |
+| checklist tick (not a transition) | `pipeline.repository.ts:343-358` | `applications.checklist_progress` only                                                                                                                                                                                               | single statement                                              | unchanged; feeds guard 2's soft warning                                                                       |
+
+Three write-contract facts fall out of the table and belong in the C# port's spec:
+
+1. **No transition writes an `audit_logs` row, on either stack** (§2.9), so `stage_movements` is the
+   entire trail — and of the six transitions that exist today, **four write no `stage_movements` row
+   at all**: both entry paths, rejection, and the hire. Only the single and bulk stage moves do.
+2. **`ACTIVE → HIRED` is the only transition that writes outside the pipeline's own tables**, and it
+   writes six of them. If the kernel is to own the transition, D1's fix must stay inside
+   `offer/lifecycle.ts`'s existing transaction rather than becoming a second call.
+3. **The public entry path is the only one with a non-transactional side effect** (CV ingest). That is
+   deliberate and documented; the port must not "fix" it into the transaction, or a flaky S3 fetch
+   starts rolling back applications.
+
+### 5.3 Guards, and which are new
+
+| #   | Guard                                             | Today                                       | Proposed  |
+| --- | ------------------------------------------------- | ------------------------------------------- | --------- |
+| 1   | target stage belongs to the application's vacancy | enforced, `pipeline.service.ts:85-87`       | keep      |
+| 2   | source-stage checklist complete                   | soft warn, `pipeline.service.ts:89-93`      | keep soft |
+| 3   | `status = ACTIVE`                                 | **absent**                                  | hard fail |
+| 4   | `toStageId ≠ currentStageId`                      | **absent** (FE-only, `kanban-board.tsx:32`) | hard fail |
+| 5   | backward / skip requires a non-empty `reason`     | **absent**                                  | hard fail |
+| 6   | no transition out of a terminal status            | **absent**                                  | hard fail |
+| 7   | entry into the pipeline writes a movement row     | **absent** (D2)                             | invariant |
+
+Guards 3, 4 and 6 are strictly narrowing and can ship independently of the port. Guard 5 is a UX
+change and needs product sign-off.
+
+### 5.4 Where the guard lives — the cross-stack contract
+
+Follow the established golden-fixture pattern — `contracts/` holds **20** `*-fixtures` directories
+today (plus `contracts/openapi/`), so this is the house pattern, not a new one. Verified end-to-end
+against the reporting slice:
+
+1. **A pure kernel in `packages/shared`** — sibling of `packages/shared/src/reporting.ts`,
+   `compensation.ts`, `dei.ts`, `engagement.ts`, `ninebox.ts`, `succession.ts`, `team-intel.ts`.
+   Signature shape: `evaluateTransition(input) → { allowed, code, warnings }`. Pure: no `db`, no
+   `TRPCError`, no clock, no I/O.
+2. **A mirror kernel in `Tims.Domain`** — sibling of `Tims.Domain.Reporting`.
+3. **A golden fixture at `contracts/pipeline-fixtures/transition-kernel.json`**, asserted by both
+   sides from the one file. The mechanism is already wired: the TS side reads it directly
+   (`tests/reporting/funnel-view-fixtures.test.ts:20`) and the C# side links `contracts/*` into the
+   test assembly (`tests/Tims.UnitTests/Tims.UnitTests.csproj:67-68`) and reads it from
+   `AppContext.BaseDirectory` (`Fixtures/KpiViewFixtureTests.cs:21`). A `pipeline-fixtures` glob needs
+   one more `<Content Include>` entry in that `.csproj`.
+4. **The DB stays the last line, not the only one.** `applications.status` becomes a Prisma enum
+   (`.claude/rules/db.md` § Schema Conventions), which makes `hired`/`withdrawn` representable and
+   makes typos unrepresentable. Order/status _combinations_ stay in the kernel — a `CHECK` constraint
+   cannot see the stage row.
+
+Callers of the kernel, all of which must go through it once it exists: `pipeline.service.ts` (2.1,
+2.2), `candidate.service.ts` (2.4a), `portal.ts` (2.4b, which needs a service+repository first — §0.2),
+`offer/lifecycle.ts` (2.5).
+
+Fixture cases the kernel must pin, at minimum, one per row of §5.2 plus: same-stage rejection;
+transition attempted on a `REJECTED` row; forward-skip with and without a reason; entry with a null
+`fromStageId`; and a stage whose `order` ties another stage's `order` (nothing prevents duplicate
+`order` values today — `stages.ts:42` validates only `min(0)`).
+
+### 5.5 Fan-out — recommendation: keep it pull-based
+
+#103 asks for an event-driven vs direct-call decision. §2.9 establishes that **there is nothing to
+migrate**: no notification, no audit write, and no push of any kind happens on a transition today.
+Analytics, the AI agent and the portal all read on demand.
+
+Recommendation: **do not introduce a message bus as part of this port.** Preserve pull. Introduce the
+`stage_movements` row as the single append-only event record it already is, and if a future feature
+needs push (candidate stage-change emails are the obvious one), add it then, as its own issue, with
+the coexistence rule satisfied by the owning stack writing its own table.
+
+The one thing the port **must** add is the missing audit coverage — §2.9 shows `permissionProcedure`
+carries no audit middleware, so a stage transition currently produces no `audit_logs` row on either
+stack. That is a compliance question, not a design preference, and it should be raised separately
+rather than absorbed silently here.
+
+### 5.6 Open questions requiring a human decision
+
+- **Q1.** Should `convertToEmployee` set `status = HIRED` **and** move the application to a terminal
+  stage, or only set the status? Setting only the status leaves the card sitting in "Oferta" on the
+  board with a `HIRED` badge. Moving it requires knowing which stage is terminal, which requires
+  `isTerminalWin` (§5.1), which requires a per-tenant backfill.
+- **Q2.** What `movedBy` does the public apply flow use (D2)? Nullable column, or a seeded system
+  user per org? Nullable is a smaller migration; a system user keeps the FK honest and every
+  `stage_movements` row attributable.
+- **Q3.** Is `REJECTED → ACTIVE` reinstatement a supported operation? `pipeline.service.ts:145`
+  currently forbids re-rejecting but nothing un-rejects, and `rejectedAt`/`rejectedReason` have no
+  clearing path.
+- **Q4.** Should stage `order` be made unique per vacancy? Nothing enforces it today
+  (`pipeline.prisma:1-21` has no `@@unique([vacancyId, order])`), and ties make "forward one step"
+  ambiguous.
+
+---
+
+## 6. Migration path that does not break existing rows
+
+Ordered so that each step is independently shippable and independently revertable. No step requires a
+backfill that can fail on live data.
+
+**Step 1 — narrowing guards only, no schema change.** Add guards 3, 4 and 6 (§5.3) in
+`pipeline.service.ts`. These reject inputs that are currently accepted; they cannot corrupt existing
+rows because they only ever refuse a _new_ write. Risk: a client that today relies on same-stage moves
+starts getting `BAD_REQUEST` — verified as low, since `kanban-board.tsx:32` already suppresses the
+gesture and `bulkMove` has zero FE callers (§2.2). The remaining FE surface to check is the
+`moveCandidate` `onSuccess` handler at `page.tsx:77-106`: it fires two independent toasts and calls
+`getNextActionForStage(destinationStage.name)` (`:94`, §1.1). A guard that turns a move into a
+`BAD_REQUEST` short-circuits to the `onError` handler at `:73-76` — which rolls the optimistic move
+back from the query cache (`:74`) and shows the server message — and never reaches either toast, so
+the narrowing is safe there too — but that path was not covered by the first draft's "verified as low"
+and is now.
+
+**Step 2 — extract the kernel, behaviour-identical.** Move the Step-1 predicates into
+`packages/shared`, add the golden fixture, add the C# mirror. Pure refactor on the TS side; the fixture
+is the proof. No production behaviour change.
+
+**Step 3 — close D1.** One statement in the existing `runTenantTransaction` at
+`offer/lifecycle.ts:92`, writing the application's terminal state. Forward-only: existing already-
+converted offers stay as they are. A separate, reversible backfill script can then reconcile
+historical rows by joining `offers.status='converted'` → `offers.application_id`; it should be
+reviewed and run once, not embedded in the deploy.
+
+**Step 4 — close D2, additively.** Resolve Q2, then write the entry movement row in both creation
+paths inside a transaction with the application insert. **Do not backfill.** Every reader already
+tolerates a missing movement via `movements[0]?.movedAt ?? app.appliedAt` — all four sites:
+`pipeline.service.ts:70`, `pipeline-analytics.service.ts:23,39`, `alert-evaluation.repository.ts:257`
+(corrected from `pipeline.repository.ts:70`, a comment separator — see the note in §D2) — so
+historical rows keep working untouched. The funnel undercount (§D2) heals forward for new
+applications; whether to synthesize historical entry rows from `applications.applied_at` is a
+separate, optional, reviewable script.
+
+**Step 5 — `status` becomes a Prisma enum.** Only safe after Step 3, because the enum must contain
+`HIRED`/`WITHDRAWN` and the column must contain no value outside the enum. Verify against prod first:
+`SELECT DISTINCT status FROM applications` — expected `{active, rejected}` per §1.2, but **verify, do
+not assume**; nothing has ever constrained this column. Per `.claude/rules/db.md` § Migration
+Discipline, this lands as reviewed SQL applied via psql, with `packages/db/baseline/prod-public-schema.sql`
+re-captured in the same PR and `/gate` check 16 passing.
+
+**Step 6 — `isTerminalWin` (Q1), if Q1 says yes.** Nullable/defaulted boolean, backfilled per tenant
+by an operator, not by a script guessing at stage names.
+
+**Step 7 — the C# port (#88)** then implements against a specified machine instead of a described one.
+
+Ordering constraint worth stating plainly: Steps 1–4 are **TS-only and unblocked today**. None of them
+requires #88, and #88 does not require them. They can proceed in parallel with any other Phase-5 work.
+
+---
+
+## 7. Scope: what is deliberately NOT in this spike
+
+#103's acceptance criteria include _"Golden-fixture the transition kernel across both stacks before
+any endpoint work."_ **That is L-sized code work and does not belong under a `type:spike` label.** It
+means: a new `packages/shared` kernel, a new `Tims.Domain` assembly, a new `contracts/pipeline-fixtures/`
+directory, a new `<Content Include>` in `tests/Tims.UnitTests/Tims.UnitTests.csproj:67-68`, vitest
+coverage on one side and xUnit on the other, and refactoring four call sites (§5.4) onto it. It should
+be filed as its own issue, blocked on this doc, and sized alongside #88.
+
+This doc also does **not** cover:
+
+- the six pipeline-stage-configuration procedures (`routers/pipeline/stages.ts`) beyond §2.7's
+  observation that they mutate the state space;
+- `pipeline.getNextBestAction`'s Bedrock agent (#43 notes its live smoke test was never run);
+- the three analytics reads (`routers/pipeline/analytics.ts:8,16,23`), except where they consume
+  movement rows;
+- the `portal.ts` layering violation (§0.2), which needs its own fix regardless of this design.
+
+### 7.1 Deviations from #103's acceptance criteria, stated rather than left implicit
+
+_Added 2026-08-10._ Four of #103's requirements are not met as written. A deviation that is argued is
+a decision; a deviation that is silent is a defect, and all four were silent in the first draft.
+
+| #103 requirement                                                                            | Status here                                                                                               |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| AC#1: write `docs/architecture/csharp-migration/phase-5-slice-20-pipeline-state-machine.md` | **Not met — this file should be renamed.** See below.                                                     |
+| AC#2: states, transitions, guards **and side effects**                                      | Met as of 2026-08-10; the side-effect contract is the table in §5.2. It was missing from the first draft. |
+| AC#5: golden-fixture the kernel across both stacks                                          | **Deliberately declined** (§7 above) and **not yet tracked** — no follow-up issue exists.                 |
+| Verification block: two `tsc` runs, `npx vitest run`, `dotnet test`, gitleaks, tier record  | N/A for a text-only change, except the tier record, which is a PR-body requirement — see below.           |
+
+**AC#1 — the filename.** #103 names an exact path and this doc does not use it. Of the 44 files in
+`docs/architecture/csharp-migration/`, 32 are `phase-*` (21 of them `phase-5-slice-*`) and 12 use a
+topic name or a runbook name instead, so the convention is dominant but not universal — which is
+presumably how the deviation went unnoticed. It is not defensible here:
+#103's AC names the file explicitly, `slice-18` is the highest number in use so `slice-20` is free, and
+nothing in the repo links to the current name (`grep -rn candidate-pipeline-state-machine` over `*.md`,
+`*.ts`, `*.tsx`, `*.json` returns only this file). **It should be renamed to
+`phase-5-slice-20-pipeline-state-machine.md` before this lands** — a single `git mv`, with the
+`docs/REMAINING-WORK.md:534` row (§8) pointed at the new path in the same commit. It is left unrenamed
+in this editing pass only because the pass was scoped to the file's contents.
+
+**AC#5 — declined here, and now filed as #196.** §7 argues the golden-fixture work out of scope for a
+`type:spike`: it is L-sized code, not design. It is tracked as **#196** ("Golden-fixture the pipeline
+transition kernel across both stacks"), so the criterion has an owner rather than sitting deferred
+inside this document.
+
+> **Corrected 2026-08-10.** This paragraph previously said no such issue existed and cited
+> `gh issue list --state open` as matching "only #103 and #88" on `pipeline|kernel|transition|fixture`.
+> Re-run against open issue TITLES, that pattern returns **three**: #88, #103 and **#122** (which matches
+> on _fixture_ — it is C# test-fixture drift, not a golden-fixture kernel harness). The conclusion held,
+> but the command was not reproducible as written, which is the defect class this section exists to close.
+
+**Verification tier.** `.claude/rules/verification.md` requires the PR body to carry a
+`## Verification` section naming **which tier actually ran**, or CI's `verification-gate` job fails the
+PR; and it requires that a tier-2/tier-3 fallback is not described as "cross-model". Nothing in this
+doc records that, and a text-only doc does not exempt the PR from it.
+
+**Baseline reconciliation.** #103's Verification block pins the suite at "282 files / 2615 tests green
+at `eaac76eb`". That is stale by a wide margin: the current anchor is **3046 passing across 310 files**
+(`.claude/commands/gate.md:48`, as of 2026-08-10) — **431 tests and 28 files** above #103's figure.
+Anyone re-running #103's checklist against its own stated baseline risks "correcting" the anchor
+downward, which is the same defect class as a gate that cannot fail. Use the gate's number, not the
+issue's.
+
+## 8. Claims in the source material this doc contradicts
+
+| Source                                                                                   | This doc                                                                                   |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| #103: transition logic is "spread across `pipeline/movements.ts`, `pipeline/stages.ts`"  | §0.1 — those two files are the centralized part; the scatter is elsewhere                  |
+| #103: "Should precede #88"                                                               | §0.3 — no code dependency in either direction                                              |
+| #88 Hazards: implies #103's subject is contained by the `pipeline/*` port                | §0.3 — it spans #84, #87, #88 and #91                                                      |
+| #30: movements "fan out into analytics, notifications, audit, AI agents, and the portal" | §2.9 — notifications and audit do not exist; the other three pull, nothing is pushed       |
+| `docs/REMAINING-WORK.md:534` (at `013a86bd`): "No sub-plan exists yet."                  | true when written; this doc is that sub-plan and that row should be updated in the same PR |
+| #103 Verification: "baseline is 282 files / 2615 tests green at `eaac76eb`"              | §7.1 — stale; the anchor is 3046 tests / 310 files (`.claude/commands/gate.md:48`)         |
+| #103 AC#1: write `phase-5-slice-20-pipeline-state-machine.md`                            | §7.1 — this file uses a topic name and should be renamed before it lands                   |
+| `.claude/rules/db.md` § Schema Conventions: "Prisma enums for all status/type fields"    | §1.2 — `applications.status` is a bare `String` (`pipeline.prisma:30`)                     |
+| `.claude/rules/db.md`: "explicit `onDelete:` on every `@relation`"                       | §D4 — `pipeline.prisma:72-73` rely on implicit defaults                                    |
+| `.claude/rules/api-security.md` § Service Layer: routers import no Prisma                | §0.2 — `portal.ts:4,235` imports and calls `db` directly                                   |

--- a/docs/architecture/csharp-migration/phase-5-slice-17-audit-log-read.md
+++ b/docs/architecture/csharp-migration/phase-5-slice-17-audit-log-read.md
@@ -7,11 +7,34 @@ cutover deferred, TS untouched except behavior-preserving pure-kernel extraction
 
 ## Scope decision (read this first)
 
+> **Corrected 2026-08-10 (#102 / #61 AC3) — the first bullet below is out of date.** `exportLogs` is **not**
+> a stub and `routers/audit.ts` is **not** dead code: the tenant-scoped CSV/JSON export shipped 2026-07-31 in
+> `863b62f4`, six days after this document was written, and is reachable today at
+> `apps/web/app/(admin)/settings/audit-log/page.tsx:28` → `packages/api/src/routers/audit.ts:28`
+> (`permissionProcedure('audit','export')`) → `services/audit.service.ts:50` →
+> `repositories/audit.repository.ts:46`. The other four procedures do still have zero frontend consumers.
+> Anyone planning the port should read
+> `docs/architecture/csharp-migration/audit-compliance-domain.md` §2.3, not this bullet.
+>
+> **And the distinction this document conflates (#61 AC3).** "Audit" here is _two_ surfaces with two
+> different authorization models, and they must not be merged in the port:
+>
+> - **Tenant-scoped** — `packages/api/src/routers/audit.ts`, read through `tenantDb`
+>   (`repositories/audit.repository.ts:1`), org-bounded, gated by the `audit` permission grant, which the
+>   access matrix gives to **`super_admin` only** (`packages/db/prisma/seed-access-matrix.ts:35,40`). A C#
+>   port of this surface needs `TenantScope` **and** the grant check.
+> - **Platform-scoped** — the surface this slice actually ports, read through the privileged `db` client,
+>   deliberately cross-org, gated by `PlatformOwnerGate` with **no** grant check and **no** `TenantScope`
+>   (`Program.cs:446-450` — "NEVER wrapped in TenantScope" is stated at `:448`).
+>
+> `PlatformOwnerGate` is a wider and different authorization model than `audit:read`. Reusing this slice's
+> gate for the tenant surface would silently widen it.
+
 Three surfaces touch "audit" in this codebase; only two are live:
 
 - `packages/api/src/routers/audit.ts` (org-scoped `listLogs`/`getLogDetail`/`exportLogs`[stub]/`getAccessReport`/
   `getChangesByEntity`) — registered in `root.ts`, **zero frontend consumers**. Dead code. **Out of scope** —
-  not ported, not deleted, in this slice.
+  not ported, not deleted, in this slice. _(Superseded — see the correction above.)_
 - `platform.getCrossOrgAuditLogs` + `platform.exportAuditLogsCsv` (`routers/platform/system.ts:257-354`) —
   backs `apps/web/app/(admin)/platform/audit/page.tsx`. **In scope.**
 - `routers/platform/access-review.ts` (CB-2b — `getAccessReview`/`exportAccessReviewCsv`/`attestAccessReview`/


### PR DESCRIPTION
Two domain characterizations for the Phase-5 port queue. Both are written against **source**, not
against their issues — because both issues mislocate their own subject, and the docs say so with
citations.

## #102 — audit / compliance

Writer census: **23** TS `audit_logs` sites, 2 `data_access_logs`, and on the C# side **3 writer
classes across 14 invocation sites**.

The most useful finding is not a count:

> **`getRecentPlatformEvents` (`routers/platform/system.ts:118-130`) reads `audit_logs` cross-org with
> NO `where` clause at all**, returning actor PII.

It is correctly gated by `platformProcedure`, so this is **authorized by design, not a vulnerability**.
But a C# port must reproduce that cross-org read *deliberately* and must never wrap it in
`TenantScope`. #102's own hazard pointed at a different procedure (`getRecentActivity`,
`dashboard.ts:354`) and would have hidden it.

**Also corrects `phase-5-slice-17-audit-log-read.md`**, which called `routers/audit.ts` dead code and
`exportLogs` a stub. The tenant-scoped export shipped in `863b62f4` — six days *after* that doc was
written — and is live at `settings/audit-log/page.tsx:28`.

That correction delivers **#61's AC3**: audit is **two** surfaces with different authorization models,
and merging them in a port would silently widen authorization.

| Surface | Client | Gate | Scope |
| --- | --- | --- | --- |
| Tenant-scoped (`routers/audit.ts`) | `tenantDb` | `audit` permission grant — **super_admin only** | org-bounded |
| Platform-scoped (this slice) | privileged `db` | `PlatformOwnerGate`, **no grant check** | cross-org, and `Program.cs:448` states it is **never** wrapped in `TenantScope` |

## #103 — candidate pipeline state machine

**Headline: there is no legal-transition guard.** `pipeline.service.ts:82-108` emits soft warnings
only — any stage can move to any stage. Plus two data-integrity defects: `convertToEmployee` hires
without ever closing the application, and two paths create applications with **no `stage_movements`
row**, so the audit trail starts empty.

The issue blamed `pipeline/movements.ts` and `pipeline/stages.ts`. Those are the *well-layered* part —
every write funnels through `pipeline.repository.ts`. The real scatter is `candidate.service.ts:212`,
`portal.ts:240` and `offer/lifecycle.ts:145-161`. And there is **no code dependency in either
direction** with #88, contrary to the issue.

AC#5 (golden-fixture the kernel across both stacks) is declined here as L-sized **code** hiding under a
`type:spike` label, and filed as **#196** so the criterion has an owner rather than sitting deferred
inside a document.

## How these were verified — this is the part that matters

Written, then **adversarially claim-audited**: every citation opened and checked against source.

**First pass returned `FIX-FIRST` on both.** 16 false claims on the audit doc (3 HIGH), 10 on the
pipeline doc (1 HIGH), plus 12 unsupported superlatives. Among them:

- a **Corrections table** — the doc's own authority-asserting section — citing **line 52 of a 49-line file**
- a "**15 sites**" headline contradicted by the doc's own table three lines above it (**13**)
- a named procedure, `getPlatformDashboard`, that **exists nowhere in the repo**

Corrections applied, then **re-verified** — which found 4 more, **three introduced by the fix pass
itself**. That is the documented pattern on this repo: each review round finds a defect in the previous
round's fix. Those four were fixed by hand and each re-checked against source:

1. a self-refuting clause (its own preceding sentence disproved it)
2. a heading claiming 13 C# invocation sites where its own totals table said 14 — I counted: 6 + 1 + 7 = **14**
3. a grep presented as reproducible that was not (20 hits, all inside the implementation chain; the
   load-bearing **negative** is exact — 0 in `apps/web`, 0 in `scripts/`, 0 in `tests/`)
4. a `gh issue list` claim matching "only #103 and #88" — it matches **three** (#122 matches on *fixture*)

## Verification

- `npx vitest run` — **3046 passed / 310 files**, exit 0 (docs only; no code touched)
- `npx prettier --check` — clean
- gitleaks — no leaks

**Tier: same-model adversarial only.** `/gate` check 15 is exit 2 (Codex quota to 2026-08-15;
`OMNIROUTE_MODEL` unset so tier 2 correctly refuses). A write → claim-audit → fix → re-verify cycle ran
instead. **Nothing here is cross-model-verified.**

Refs #102, #103, #61
