### PR TITLE
feat(parity): register the monitoring read surface + seed its grants (#195 AC1)

### DIFF
--- a/scripts/parity/seed.ts
+++ b/scripts/parity/seed.ts
@@ -85,8 +85,12 @@ const ORG_KEYS: readonly ('a' | 'b')[] = ['a', 'b'];
  * not by any per-org role/RLS), so seeding one per org would fabricate a nonexistent second
  * identity. It's seeded exactly ONCE, under orgKey 'a', purely because the harness's
  * per-(org,role) token-cache keying needs *some* orgKey to hang the cached token off of —
- * `organizationId` is otherwise irrelevant to this identity (see the `audit-log` surface in
- * surfaces.ts, the only surface that uses this role). */
+ * `organizationId` is otherwise irrelevant to this identity.
+ *
+ * (This used to point at "the `audit-log` surface in surfaces.ts, the only surface that uses this
+ * role". Stale since 2026-07-31: audit-log and access-review were both REMOVED from surfaces.ts in
+ * 18282f96. Today the only READ surface listing `platform_owner` in its roles is `organization`, and
+ * it probes with org_admin — no read surface uses platform_owner as its probeRole.) */
 export function planSeed(roles: string[]): SeedPlan {
   const users: SeededUser[] = [];
   for (const orgKey of ORG_KEYS)
@@ -1863,6 +1867,32 @@ async function seedEngagementGrants(db: Client, roleIds: Map<string, string>): P
   }
 }
 
