### PR TITLE
feat(parity): register the platform-organizations read + write surfaces (#195)

### DIFF
--- a/scripts/parity/cli.ts
+++ b/scripts/parity/cli.ts
@@ -111,9 +111,16 @@ async function mintTokens(
   if (!orgAToken) throw new Error(`mintTokens: failed to mint org-A token for role "${primaryRole}"`);
   // platform_owner is deliberately seeded ONLY under org A (see planSeed's comment: it's an
   // org-less identity, seeded once purely to hang the token cache off of) — an org-B counterpart
-  // structurally does not exist, so don't require one. Every surface that uses platform_owner as
-  // probeRole (access-review, audit-log) has globalScope:true on every endpoint, so orgBToken is
-  // never actually read by the RLS check for them; leaving it '' is safe.
+  // structurally does not exist, so don't require one.
+  //
+  // CORRECTED 2026-08-10 (#195): this comment used to say "every surface that uses platform_owner as
+  // probeRole (access-review, audit-log) has globalScope:true", which is stale twice over. Both of
+  // those READ surfaces were REMOVED from surfaces.ts on 2026-07-31 (18282f96) and neither has
+  // existed since; and no surface in surfaces.ts uses platform_owner as probeRole at all — the
+  // platform-owner surfaces deliberately probe with an ORG-SCOPED role (org_admin), because an
+  // org-less identity has no org-B counterpart to probe with. This branch is therefore currently
+  // unreachable from surfaces.ts and is reached only via write-surfaces.ts's access-review surface,
+  // which does set probeRole: 'platform_owner'. Kept, because that is a real caller.
   if (!orgBToken && primaryRole !== 'platform_owner') {
     throw new Error(`mintTokens: failed to mint org-B token for role "${primaryRole}"`);
   }

--- a/scripts/parity/seed.ts
+++ b/scripts/parity/seed.ts
@@ -2169,6 +2169,36 @@ export async function ensureAccessReviewWritePreconditions(_cfg: HarnessConfig):
   // Intentionally a no-op — see the block comment above.
 }
 
+/** The platform-organizations write surface's ids (#195). */
+export interface PlatformOrganizationsWriteResources {
+  orgA: string;
+  orgAdminUserId: string;
+  platformOwnerUserId: string;
+}
+
+/** No-op, like access-review: both writes are unconditional updates on an org that the base seed
+ *  already creates, so there is no fixture to build and nothing to reset between runs. */
+export async function ensurePlatformOrganizationsWritePreconditions(_cfg: HarnessConfig): Promise<void> {
+  // Intentionally a no-op — see the doc comment above.
+}
+
+/** Read-only resolution of the platform-organizations write surface's ids from the seeded DB. */
+export async function resolvePlatformOrganizationsWriteResources(
+  cfg: HarnessConfig,
+): Promise<PlatformOrganizationsWriteResources> {
+  const db = makeDbClient(cfg);
+  await db.connect();
+  try {
+    return {
+      orgA: await orgIdBySlug(db, ORG_SLUGS.a),
+      orgAdminUserId: await userIdByEmail(db, 'parity+a-org_admin@tims.test'),
+      platformOwnerUserId: await userIdByEmail(db, 'parity+a-platform_owner@tims.test'),
+    };
+  } finally {
+    await db.end();
+  }
+}
+
 /** Read-only resolution of the access-review write surface's ids from the seeded DB. */
 export async function resolveAccessReviewWriteResources(cfg: HarnessConfig): Promise<AccessReviewWriteResources> {
   const db = makeDbClient(cfg);

--- a/scripts/parity/surfaces.test.ts
+++ b/scripts/parity/surfaces.test.ts
@@ -54,11 +54,55 @@ describe('SURFACES', () => {
         expect(ep.idScopeKey, `${key}/${ep.name} is globalScope AND by-id`).toBeUndefined();
       }
     }
-    // Documented state: nine-box's simulate + quadrant-plan are the only globalScope endpoints, and
-    // both are pure kernels. The loop above is the invariant; this pins the count so a NEW
-    // globalScope endpoint has to be looked at deliberately — and so that the loop going empty
-    // (which would make the invariant unenforced while still reading as enforced) fails here.
-    expect(seen).toBe(2);
+    // Documented state, 4 endpoints across 2 surfaces. The loop above is the invariant; this pins the
+    // count so a NEW globalScope endpoint has to be looked at deliberately — and so that the loop
+    // going empty (which would make the invariant unenforced while still reading as enforced) fails
+    // here.
+    //
+    //   nine-box simulate + quadrant-plan — PURE KERNELS. Org-independent computation; the original
+    //     and still the paradigm case for this flag.
+    //   organization kpis + list — PLATFORM-OWNER CROSS-ORG READS (#195, added 2026-08-10). A
+    //     different justification for the same flag, and worth stating so it is not read as
+    //     precedent for the kernel case: these DO read org data, but the surface is
+    //     platformProcedure/PlatformOwnerGate over the unscoped `db`, so there is no per-caller
+    //     tenant boundary and Mode B's identical-payload heuristic would fire on the correct
+    //     behaviour. `list` enumerates every tenant by definition. RBAC (org_admin 403 on both) is
+    //     what proves the boundary here, not RLS.
+    //
+    // Neither of the two new ones is by-id, so the invariant above still bites for them unchanged —
+    // `getOrganization` was left unregistered rather than weaken it (see surfaces.ts).
+    expect(seen).toBe(4);
+  });
+
+  // ── #195: the platform-organizations read surface (2026-08-10) ───────────────────────────────
+  it('organization is registered with its flag + the 3 reads, minus the by-id detail', () => {
+    const s = SURFACES['organization'];
+    expect(s.flag).toBe('Platform__PlatformOrganizationsReadEnabled');
+    expect(s.roles).toEqual(['platform_owner', 'org_admin']);
+    // org-scoped probe role: a platform owner is org-less and has no org-B counterpart to probe with.
+    expect(s.probeRole).toBe('org_admin');
+
+    expect(s.endpoints.map((e) => e.name)).toEqual(['kpis', 'list']);
+
+    for (const ep of s.endpoints) {
+      // Both flags still dark, TS still the live path — so every endpoint MUST keep a tsProcedure and
+      // produce a real byte diff. A [WEAK] here would mean the pre-flip readiness check proves nothing.
+      expect(ep.tsProcedure, ep.name).toBeTruthy();
+      // RBAC is the boundary proof on a platform-owner surface, since RLS is N/A.
+      expect(ep.expectedByRole, ep.name).toEqual({ platform_owner: 200, org_admin: 403 });
+      expect(ep.globalScope, ep.name).toBe(true);
+    }
+  });
+
+  it('getOrganization stays UNregistered until a by-id platform-owner endpoint can be expressed', () => {
+    // Pins a DELIBERATE omission so it reads as a decision, not an oversight. Registering it needs a
+    // real org id in `{id}` AND no Mode-A IDOR probe; the only way to express the second today is
+    // `globalScope`, which the invariant above forbids combining with `idScopeKey` — correctly, since
+    // that flag means "pure kernel", not "no tenant boundary for this caller". Overloading it would
+    // silently disable a genuine IDOR probe on some future surface.
+    const names = SURFACES['organization'].endpoints.map((e) => e.name);
+    expect(names).not.toContain('detail');
+    expect(SURFACES['organization'].endpoints.some((e) => e.idScopeKey)).toBe(false);
   });
 
   // ── Coverage-audit additions (2026-07-27) ────────────────────────────────────────────────────

--- a/scripts/parity/surfaces.ts
+++ b/scripts/parity/surfaces.ts
@@ -69,6 +69,76 @@ export interface Surface {
  * Task 9 RLS, Task 10 RBAC) iterate this map; they never hardcode a surface's routes/roles.
  */
 export const SURFACES: Record<string, Surface> = {
+  // ── platform organizations (READ) ───────────────────────────────────────────────────────────
+  // Registered 2026-08-10 (#195), immediately after Phase-5 slices 19 (PR #198) and 20 (PR #202)
+  // shipped the C# port. #195's own body says `organization` is NOT a gap "because they have no C#
+  // endpoints at all" — that was TRUE when it was written and is now stale: PlatformOrganizationsRead
+  // Endpoints ships 3 routes and PlatformOrganizationsWriteEndpoints 2.
+  //
+  // WHY THIS MATTERS MORE THAN A TYPICAL REGISTRATION: without it, step 5 (verify in prod) for the
+  // whole organizations domain was not "Federico-gated" but UNRUNNABLE BY ANYONE, and #76's decision
+  // comment requires the fail-closed audit divergence to be "pinned by a parity fixture" — an
+  // obligation that could not be discharged while the surface was unregistered.
+  //
+  // BOTH FLAGS ARE STILL DARK, so `verify organization` is a PRE-flip readiness check: it proves the
+  // C# responses match TS before Federico flips anything, which is exactly the order the strangler
+  // recipe wants. Every endpoint keeps its `tsProcedure` — the TS side is still the live production
+  // path — so these are REAL byte diffs, not `[WEAK]`.
+  //
+  // RLS IS N/A ON EVERY ENDPOINT, AND THAT IS THE CORRECT ANSWER, NOT A GAP. This surface is
+  // `platformProcedure` on the TS side and `PlatformOwnerGate` on the C# side, over the UNSCOPED `db`
+  // — it is cross-org BY DESIGN. A platform owner reading org B is the feature, so a Mode-A IDOR
+  // probe would assert the opposite of the requirement. `globalScope: true` makes `checks/rls.ts`
+  // report a documented N/A (it short-circuits at rls.ts:189, BEFORE the `idScopeKey` branch at :199)
+  // rather than a spurious FAIL. The authorization boundary here is the GATE, and it is RBAC — not
+  // RLS — that proves it, via the org_admin 403 on every endpoint. Same disposition and same reason
+  // as the access-review read surface that used to live here.
+  //
+  // probeRole is `org_admin`, not `platform_owner`: a platform owner is org-less and seeded only
+  // under org A (seed.ts:84), so it has no org-B counterpart to probe with. Precedent verbatim from
+  // the removed access-review entry.
+  //
+  // `getOrganization` (the by-id detail read) is DELIBERATELY NOT REGISTERED HERE, and that is the
+  // honest answer rather than a shortcut. It needs two things at once — a real org id bound into
+  // `{id}`, and no Mode-A IDOR probe — and the only existing way to express the second is
+  // `globalScope`, which surfaces.test.ts:46 explicitly forbids combining with `idScopeKey`
+  // ("no by-id endpoint may claim org-independence"). That guard is CORRECT: `globalScope` means
+  // "pure kernel, org-independent computation" (nine-box simulate/quadrant-plan), whereas this
+  // endpoint reads org-specific rows and merely has no tenant boundary FOR THIS CALLER. Those are
+  // different properties, and overloading one flag for both is precisely what would silently
+  // disable a real IDOR probe on some future surface. The removed access-review entry sidestepped
+  // it with a fixed non-existent org id, which cannot work here — `getOrganization` 404s on an
+  // unknown org (organizations.ts:100), so the platform_owner case would assert 404, not 200.
+  // Registering it needs a distinct, explicit concept (a platform-owner "no IDOR by design" marker,
+  // the read-side analogue of write-surfaces.ts's documented omission of `buildIdor` on
+  // access-review `attest`). Filed rather than smuggled in under an existing flag.
+  organization: {
+    key: 'organization',
+    flag: 'Platform__PlatformOrganizationsReadEnabled',
+    roles: ['platform_owner', 'org_admin'],
+    probeRole: 'org_admin', // org-scoped role — RLS/cross-tenant probing is N/A here; see globalScope.
+    endpoints: [
+      {
+        name: 'kpis',
+        csharpPath: '/platform/organizations/kpis',
+        tsProcedure: 'platform.getOrganizationKpis',
+        input: {},
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        globalScope: true,
+      },
+      // The list is cross-org by definition (it enumerates EVERY tenant), so there is no per-org
+      // payload to compare — the clearest case in the registry for globalScope.
+      {
+        name: 'list',
+        csharpPath: '/platform/organizations',
+        tsProcedure: 'platform.listOrganizations',
+        input: {},
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+        globalScope: true,
+      },
+    ],
+  },
   // ── compensation ────────────────────────────────────────────────────────────────────────────
   // UPDATE 2026-07-29: 5 of the original 7 registered compensation reads had their TS procedures
   // DELETED (NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP confirmed live in prod) — salary-bands,

--- a/scripts/parity/write-surfaces.test.ts
+++ b/scripts/parity/write-surfaces.test.ts
@@ -504,6 +504,66 @@ describe('WRITE_SURFACES ninebox', () => {
   });
 });
 