+/** Grants the `monitoring:read` permission the six monitoring READ endpoints check (#195).
+ *
+ *  Scopes come from `packages/db/prisma/seed-access-matrix.ts` and are NOT invented here:
+ *  hr_admin holds `monitoring` read+update @organization (:54), hrbp holds read @unit (:70).
+ *  Only `read` is seeded — the two monitoring WRITES (dismissAlert / configureAlertRules) have no C#
+ *  port yet, so an update grant would assert nothing.
+ *
+ *  WITHOUT THIS, EVERY MONITORING READ 403s AND IT LOOKS LIKE A C# BUG. `MonitoringStaffGate` runs the
+ *  same `PermissionService` kernel as TS, which legitimately finds zero `role_permissions` rows on a
+ *  freshly-seeded org. That is exactly what happened on the engagement read flip (#166): 12/43 FAIL,
+ *  root-caused to this same missing-grant fixture gap rather than to the product.
+ *
+ *  `org_admin` is DELIBERATELY left ungranted — it is absent from MATRIX entirely, so it holds no
+ *  grants at all, which makes it the surface's deny role. Its 403 is therefore a GRANT-level denial
+ *  (PermissionService says no) rather than a gate-level one, which is the stronger assertion: it
+ *  proves the permission check runs, not merely that some gate rejected an unknown principal. */
+async function seedMonitoringGrants(db: Client, roleIds: Map<string, string>): Promise<void> {
+  const readPerm = await upsertPermission(db, 'monitoring', 'read');
+  for (const key of ORG_KEYS) {
+    const hrAdmin = roleIds.get(`${key}:hr_admin`);
+    if (hrAdmin) await upsertRolePermission(db, hrAdmin, readPerm, 'organization');
+    const hrbp = roleIds.get(`${key}:hrbp`);
+    if (hrbp) await upsertRolePermission(db, hrbp, readPerm, 'unit');
+  }
+}
+
 /** Write-verify-only survey + action-plan fixtures (fixed UUIDs). */
 export const WRITE_ENGAGEMENT = {
   activateSurveyA: 'e0000364-0000-4000-8000-000000000001', // activateSurvey from-state (draft, org A)
@@ -2378,6 +2408,7 @@ export async function seed(cfg: HarnessConfig, roles: string[]): Promise<SeedRes
     // data seed here — write fixtures are seeded in ensureEngagementWritePreconditions (write path
     // only); read fixtures (surveys/survey_responses for enps etc.) are seeded separately below.
     if (roles.includes('hr_admin') || roles.includes('hrbp')) await seedEngagementGrants(db, roleIds);
+    if (roles.includes('hr_admin') || roles.includes('hrbp')) await seedMonitoringGrants(db, roleIds);
     // eNPS read data (both orgs, DIFFERENTIATED — see the fixture-rationale comment above
     // seedEngagementEnpsData). Org-independent of `roles`; only needs each org's super_admin id.
     await seedEngagementEnpsData(db, orgIds.a, orgIds.b, userIds);

--- a/scripts/parity/surfaces.test.ts
+++ b/scripts/parity/surfaces.test.ts
@@ -74,6 +74,47 @@ describe('SURFACES', () => {
     expect(seen).toBe(4);
   });
 
+  // ── #195 AC1: the monitoring read surface (2026-08-10) ───────────────────────────────────────
+  it('monitoring registers all 6 deployed routes', () => {
+    const s = SURFACES['monitoring'];
+    expect(s.flag).toBe('Platform__MonitoringReadEnabled');
+    // Counted from MonitoringReadEndpoints.cs, not taken from #195's text. If a 7th route ships, this
+    // is where the omission surfaces.
+    expect(s.endpoints.map((e) => e.name)).toEqual([
+      'executive-kpis',
+      'module-health',
+      'alerts',
+      'action-plan-alerts',
+      'cross-module-trend',
+      'alert-rules',
+    ]);
+    // probeRole must be a role with a REAL org-wide grant, not super_admin — super_admin bypasses the
+    // permission kernel, so probing with it would never exercise a grant.
+    expect(s.probeRole).toBe('hr_admin');
+    expect(s.roles).toContain(s.probeRole);
+  });
+
+  it('monitoring keeps a DENIED role, or its RBAC check proves nothing', () => {
+    // All three normally-granted roles expect 200 here (MonitoringStaffGate deliberately does not
+    // force the org gate, so hrbp@unit is 200 too). Without org_admin — which is absent from MATRIX
+    // and holds no grants — every RBAC assertion on this surface would be "200 means allowed", with
+    // nothing proving the permission check can say no.
+    const s = SURFACES['monitoring'];
+    for (const ep of s.endpoints) {
+      const denied = Object.entries(ep.expectedByRole).filter(([, v]) => v === 403);
+      expect(denied.map(([r]) => r), `${ep.name} has no denied role`).toEqual(['org_admin']);
+    }
+  });
+
+  it('monitoring runs REAL RLS — nothing globalScope, nothing by-id', () => {
+    // These are org-scoped aggregates, so Mode B is the meaningful check. globalScope or idScopeKey
+    // here would silently downgrade it to N/A or to an IDOR probe that does not apply.
+    for (const ep of SURFACES['monitoring'].endpoints) {
+      expect(ep.globalScope, ep.name).toBeUndefined();
+      expect(ep.idScopeKey, ep.name).toBeUndefined();
+    }
+  });
+
   // ── #195: the platform-organizations read surface (2026-08-10) ───────────────────────────────
   it('organization is registered with its flag + the 3 reads, minus the by-id detail', () => {
     const s = SURFACES['organization'];

--- a/scripts/parity/surfaces.ts
+++ b/scripts/parity/surfaces.ts
@@ -69,6 +69,100 @@ export interface Surface {
  * Task 9 RLS, Task 10 RBAC) iterate this map; they never hardcode a surface's routes/roles.
  */
 export const SURFACES: Record<string, Surface> = {
+  // ── monitoring (READ) ───────────────────────────────────────────────────────────────────────
+  // Registered 2026-08-10 (#195, AC 1). Six routes, matching the six TS reads 1:1 — counted from
+  // MonitoringReadEndpoints.cs, not taken from the issue text.
+  //
+  // WHY THIS ONE MATTERS MOST OF THE ~11 UNREGISTERED SURFACES: MonitoringReadEndpoints is DEPLOYED
+  // and its RLS/RBAC probes have never run, and `Platform__MonitoringReadEnabled` is the single env
+  // var gating ownership flips #64 and #68 (measured absent from the live App Runner service on
+  // 2026-08-10). Registering it first means the flip can be parity-verified BEFORE it is flipped,
+  // instead of flipped blind — the ordering that caught the real engagement-read failure in #166.
+  //
+  // UNLIKE the `organization` surface below, RLS HERE IS REAL AND RUNS. These are org-scoped reads
+  // (`permissionProcedure('monitoring','read')` / `MonitoringStaffGate`, org id from the caller's
+  // context), so no endpoint is `globalScope` and none is by-id: every one gets a Mode-B check, which
+  // is the meaningful shape for a tenant-scoped aggregate.
+  //
+  // RBAC — the grants are seeded by seed.ts's seedMonitoringGrants, copied from
+  // seed-access-matrix.ts rather than invented: hr_admin read@organization (:54), hrbp read@unit
+  // (:70). ALL THREE granted roles expect 200, including hrbp: MonitoringStaffGate deliberately does
+  // NOT force the org gate (its docblock:17-22 — the TS reader applies no `requireOrgScope` to any of
+  // the six, so forcing it would 403 a role that reads these dashboards today). The only scope
+  // mechanic is a `scopeWhereFor('actionPlan')` ROW filter on action-plan-alerts, which changes the
+  // rows, not the status.
+  //
+  // That leaves no denial among the usual three roles, which would make the RBAC check vacuous — so
+  // `org_admin` is added as the DENY role. It is absent from MATRIX entirely, holds no grants, and is
+  // therefore refused by PermissionService itself: a GRANT-level 403, which proves the permission
+  // check ran, not merely that some gate rejected an unknown principal.
+  //
+  // KNOWN RISK, stated rather than discovered at run time: these payloads are time-dependent
+  // (KPI windows, a 6/12/24-month trend window, alert timestamps). Both stacks compute their window
+  // independently, so a run that straddles a month boundary can diff spuriously. If that shows up,
+  // the fix is a normalize rule here — not a code change.
+  monitoring: {
+    key: 'monitoring',
+    flag: 'Platform__MonitoringReadEnabled',
+    roles: ['super_admin', 'hr_admin', 'hrbp', 'org_admin'],
+    probeRole: 'hr_admin', // org-scoped, org-wide grant — a real 200, not a super_admin bypass.
+    endpoints: [
+      {
+        name: 'executive-kpis',
+        csharpPath: '/monitoring/executive-kpis',
+        tsProcedure: 'monitoring.getExecutiveKpis',
+        input: {},
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+      {
+        name: 'module-health',
+        csharpPath: '/monitoring/module-health',
+        tsProcedure: 'monitoring.getModuleHealth',
+        input: {},
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+      // The Zod input is `.optional()` as a whole, with page/limit defaulting to 1/20 — send them
+      // explicitly so the C# query string and the tRPC input describe the same page.
+      {
+        name: 'alerts',
+        csharpPath: '/monitoring/alerts?page=1&limit=20',
+        tsProcedure: 'monitoring.getActiveAlerts',
+        input: { page: 1, limit: 20 },
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+      // hrbp reaches this one but sees scopeWhereFor('actionPlan')-filtered ROWS. Status is still
+      // 200, which is all the RBAC check asserts; the row filter is a parity concern, not an RBAC one.
+      {
+        name: 'action-plan-alerts',
+        csharpPath: '/monitoring/action-plan-alerts',
+        tsProcedure: 'monitoring.getActionPlanAlerts',
+        input: {},
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+      // `metric` has NO default on the TS side (period defaults to 12m) — it must be supplied or Zod
+      // rejects the call before any of this is exercised.
+      {
+        name: 'cross-module-trend',
+        csharpPath: '/monitoring/cross-module-trend?metric=headcount&period=12m',
+        tsProcedure: 'monitoring.getCrossModuleTrend',
+        input: { metric: 'headcount', period: '12m' },
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+      {
+        name: 'alert-rules',
+        csharpPath: '/monitoring/alert-rules',
+        tsProcedure: 'monitoring.getAlertRules',
+        input: {},
+        expectedByRole: { super_admin: 200, hr_admin: 200, hrbp: 200, org_admin: 403 },
+        normalize: { dropNullish: true },
+      },
+    ],
+  },
   // ── platform organizations (READ) ───────────────────────────────────────────────────────────
   // Registered 2026-08-10 (#195), immediately after Phase-5 slices 19 (PR #198) and 20 (PR #202)
   // shipped the C# port. #195's own body says `organization` is NOT a gap "because they have no C#


### PR DESCRIPTION
Closes **AC 1** of #195. Six routes, matching the six TS reads 1:1 — counted from
`MonitoringReadEndpoints.cs`, not taken from the issue text.

## Why monitoring first, of the ~11 unregistered surfaces

`MonitoringReadEndpoints` is **deployed** and its RLS/RBAC probes have never run, and
`Platform__MonitoringReadEnabled` is the single env var gating ownership flips **#64 and #68** —
measured absent from the live App Runner service (26 env vars, 20 of them `…Enabled: true`).

So registering it first means the flip can be **parity-verified before it is flipped**, instead of
flipped blind. That is the ordering that caught the real engagement-read failure in #166.

## The grant fixture is what would otherwise make this fiction

`monitoring` grants did not exist in the parity seed **at all**. Without them, `MonitoringStaffGate`
runs the same `PermissionService` kernel as TS, legitimately finds zero `role_permissions` rows on a
freshly-seeded org, and 403s every role on every endpoint — which reads as a C# bug and is not one.

That is precisely the #166 failure: 12/43 FAIL, root-caused to this same missing-grant gap rather
than to the product. `seedMonitoringGrants` copies scopes from `seed-access-matrix.ts` rather than
inventing them — hr_admin `read@organization` (`:54`), hrbp `read@unit` (`:70`). Only `read`: the two
monitoring writes have no C# port yet, so an update grant would assert nothing.

## RLS is real here, unlike the organizations surface in #203

These are org-scoped aggregates, so nothing is `globalScope` and nothing is by-id — every endpoint
gets a Mode-B check. Pinned by a test, so a future edit cannot silently downgrade it to N/A.

## The RBAC check needed a denied role, or it proves nothing

All three normally-granted roles expect 200 here — **including hrbp**, because `MonitoringStaffGate`
deliberately does not force the org gate (docblock `:17-22`: the TS reader applies no
`requireOrgScope` to any of the six, so forcing it would 403 a role that reads these dashboards
today). The only scope mechanic is a `scopeWhereFor('actionPlan')` **row** filter, which changes rows,
not status.

That would have left an RBAC matrix where every assertion is "200 means allowed" and nothing proves
the permission kernel can say no. So `org_admin` is the deny role: absent from MATRIX entirely, holds
no grants, refused by `PermissionService` itself — a **grant-level** 403, which is the stronger
assertion than a gate-level one. Mutation-proved: dropping the 403 expectations reddens the guard.

## A third dangling pointer to the 2026-07-31 removals

`seed.ts` said `organizationId` is irrelevant to platform_owner "(see the `audit-log` surface in
surfaces.ts, the only surface that uses this role)". Stale since `18282f96`, like the two corrected in
#203. That is now three dangling references left by those two surface deletions — which is itself
evidence for restoring them (see #195's comments).

## Known risk, stated rather than discovered at run time

These payloads are time-dependent (KPI windows, a 6/12/24-month trend window, alert timestamps). Both
stacks compute their window independently, so a run straddling a month boundary can diff spuriously.
If that appears, the fix is a `normalize` rule here — not a code change.

## Verification

| Gate | Result |
| --- | --- |
| vitest | 3058 / 310 (+3) |
| `tsc --noEmit` | clean |
| gitleaks | clean |
| **Check 15 (cross-model)** | **⚠️ NOT RUN — exit 2.** Codex quota-blocked to 2026-08-15. |

## Still open on #195 after this

- Audit the remaining ~10 deployed-but-unregistered surfaces
- Decide on restoring the access-review + audit-log read surfaces (both flags are `true` in prod
  right now, so those are live surfaces missing their probes)
- The `*Endpoints.cs`-without-a-registry-entry guard, with the non-vacuity floor
- Express a platform-owner by-id read so `getOrganization` can be registered

Refs #195