+// Registry-level pin. There was none before #195: adding or DELETING an entire write surface tripped
+// nothing, so the per-surface describes below could silently stop covering a live surface — the exact
+// "an assertion that cannot run is not a guard" failure surfaces.test.ts already guards against on the
+// read side. Changing this list must be deliberate.
+describe('WRITE_SURFACES registry', () => {
+  it('pins the registered write surfaces', () => {
+    expect(Object.keys(WRITE_SURFACES).sort()).toEqual(
+      ['access-review', 'compensation', 'engagement', 'evaluation360', 'ninebox', 'organization', 'succession'].sort(),
+    );
+  });
+
+  it('every surface has a probeRole that appears in its own roles list', () => {
+    // A probeRole outside roles[] mints a token for an identity the surface never declares, so the
+    // light-parity and IDOR probes would run as somebody the RBAC matrix says nothing about.
+    for (const [key, s] of Object.entries(WRITE_SURFACES)) {
+      expect(s.roles, key).toContain(s.probeRole);
+    }
+  });
+});
+
+describe('WRITE_SURFACES organization', () => {
+  const s = WRITE_SURFACES['organization'];
+
+  it('is registered with its flag, the platform-owner probe, and both writes', () => {
+    expect(s.flag).toBe('Platform__PlatformOrganizationsWriteEnabled');
+    expect(s.probeRole).toBe('platform_owner');
+    expect(s.roles).toEqual(['platform_owner', 'org_admin']);
+    expect(s.endpoints.map((e) => e.name)).toEqual(['update', 'suspend']);
+  });
+
+  it('omits buildIdor on both writes — a platform owner is cross-org by design', () => {
+    // Same disposition as access-review attest. If a future edit adds an IDOR probe here it would
+    // assert that a platform owner CANNOT reach another org, which is the opposite of the requirement.
+    for (const e of s.endpoints) expect(e.buildIdor, e.name).toBeUndefined();
+  });
+
+  it('denies org_admin at the gate on both writes', () => {
+    for (const e of s.endpoints) {
+      expect(e.expectedByRole, e.name).toEqual({ platform_owner: 'allow', org_admin: 'deny' });
+      expect(e.rbacDenyStatus ?? 403, e.name).toBe(403);
+    }
+  });
+
+  it('never suspends the parity org — the flag is always false (activate)', () => {
+    // Suspending org A would set is_active=false on the tenant every OTHER surface authenticates into,
+    // turning one write check into a cross-surface outage. This pins the safety choice so it cannot be
+    // "fixed" into a real suspension by someone who reads suspend:false as a typo.
+    const suspend = s.endpoints.find((e) => e.name === 'suspend')!;
+    const built = suspend.buildParity({ base: '', orgA: 'ORG_A', orgAdminUserId: 'X', platformOwnerUserId: 'Y' } as never);
+    expect(built.body).toEqual({ suspend: false });
+    expect(built.path).toBe('/platform/organizations/ORG_A/suspend');
+  });
+
+  it('update writes only name — never slug, which every other surface resolves org A by', () => {
+    const update = s.endpoints.find((e) => e.name === 'update')!;
+    const built = update.buildParity({ base: '', orgA: 'ORG_A', orgAdminUserId: 'X', platformOwnerUserId: 'Y' } as never);
+    expect(Object.keys(built.body as object)).toEqual(['name']);
+  });
+});
+
 describe('WRITE_SURFACES access-review', () => {
   const s = WRITE_SURFACES['access-review'];
   const ar: AccessReviewWriteResolved = { base: 'http://c', orgA: 'orgA', orgAdminUserId: 'orgAdmin' };

--- a/scripts/parity/write-surfaces.ts
+++ b/scripts/parity/write-surfaces.ts
@@ -1415,8 +1415,10 @@ export interface AccessReviewWriteResolved extends WriteResolvedBase {
 const ACCESS_REVIEW_NOTES_MARKER = 'parity';
 
 // Coverage-audit addition (2026-07-27): 1 write under Platform__AccessReviewWriteEnabled.
-// `attest` = PlatformOwnerGate (the SAME gate as the access-review READ surface in surfaces.ts —
-// see that entry's comment) + an unconditional insert into `access_reviews`. UNLIKE every other
+// `attest` = PlatformOwnerGate + an unconditional insert into `access_reviews`. (This comment used to
+// point at "the access-review READ surface in surfaces.ts" for the gate rationale; that surface was
+// REMOVED on 2026-07-31 (18282f96) and the pointer dangled until #195. The same gate is now described
+// by the `organization` read surface in surfaces.ts.) UNLIKE every other
 // write surface here, this one has NO cross-org IDOR concept: a platform owner is INTENTIONALLY
 // cross-org (they attest ANY org's access review by design — the same reason the read surface's
 // RLS check is `globalScope` rather than a leak signal), so `buildIdor` is correctly omitted —

--- a/scripts/parity/write-surfaces.ts
+++ b/scripts/parity/write-surfaces.ts
@@ -31,6 +31,8 @@ import {
   resolveNineBoxWriteResources,
   ensureAccessReviewWritePreconditions,
   resolveAccessReviewWriteResources,
+  ensurePlatformOrganizationsWritePreconditions,
+  resolvePlatformOrganizationsWriteResources,
   WRITE_EVAL_CYCLES,
   WRITE_CYCLE_MARKER,
   WRITE_SUCCESSION_ROLES,
@@ -1483,6 +1485,130 @@ const accessReviewSurface: WriteSurface<AccessReviewWriteResolved> = {
   ],
 };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// platform organizations — Platform__PlatformOrganizationsWriteEnabled (2 writes)
+// ─────────────────────────────────────────────────────────────────────────────
+/** Concrete ids for the platform-organizations write surface (seed.ts). */
+export interface PlatformOrganizationsWriteResolved extends WriteResolvedBase {
+  /** org-A id — the update/suspend target. */
+  orgA: string;
+  /** org-A `org_admin` user id — the denied role, for the no-mutation read-back. */
+  orgAdminUserId: string;
+  /** the seeded platform owner — the actor every ALLOWED write must be attributed to. */
+  platformOwnerUserId: string;
+}
+
+const ORG_WRITE_NAME_MARKER = 'Parity Org Write Marker';
+
+// Registered 2026-08-10 (#195) for Phase-5 slice 20 (PR #202). Like access-review above, this surface
+// has NO cross-org IDOR concept — a platform owner updates ANY org by design — so `buildIdor` is
+// correctly omitted. `org_admin` is refused by PlatformOwnerGate BEFORE any body parse, so its 403 is
+// gate-level.
+//
+// TWO DELIBERATE SAFETY CHOICES, because this surface mutates the org every OTHER surface runs on:
+//
+//  1. `suspend` sends `{ suspend: false }` (ACTIVATE), never `true`. Suspending org A would set
+//     is_active=false on the tenant that every other parity surface authenticates into, turning one
+//     surface's write check into a cross-surface outage. Activating an already-active org still
+//     exercises the whole path — gate, TenantScope transaction, the fail-closed audit INSERT, the
+//     response shape — and still writes an `org_activated` audit row, which is what the read-back
+//     asserts. The only thing it does not cover is the notify fan-out, which fires solely on
+//     suspend=true (organizations.ts:220); that stays uncovered here on purpose.
+//  2. `update` writes only `name`, never `slug`. Every other surface resolves org A BY SLUG
+//     (seed.ts orgIdBySlug), so renaming is inert for them while still being a real, readable-back
+//     column write.
+//
+// Both writes are idempotent, so re-running `verify-write organization` needs no teardown.
+const platformOrganizationsSurface: WriteSurface<PlatformOrganizationsWriteResolved> = {
+  key: 'organization',
+  flag: 'Platform__PlatformOrganizationsWriteEnabled',
+  probeRole: 'platform_owner',
+  roles: ['platform_owner', 'org_admin'],
+  ensurePreconditions: ensurePlatformOrganizationsWritePreconditions,
+  resolveResources: resolvePlatformOrganizationsWriteResources,
+  endpoints: [
+    {
+      name: 'update',
+      method: 'PATCH',
+      buildParity: (r) => ({ path: `/platform/organizations/${r.orgA}`, body: { name: ORG_WRITE_NAME_MARKER } }),
+      // no buildIdor: platform-owner update has no cross-tenant boundary to probe (see above).
+      expectedByRole: { platform_owner: 'allow', org_admin: 'deny' },
+      rbacDenyStatus: 403,
+      expectResponse: (b) => {
+        const o = asObj(b);
+        if (!o) return 'response is not an object';
+        if (typeof o.id !== 'string' || !UUID_RE.test(o.id)) return `expected a uuid id, got ${JSON.stringify(o.id)}`;
+        if (o.name !== ORG_WRITE_NAME_MARKER) return `expected name ${ORG_WRITE_NAME_MARKER}, got ${JSON.stringify(o.name)}`;
+        return null;
+      },
+      // The column write AND the fail-closed audit row, together — the audit is the half a
+      // response-shape assertion cannot see, and #76's whole divergence lives in it.
+      readbackMutated: (r) => ({
+        sql: `SELECT o.name,
+                     (SELECT count(*)::int FROM audit_logs a
+                       WHERE a.organization_id = o.id AND a.action = 'org_updated' AND a.actor_id = $2) AS audits
+                FROM organizations o WHERE o.id = $1`,
+        params: [r.orgA, r.platformOwnerUserId],
+        expect: (rows) => {
+          const row = rows[0];
+          if (!row) return 'org A not found on read-back';
+          if (row.name !== ORG_WRITE_NAME_MARKER) return `name is ${JSON.stringify(row.name)}, expected the marker`;
+          if (Number(row.audits) < 1) return 'no org_updated audit row attributed to the platform owner';
+          return null;
+        },
+      }),
+      // rbac-deny (org_admin): the gate must refuse BEFORE the transaction, so no audit row may carry
+      // the denied user as actor. Asserting on the audit rather than the name is deliberate — the name
+      // is already the marker from the allow case, so it could not distinguish a leak.
+      readbackNoMutation: (r) => ({
+        sql: `SELECT count(*)::int AS n FROM audit_logs WHERE organization_id = $1 AND actor_id = $2`,
+        params: [r.orgA, r.orgAdminUserId],
+        expect: (rows) =>
+          Number(rows[0]?.n) === 0 ? null : `a forbidden update by org_admin still wrote ${rows[0]?.n} audit row(s)`,
+      }),
+    },
+    {
+      name: 'suspend',
+      method: 'POST',
+      // `suspend: false` — ACTIVATE. See the surface comment: suspending org A would break every
+      // other surface's authentication.
+      buildParity: (r) => ({ path: `/platform/organizations/${r.orgA}/suspend`, body: { suspend: false } }),
+      expectedByRole: { platform_owner: 'allow', org_admin: 'deny' },
+      rbacDenyStatus: 403,
+      expectResponse: (b) => {
+        const o = asObj(b);
+        if (!o) return 'response is not an object';
+        if (typeof o.id !== 'string' || !UUID_RE.test(o.id)) return `expected a uuid id, got ${JSON.stringify(o.id)}`;
+        if (o.isActive !== true) return `expected isActive true after activate, got ${JSON.stringify(o.isActive)}`;
+        return null;
+      },
+      readbackMutated: (r) => ({
+        sql: `SELECT o.is_active,
+                     (SELECT count(*)::int FROM audit_logs a
+                       WHERE a.organization_id = o.id AND a.action = 'org_activated' AND a.actor_id = $2) AS audits
+                FROM organizations o WHERE o.id = $1`,
+        params: [r.orgA, r.platformOwnerUserId],
+        expect: (rows) => {
+          const row = rows[0];
+          if (!row) return 'org A not found on read-back';
+          if (row.is_active !== true) return `is_active is ${JSON.stringify(row.is_active)}, expected true`;
+          // The action name is the ONLY thing distinguishing activate from suspend — TS picks it from
+          // the flag (organizations.ts:233) and so must C#.
+          if (Number(row.audits) < 1) return 'no org_activated audit row attributed to the platform owner';
+          return null;
+        },
+      }),
+      readbackNoMutation: (r) => ({
+        sql: `SELECT count(*)::int AS n FROM audit_logs
+               WHERE organization_id = $1 AND actor_id = $2 AND action IN ('org_suspended', 'org_activated')`,
+        params: [r.orgA, r.orgAdminUserId],
+        expect: (rows) =>
+          Number(rows[0]?.n) === 0 ? null : `a forbidden suspend by org_admin still wrote ${rows[0]?.n} audit row(s)`,
+      }),
+    },
+  ],
+};
+
 export const WRITE_SURFACES: Record<string, AnyWriteSurface> = {
   compensation: defineWriteSurface(compensationSurface),
   evaluation360: defineWriteSurface(evaluation360Surface),
@@ -1490,4 +1616,5 @@ export const WRITE_SURFACES: Record<string, AnyWriteSurface> = {
   engagement: defineWriteSurface(engagementSurface),
   ninebox: defineWriteSurface(nineboxSurface),
   'access-review': defineWriteSurface(accessReviewSurface),
+  organization: defineWriteSurface(platformOrganizationsSurface),
 };


### PR DESCRIPTION
Closes the organizations half of #195. Phase-5 slices 19 (#198) and 20 (#202) shipped the C# port,
but the surface was never registered — so step 5 "verify in prod" was not *Federico-gated*, it was
**unrunnable by anyone**, and #76's requirement that the fail-closed audit divergence be "pinned by a
parity fixture" could not be discharged at all.

Both flags are still dark and TS is still the live production path, so every registered endpoint
keeps its `tsProcedure` and produces a **real byte diff**, not `[WEAK]`. `verify organization` /
`verify-write organization` are now genuine pre-flip readiness checks.

## RLS is N/A here, and that is the correct answer

The surface is `platformProcedure` / `PlatformOwnerGate` over the **unscoped** `db` — cross-org by
design. A Mode-A IDOR probe would assert the opposite of the requirement, and Mode B's
identical-payload heuristic would fire on correct behaviour (`list` enumerates every tenant). So the
reads are `globalScope` and the writes omit `buildIdor`, exactly as access-review does. **RBAC —
org_admin 403 on every endpoint — is what proves the boundary**, which matches what the slice docs
already say: the gate is the entire authorization boundary.

## What I did *not* do, and why

**`getOrganization` is deliberately unregistered.** It needs a real org id in `{id}` *and* no Mode-A
probe. The only way to express the second today is `globalScope`, and `surfaces.test.ts:46` forbids
combining it with `idScopeKey`. That guard is **correct**: `globalScope` means "pure kernel,
org-independent computation", not "no tenant boundary for *this caller*". Different properties —
overloading one flag for both is precisely how a genuine IDOR probe gets silently disabled on some
future surface.

I had it working the other way first (`globalScope` + `idScopeKey`, plus a new `organization`
ResourcePair) and the existing guard caught me. Reverted rather than weakened; registering that
endpoint needs its own explicit marker, which is a separate change. The removed access-review entry
sidestepped this with a fixed non-existent org id — that cannot work here, since `getOrganization`
404s on an unknown org.

## Two safety choices on the write surface

This surface mutates the org **every other surface runs on**:

1. `suspend` sends `{ suspend: false }` (activate), never `true` — suspending org A would set
   `is_active=false` on the tenant every other parity surface authenticates into. Activating an
   already-active org still exercises gate → transaction → fail-closed audit → response. The notify
   fan-out (suspend-only) stays uncovered, on purpose and in writing.
2. `update` writes only `name`, never `slug` — every other surface resolves org A by slug.

Both pinned by tests that go red if someone "fixes" `suspend: false` into a real suspension.

## A guard the write registry never had

`write-surfaces.test.ts` had per-surface describes but **no registry-level pin**, so adding — or
deleting — an entire write surface tripped nothing. That is the same "an assertion that cannot run is
not a guard" failure the read side already guards against, and plausibly how the access-review read
surface disappeared unnoticed. Added a key-set pin plus a probeRole-∈-roles invariant.

## Verification

| Gate | Result |
| --- | --- |
| vitest | 3055 tests / 310 files (+9 from 3046) |
| `tsc` api + web | clean |
| table-ownership, gitleaks | clean |
| **Check 15 (cross-model)** | **⚠️ NOT RUN — exit 2.** Codex quota-blocked to 2026-08-15. |

Mutation-proved (4): adding `idScopeKey` to a `globalScope` endpoint reddens 3 read tests; flipping
`suspend:false`→`true` reddens the safety pin; removing the write surface reddens the new key-set pin
plus 4 per-surface tests.

## Finding worth its own decision — NOT actioned here

The **access-review READ surface was removed on 2026-07-31** (`18282f96`) because its `tsProcedure`
references "would otherwise break `verify access-review` at runtime". `tsProcedure` became
**optional** on 2026-08-06 (`efb7553f`) — verified by `git merge-base --is-ancestor`, so the removal
predates the fix. Under today's rules it should have been kept as C#-only, exactly as nine-box was in
#194. Deleting it retired the RLS Mode-A probe and the RBAC deny assertions **for a surface that is
live in prod**. The same question applies to audit-log (`2950a06c`).

Neither is restored here — that is coverage restoration for live surfaces and deserves its own
reviewed change. It is also why #195's remaining ACs (monitoring's 6 routes, the ~11-surface audit,
and the "no endpoints file without a registry entry" guard) are still open; this PR does not close
the issue.

## Stale comments corrected

`cli.ts` claimed "every surface that uses platform_owner as probeRole (access-review, audit-log) has
globalScope:true" — stale twice: both read surfaces were removed on 2026-07-31, and no surface in
`surfaces.ts` uses `platform_owner` as probeRole at all. `write-surfaces.ts:1418` pointed at "the
access-review READ surface in surfaces.ts" — a dangling pointer since the same commit.

Refs #195
