### PR TITLE
feat(parity): re-register the access-review + audit-log read surfaces, C#-only (#195)

### DIFF
--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -226,8 +226,12 @@ describe-service`; only the frontend Vercel flag was missing.)
     was rolled back immediately, harness fixed + 782/782 unit + 1012/1012 integration tests still
     passing, re-verified 43/43 PASS, then re-flipped for real.
   - Platform organizations (Phase-5 Slice-19 read, Slice-20 write) — #76. Platform-owner-only and
-    deliberately CROSS-ORG. **BOTH DARK**, no FE flag, no parity-registry entry (`surfaces.ts` covers 4
-    domains — #195), so step 5 is currently unrunnable by anyone rather than merely Federico-gated.
+    deliberately CROSS-ORG. **BOTH DARK**, no FE flag. This used to add "no parity-registry entry
+    (`surfaces.ts` covers 4 domains — #195), so step 5 is unrunnable by anyone"; that is STALE as of
+    2026-08-11 — #203 registered the read and write surfaces, #204 added monitoring, and the
+    access-review/audit-log reads were restored, so SURFACES now holds 8 keys and `verify
+    organization` / `verify-write organization` are runnable. Step 5 is Federico-gated again, not
+    blocked. (`getOrganization` alone stays unregistered — it needs a by-id platform-owner marker.)
     Slice 19 (PR #198) ported `getOrganizationKpis`/`listOrganizations`/`getOrganization` behind
     `Platform:PlatformOrganizationsReadEnabled`. Slice 20 ported `updateOrganization`/
     `suspendOrganization` behind `Platform:PlatformOrganizationsWriteEnabled`, which is the

--- a/docs/architecture/csharp-migration/phase-5-slice-19-platform-organizations-read.md
+++ b/docs/architecture/csharp-migration/phase-5-slice-19-platform-organizations-read.md
@@ -99,5 +99,5 @@ soft-deleting organizations, both stacks list them as live. Recorded so the abse
   assertions red, with a green control either side
 
 Parity fixtures and the `scripts/parity/surfaces.ts` registration are **not** in this slice — see #195,
-which tracks that the registry covers 4 of ~15 C# domains and that `verify` is unrunnable for most of
+which tracked that the registry covered 4 of ~15 C# domains and that `verify` was unrunnable for most of
 them. Registering this surface belongs with that work.

--- a/docs/architecture/csharp-migration/phase-5-slice-20-platform-organizations-write.md
+++ b/docs/architecture/csharp-migration/phase-5-slice-20-platform-organizations-write.md
@@ -31,7 +31,8 @@ row returns an error here — so it is recorded rather than left to be discovere
 
 > **#76's decision comment required this to be "pinned by a parity fixture". That obligation is NOT
 > discharged here, and an earlier draft of this doc claimed otherwise.** The surface has no
-> `scripts/parity/surfaces.ts` entry at all (#195 — the registry covers 4 of ~15 C# domains), so there is
+> `scripts/parity/surfaces.ts` entry at all (#195 — at the time, the registry covered 4 of ~15 C# domains;
+> #203/#204 and the 2026-08-11 access-review/audit-log restoration took it to 8), so there was
 > nothing to hang a fixture on and nothing will diff C# against TS at step 5. What _does_ pin the
 > behaviour is the mutation proof below, against a real Postgres. Closing the parity-fixture gap needs
 > #195 first.

--- a/scripts/deploy/README-cutover.md
+++ b/scripts/deploy/README-cutover.md
@@ -127,26 +127,26 @@ Cross-checked directly against `services/Tims.Platform/src/Tims.Api/Configuratio
 number) and independently corroborated by the `flag:` field in `scripts/parity/surfaces.ts` /
 `scripts/parity/write-surfaces.ts`.
 
-| Surface (this script) | Kind  | Backend flag                | Parity CLI invocation          | FE flag (`apps/web`)                         | Status                                                                      |
-| --------------------- | ----- | --------------------------- | ------------------------------ | -------------------------------------------- | --------------------------------------------------------------------------- |
-| `team-intel`          | read  | `TeamIntelReadEnabled`      | `NONE` (TS router deleted)     | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `reporting`           | read  | `ReportingReadEnabled`      | `NONE` (TS router deleted)     | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `billing-read`        | read  | `BillingReadEnabled`        | `NONE` (TS router deleted)     | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
-| `billing-usage`       | read  | `BillingUsageEnabled`       | `NONE` (TS router deleted)     | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
-| `evaluation360`       | read  | `Evaluation360ReadEnabled`  | `NONE` (TS router deleted)     | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
-| `succession`          | read  | `SuccessionReadEnabled`     | `verify succession`            | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/9 procedures, see cutover.sh)       |
-| `compensation`        | read  | `CompensationReadEnabled`   | `verify compensation`          | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
-| `nine-box`            | read  | `NineBoxReadEnabled`        | `verify ninebox`               | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
-| `engagement`          | read  | `EngagementReadEnabled`     | `verify engagement`            | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
-| `dei`                 | read  | `DeiReadEnabled`            | `verify dei`                   | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | CONFIRMED LIVE (partial TS deletion — 9/11 read procedures, see cutover.sh) |
-| `audit-log`           | read  | `AuditLogReadEnabled`       | `NONE` (TS procedures deleted) | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `access-review`       | read  | `AccessReviewReadEnabled`   | `NONE` (TS procedures deleted) | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED                                                                  |
-| `evaluation360-write` | write | `Evaluation360WriteEnabled` | `verify-write evaluation360`   | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIP-READY                                                                  |
-| `succession-write`    | write | `SuccessionWriteEnabled`    | `verify-write succession`      | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
-| `nine-box-write`      | write | `NineBoxWriteEnabled`       | `verify-write ninebox`         | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
-| `compensation-write`  | write | `CompensationWriteEnabled`  | `verify-write compensation`    | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
-| `engagement-write`    | write | `EngagementWriteEnabled`    | `verify-write engagement`      | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
-| `access-review-write` | write | `AccessReviewWriteEnabled`  | `verify-write access-review`   | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | TS DELETED (write-surface tests C# directly via SQL/HTTP, no TS dependency) |
+| Surface (this script) | Kind  | Backend flag                | Parity CLI invocation        | FE flag (`apps/web`)                         | Status                                                                      |
+| --------------------- | ----- | --------------------------- | ---------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
+| `team-intel`          | read  | `TeamIntelReadEnabled`      | `NONE` (TS router deleted)   | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `reporting`           | read  | `ReportingReadEnabled`      | `NONE` (TS router deleted)   | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `billing-read`        | read  | `BillingReadEnabled`        | `NONE` (TS router deleted)   | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
+| `billing-usage`       | read  | `BillingUsageEnabled`       | `NONE` (TS router deleted)   | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
+| `evaluation360`       | read  | `Evaluation360ReadEnabled`  | `NONE` (TS router deleted)   | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
+| `succession`          | read  | `SuccessionReadEnabled`     | `verify succession`          | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/9 procedures, see cutover.sh)       |
+| `compensation`        | read  | `CompensationReadEnabled`   | `verify compensation`        | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
+| `nine-box`            | read  | `NineBoxReadEnabled`        | `verify ninebox`             | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
+| `engagement`          | read  | `EngagementReadEnabled`     | `verify engagement`          | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
+| `dei`                 | read  | `DeiReadEnabled`            | `verify dei`                 | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | CONFIRMED LIVE (partial TS deletion — 9/11 read procedures, see cutover.sh) |
+| `audit-log`           | read  | `AuditLogReadEnabled`       | `verify audit-log`           | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `access-review`       | read  | `AccessReviewReadEnabled`   | `verify access-review`       | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `evaluation360-write` | write | `Evaluation360WriteEnabled` | `verify-write evaluation360` | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIP-READY                                                                  |
+| `succession-write`    | write | `SuccessionWriteEnabled`    | `verify-write succession`    | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
+| `nine-box-write`      | write | `NineBoxWriteEnabled`       | `verify-write ninebox`       | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
+| `compensation-write`  | write | `CompensationWriteEnabled`  | `verify-write compensation`  | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
+| `engagement-write`    | write | `EngagementWriteEnabled`    | `verify-write engagement`    | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
+| `access-review-write` | write | `AccessReviewWriteEnabled`  | `verify-write access-review` | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | TS DELETED (write-surface tests C# directly via SQL/HTTP, no TS dependency) |
 
 Run `./scripts/deploy/cutover.sh --list` for the per-surface long-form notes (why each is
 classified the way it is, and every naming quirk below).
@@ -219,17 +219,32 @@ classified the way it is, and every naming quirk below).
   the write procedure (`attestAccessReview`) were deleted; with zero procedures left, the whole
   router file (`packages/api/src/routers/platform/access-review.ts` + its schemas/service/
   repository) was removed outright, matching the `reporting` precedent, unlike `team-intel`'s
-  partial survival. `scripts/parity/surfaces.ts`'s `access-review` entry and
-  `scripts/parity/write-surfaces.ts`'s `access-review` write entry were both removed the same way,
-  so `--verify-only`/`--verify-only --flip-backend` for either access-review row is now a no-op.
-  **`audit-log` (read) also joined this group on 2026-07-31** — its flag was confirmed live in prod
-  and its only registered read procedure (`platform.getCrossOrgAuditLogs`, plus
-  `platform.exportAuditLogsCsv` which shared the same TS router) was deleted from
+  partial survival. **`audit-log` (read) also joined this group on 2026-07-31** — its flag was
+  confirmed live in prod and its only registered read procedure (`platform.getCrossOrgAuditLogs`,
+  plus `platform.exportAuditLogsCsv` which shared the same TS router) was deleted from
   `packages/api/src/routers/platform/system.ts`. Unlike `team-intel`, the FE wrapper
   (`apps/web/lib/platform-api/audit-log.ts`) also lost its flag-gating entirely — it now calls the
   C# service unconditionally, the same shape as `reporting`/`evaluation360`/`team-intel`'s
-  wrappers. `scripts/parity/surfaces.ts`'s `audit-log` entry was removed the same way, so its
-  `parity_command` is likewise `NONE` and `--verify-only` for it is the same no-op.
+  wrappers.
+- **CORRECTION + UPDATE 2026-08-11 — the two access-review/audit-log rows are NOT no-ops any more,
+  and one claim above was never true.** The paragraph above used to end by saying that
+  `scripts/parity/surfaces.ts`'s `access-review` entry _and_
+  `scripts/parity/write-surfaces.ts`'s `access-review` **write** entry "were both removed the same
+  way, so `--verify-only` for either access-review row is now a no-op". The write half of that was
+  false when written: `WRITE_SURFACES['access-review']` has never been removed (it is still in
+  `write-surfaces.ts`, still asserted by `write-surfaces.test.ts`, and `--list` has shown
+  `verify-write access-review` for that row throughout). It tests the C# endpoint directly via raw
+  SQL + HTTP and has no `tsProcedure` concept at all, so a TS deletion could not have affected it.
+  The READ half was true — and is now reversed. Both READ surfaces were **re-registered C#-only on
+  2026-08-11**, because `tsProcedure` became optional on 2026-08-06 (`efb7553f`), six days after
+  they were deleted. So `--verify-only` for `audit-log` and `access-review` runs a real check again.
+  **Read its output precisely:** the parity leg reports `[WEAK]` on every endpoint (no TS side to
+  diff against — that part of the 2026-07-31 note still holds), while the RBAC leg
+  (`platform_owner` 200 / `org_admin` 403 at `PlatformOwnerGate`) and the C#-returns-200 liveness
+  check are real, and on a principal-type gate the RBAC leg is the entire authorization proof. The
+  RLS leg is a documented N/A on both surfaces (`globalScope`) — it was N/A before the deletion too,
+  so no cross-tenant probe was lost then or regained now. `/audit/logs/export` is registered for the
+  first time; the pre-deletion entry covered only `/audit/logs`.
 - **Write-surface names use an explicit `-write` suffix** (`access-review-write`,
   `evaluation360-write`, etc.) to keep them addressable independently from their read counterpart
   — a domain's read and write flags cut over at different points in the runbook's Phase A / Phase B

--- a/scripts/deploy/README-cutover.md
+++ b/scripts/deploy/README-cutover.md
@@ -10,8 +10,12 @@ runbooks.
 different auth mechanism (API keys / Stripe webhooks, not staff-JWT) and are handled by a separate
 workstream — they are deliberately absent from this script's surface table.
 
-**Who runs what.** Same rule as the runbook: `--verify-only` is genuinely safe for anyone to run
-(it only reads, via the parity harness). `--flip-backend`/`--rollback` with `--yes` touches real
+**Who runs what.** Same rule as the runbook: `--verify-only` is safe for anyone to run — with two
+caveats that `cutover.sh`'s own safety block spells out and that were undocumented until 2026-08-11.
+`verify-write <key>` is **mutating by design** (it writes and reads back). And `verify access-review`
+attempts four `audit_logs` inserts that the org-id FK rejects, while `verify audit-log` pulls up to
+~2000 cross-tenant audit rows — including actor emails and IP addresses — onto the machine running
+it. Neither prints anything sensitive, but neither is literally "read-only" either. `--flip-backend`/`--rollback` with `--yes` touches real
 AWS infrastructure — that is **Federico-run only** (`I never touch prod`, applies to whoever is at
 the keyboard, human or agent). Without `--yes` both modes only print the commands; nothing is
 executed.
@@ -20,7 +24,7 @@ executed.
 
 | Mode             | Mutates anything? | What it does                                                                                                 |
 | ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------ |
-| `--verify-only`  | No (default)      | Runs `scripts/parity/cli.ts verify[-write] <key>` for real and reports pass/fail.                            |
+| `--verify-only`  | Read-only\*       | Runs `scripts/parity/cli.ts verify[-write] <key>` for real and reports pass/fail. \*See the caveats above.   |
 | `--flip-backend` | Only with `--yes` | Prints (or runs) the `aws apprunner update-service` recipe that flips `Platform:<Surface>Enabled` to `true`. |
 | `--rollback`     | Only with `--yes` | Same recipe, flips the flag back to `false`, plus prints the FE Vercel-revert steps.                         |
 
@@ -31,8 +35,8 @@ flag, and CONFIRMED LIVE / FLIP-READY / COEXISTENCE / TS DELETED status per
 ## Worked example: cutting over `engagement`
 
 ```bash
-# 1) Verify — safe, non-mutating, needs scripts/parity/.env populated (see scripts/parity/README.md)
-#    and a live, reachable C# service.
+# 1) Verify — read-only (see the caveats above), needs scripts/parity/.env populated
+#    (see scripts/parity/README.md) and a live, reachable C# service.
 ./scripts/deploy/cutover.sh engagement --verify-only
 
 # 2) Once that's green, flip the backend flag AND re-verify in the same breath — the script
@@ -127,26 +131,26 @@ Cross-checked directly against `services/Tims.Platform/src/Tims.Api/Configuratio
 number) and independently corroborated by the `flag:` field in `scripts/parity/surfaces.ts` /
 `scripts/parity/write-surfaces.ts`.
 
-| Surface (this script) | Kind  | Backend flag                | Parity CLI invocation        | FE flag (`apps/web`)                         | Status                                                                      |
-| --------------------- | ----- | --------------------------- | ---------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
-| `team-intel`          | read  | `TeamIntelReadEnabled`      | `NONE` (TS router deleted)   | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `reporting`           | read  | `ReportingReadEnabled`      | `NONE` (TS router deleted)   | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `billing-read`        | read  | `BillingReadEnabled`        | `NONE` (TS router deleted)   | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
-| `billing-usage`       | read  | `BillingUsageEnabled`       | `NONE` (TS router deleted)   | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
-| `evaluation360`       | read  | `Evaluation360ReadEnabled`  | `NONE` (TS router deleted)   | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
-| `succession`          | read  | `SuccessionReadEnabled`     | `verify succession`          | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/9 procedures, see cutover.sh)       |
-| `compensation`        | read  | `CompensationReadEnabled`   | `verify compensation`        | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
-| `nine-box`            | read  | `NineBoxReadEnabled`        | `verify ninebox`             | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
-| `engagement`          | read  | `EngagementReadEnabled`     | `verify engagement`          | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
-| `dei`                 | read  | `DeiReadEnabled`            | `verify dei`                 | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | CONFIRMED LIVE (partial TS deletion — 9/11 read procedures, see cutover.sh) |
-| `audit-log`           | read  | `AuditLogReadEnabled`       | `verify audit-log`           | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
-| `access-review`       | read  | `AccessReviewReadEnabled`   | `verify access-review`       | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
-| `evaluation360-write` | write | `Evaluation360WriteEnabled` | `verify-write evaluation360` | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIP-READY                                                                  |
-| `succession-write`    | write | `SuccessionWriteEnabled`    | `verify-write succession`    | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
-| `nine-box-write`      | write | `NineBoxWriteEnabled`       | `verify-write ninebox`       | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
-| `compensation-write`  | write | `CompensationWriteEnabled`  | `verify-write compensation`  | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
-| `engagement-write`    | write | `EngagementWriteEnabled`    | `verify-write engagement`    | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
-| `access-review-write` | write | `AccessReviewWriteEnabled`  | `verify-write access-review` | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | TS DELETED (write-surface tests C# directly via SQL/HTTP, no TS dependency) |
+| Surface (this script) | Kind  | Backend flag                | Parity CLI invocation         | FE flag (`apps/web`)                         | Status                                                                      |
+| --------------------- | ----- | --------------------------- | ----------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
+| `team-intel`          | read  | `TeamIntelReadEnabled`      | `NONE` (TS router deleted)    | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `reporting`           | read  | `ReportingReadEnabled`      | `NONE` (TS router deleted)    | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `billing-read`        | read  | `BillingReadEnabled`        | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
+| `billing-usage`       | read  | `BillingUsageEnabled`       | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
+| `evaluation360`       | read  | `Evaluation360ReadEnabled`  | `NONE` (TS router deleted)    | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
+| `succession`          | read  | `SuccessionReadEnabled`     | `NONE` (surface unregistered) | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | TS DELETED (surface unregistered #58 — verify is a no-op)                   |
+| `compensation`        | read  | `CompensationReadEnabled`   | `verify compensation`         | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
+| `nine-box`            | read  | `NineBoxReadEnabled`        | `verify ninebox`              | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
+| `engagement`          | read  | `EngagementReadEnabled`     | `verify engagement`           | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
+| `dei`                 | read  | `DeiReadEnabled`            | `verify dei`                  | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | TS DELETED (all 11; surface kept C#-only — see cutover.sh)                  |
+| `audit-log`           | read  | `AuditLogReadEnabled`       | `verify audit-log`            | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `access-review`       | read  | `AccessReviewReadEnabled`   | `verify access-review`        | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `evaluation360-write` | write | `Evaluation360WriteEnabled` | `verify-write evaluation360`  | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIPPED_AHEAD_OF_FLAG (ownership flipped while dark — see cutover.sh)       |
+| `succession-write`    | write | `SuccessionWriteEnabled`    | `verify-write succession`     | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
+| `nine-box-write`      | write | `NineBoxWriteEnabled`       | `verify-write ninebox`        | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
+| `compensation-write`  | write | `CompensationWriteEnabled`  | `verify-write compensation`   | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
+| `engagement-write`    | write | `EngagementWriteEnabled`    | `verify-write engagement`     | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
+| `access-review-write` | write | `AccessReviewWriteEnabled`  | `verify-write access-review`  | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | CONFIRMED LIVE (TS deleted; write surface tests C# directly, no TS dep)     |
 
 Run `./scripts/deploy/cutover.sh --list` for the per-surface long-form notes (why each is
 classified the way it is, and every naming quirk below).

--- a/scripts/deploy/cutover.sh
+++ b/scripts/deploy/cutover.sh
@@ -92,10 +92,10 @@ surface_row() {
       echo "read|DeiReadEnabled|verify|dei|NEXT_PUBLIC_DEI_READ_VIA_CSHARP|TS_DELETED|Runbook §6 Phase A #4. UPDATE 2026-07-31: flag confirmed live in prod; 9 of 11 registered read procedures had their TS side deleted, leaving getEthnicityDistribution/getDisabilityDistribution (both zero-FE-consumer). UPDATE 2026-08-06 (#60): those last 2 are now deleted too — packages/api/src/routers/dei.ts serves ONLY the generateReport mutation, which was NEVER ported to C# and is deliberately retained (see the TS-DELETION note in that file). Status flips CONFIRMED_LIVE -> TS_DELETED: the previous note said 'do not treat this as TS_DELETED', which is no longer true. As with ninebox (#57), verify stays 'verify dei' and the surface stays REGISTERED as C#-only in scripts/parity/surfaces.ts with both tsProcedure fields dropped: only checks/parity.ts reads tsProcedure, so deleting the surface would have retired the RBAC deny assertions (hrbp 403) and the RLS cross-org check against still-deployed C# demographic endpoints — a security-coverage regression, not a cleanup. A run now reports [WEAK] for parity (no TS side to compare, stated explicitly) while RBAC + RLS run for real and still fail the command. Read a green run as evidence about PERMISSIONS and ISOLATION on the C# read surface, NOT as cross-stack parity — cross-stack parity for these two now lives in DeiReadEndpointTests.cs (:139-140 bodies, :333-334 gate) + contracts/dei-fixtures/*.json. getPayEquity (FX) was gated by the separate Platform:FxReadsEnabled backend flag but shared this ONE FE flag, so its TS side was deleted in the 2026-07-31 pass despite that backend split."
       ;;
     audit-log)
-      echo "read|AuditLogReadEnabled|NONE|NONE|NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP|TS_DELETED|Phase-5 Slice-17. UPDATE 2026-07-31: flag confirmed live in prod, and this surface's only registered read procedure (platform.getCrossOrgAuditLogs, plus platform.exportAuditLogsCsv which shared the same TS router) has been deleted (packages/api/src/routers/platform/system.ts) — the C# read path is the sole implementation now, so scripts/parity/surfaces.ts's 'audit-log' entry was removed too and there is no TS side left to diff against. The FE wrapper (apps/web/lib/platform-api/audit-log.ts) now calls the C# service unconditionally rather than gating on the flag. --verify-only for this surface is now a no-op (see run_verify) rather than a real parity check."
+      echo "read|AuditLogReadEnabled|verify|audit-log|NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP|TS_DELETED|Phase-5 Slice-17. UPDATE 2026-07-31: flag confirmed live in prod, and this surface's only registered read procedure (platform.getCrossOrgAuditLogs, plus platform.exportAuditLogsCsv which shared the same TS router) has been deleted (packages/api/src/routers/platform/system.ts) — the C# read path is the sole implementation now. The FE wrapper (apps/web/lib/platform-api/audit-log.ts) now calls the C# service unconditionally rather than gating on the flag. UPDATE 2026-08-11: this row's parity_command was NONE from 2026-07-31 until now, because scripts/parity/surfaces.ts's 'audit-log' entry was removed at the same time as the TS procedures. That removal is REVERSED — the surface is re-registered C#-only (tsProcedure became optional on 2026-08-06, efb7553f, six days AFTER the deletion), so --verify-only runs a REAL check again. Read the result precisely: parity reports [WEAK] on both endpoints (no TS side to diff), while the RBAC platform_owner-200/org_admin-403 assertions and the C#-returns-200 liveness check are real and are the point. RLS is a documented N/A (globalScope) — it was N/A before the deletion too, so no cross-tenant probe was lost or regained. Both deployed routes are now registered, including /audit/logs/export, which the original entry never covered."
       ;;
     access-review)
-      echo "read|AccessReviewReadEnabled|NONE|NONE|NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP|TS_DELETED|Phase-5 Slice-18. UPDATE 2026-07-31: flag confirmed live in prod; all 3 registered TS read procedures (getAccessReview/exportAccessReviewCsv/listAccessReviewAttestations) have been deleted — the C# read path is the sole implementation now, so scripts/parity/surfaces.ts's 'access-review' entry was removed too and there is no TS side left to diff against. --verify-only for this surface is now a no-op (see run_verify) rather than a real parity check. UPDATE (same day, continued): the write flag (access-review-write) was ALSO confirmed live and its TS side deleted the same session — with BOTH sides gone, the whole TS router (packages/api/src/routers/platform/access-review.ts + its schemas/service/repository) was removed outright, matching the team-intel/reporting precedent, unlike this entry's original note. Read side is efcoreReadOnly over Phase-2 identity tables (users/roles/user_roles/role_permissions/permissions/organizations); access_reviews itself stays Prisma-owned (the C# write is a coexistence write, not an ownership flip — see table-ownership.md)."
+      echo "read|AccessReviewReadEnabled|verify|access-review|NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP|TS_DELETED|Phase-5 Slice-18. UPDATE 2026-07-31: flag confirmed live in prod; all 3 registered TS read procedures (getAccessReview/exportAccessReviewCsv/listAccessReviewAttestations) have been deleted — the C# read path is the sole implementation now. UPDATE 2026-08-11: scripts/parity/surfaces.ts's 'access-review' entry was removed on 2026-07-31 and that removal is REVERSED — re-registered C#-only, so --verify-only runs a REAL check again. Same reading as the audit-log row above: [WEAK] parity (no TS side), REAL RBAC platform_owner-200/org_admin-403, RLS a documented N/A (globalScope, unchanged before and after). All 3 routes pin a fixed non-existent org id in organizationId; neither expectation depends on that org existing (the 403 precedes any org lookup, and BuildReportAsync has no org-exists precondition — only AttestAsync does). UPDATE 2026-07-31 (same day, continued): the write flag (access-review-write) was ALSO confirmed live and its TS side deleted the same session — with BOTH sides gone, the whole TS router (packages/api/src/routers/platform/access-review.ts + its schemas/service/repository) was removed outright, matching the team-intel/reporting precedent, unlike this entry's original note. Read side is efcoreReadOnly over Phase-2 identity tables (users/roles/user_roles/role_permissions/permissions/organizations); access_reviews itself stays Prisma-owned (the C# write is a coexistence write, not an ownership flip — see table-ownership.md)."
       ;;
     evaluation360-write)
       echo "write|Evaluation360WriteEnabled|verify-write|evaluation360|NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP|FLIPPED_AHEAD_OF_FLAG|Runbook §6 Phase B #8 — FLIP-READY. UPDATE 2026-07-28: this note used to say 'once verified, drop the TS eval360 router' as a pending future step — that's now DONE (packages/api/src/routers/evaluation360.ts + its FE fallback in apps/web/lib/platform-api/evaluation360.ts were deleted outright), independent of this flag's flip state. verify-write itself is UNAFFECTED by that deletion (scripts/parity/write-surfaces.ts's 'evaluation360' entry hits the C# API directly for RBAC/IDOR checks — it never depended on the TS router). Flipping Platform:Evaluation360WriteEnabled is still the pending step to move review_cycles/rater_assignments/rater_responses to efcore table-ownership. ⚠️ UPDATE 2026-08-06 (#67, runbook §7e): THE OWNERSHIP FLIP HAS BEEN EXECUTED WHILE THIS FLAG IS STILL DARK. review_cycles/rater_assignments/rater_responses are now efcore[] in docs/architecture/table-ownership.md. This DEVIATES from runbook §8 Q8 / precondition P1, which require the write flag confirmed live in prod before the flip PR opens — all three prior flips (access_reviews, critical_roles+successors, calibration_*) had CONFIRMED_LIVE write flags. Federico authorised the deviation explicitly on 2026-08-06 after it was raised. CONSEQUENCE, stated plainly: the TS router was deleted 2026-07-28 and its orphaned repository by #54, so with this flag dark these three tables currently have NO ACTIVE WRITER ON EITHER STACK. The ledger's efcore[] entry means C# is the sole IMPLEMENTATION and sole authority for future schema changes; it does not currently mean C# is writing. Flip this flag to make the ledger operationally true, then change this status to CONFIRMED_LIVE."
@@ -134,7 +134,11 @@ status_label() {
     FLIP_READY) echo "FLIP-READY" ;;
     COEXISTENCE) echo "COEXISTENCE" ;;
     BLOCKED) echo "BLOCKED" ;;
-    TS_DELETED) echo "TS DELETED (no parity)" ;;
+    # 2026-08-11: was "TS DELETED (no parity)". That conflated two independent facts and is now
+    # false for audit-log/access-review, whose surfaces were re-registered C#-only — a deleted TS
+    # side means no cross-stack DIFF, but the RBAC/RLS checks still run. Whether parity runs at all
+    # is already printed in its own column (parity_command), so this label just states the TS fact.
+    TS_DELETED) echo "TS DELETED" ;;
     *) echo "$1" ;;
   esac
 }
@@ -178,11 +182,16 @@ EXAMPLES
   scripts/deploy/cutover.sh access-review-write --flip-backend --skip-verify-confirm-i-know-what-im-doing
   scripts/deploy/cutover.sh dei --rollback --yes
   scripts/deploy/cutover.sh --list
-  # NOTE: "reporting", "evaluation360" (read), "team-intel", "billing-usage", and "audit-log" no
-  # longer have a real --verify-only check — their TS procedures were deleted (2026-07-28 for the
-  # first two, 2026-07-29 for the next two, 2026-07-31 for audit-log), so there's nothing left to
-  # diff against. --verify-only for any of these five still runs (prints a no-op notice and exits
-  # 0) rather than erroring.
+  # NOTE: "reporting", "evaluation360" (read), "team-intel", "billing-usage", "billing-read" and
+  # "succession" have no real --verify-only check — their TS procedures were deleted AND their
+  # surfaces were removed from scripts/parity/surfaces.ts, so --verify-only prints a no-op notice
+  # and exits 0 rather than erroring. Do not read that 0 as a pass.
+  #
+  # 2026-08-11: "audit-log" and "access-review" (read) used to be on that list and are NOT any more.
+  # Their TS procedures are still deleted, but their surfaces were re-registered C#-only, so
+  # --verify-only runs a real check whose parity leg reports [WEAK] while its RBAC leg is real.
+  # A deleted TS side does not by itself make a surface unverifiable — that conflation is what put
+  # these two rows here for eleven days.
 
 See scripts/deploy/README-cutover.md for the full worked flow.
 EOF
@@ -539,8 +548,9 @@ fi
 # Exit code contract: a bare `--verify-only` (the default mode) must propagate the parity CLI's
 # own pass/fail so this script is usable as a CI/scripting gate, e.g.
 # `./cutover.sh engagement --verify-only && ./cutover.sh engagement --flip-backend --yes`
-# (for "reporting"/"evaluation360" read/"team-intel"/"billing-usage", whose TS routers are
-# deleted, run_verify's NONE branch above returns 0 unconditionally instead of a real pass/fail). Once a
+# (for "reporting"/"evaluation360" read/"team-intel"/"billing-usage"/"billing-read"/"succession",
+# whose surfaces are unregistered, run_verify's NONE branch above returns 0 unconditionally instead
+# of a real pass/fail — "audit-log"/"access-review" left that group on 2026-08-11). Once a
 # mutating mode (--flip-backend/--rollback) also ran, THEIR success is what the exit code reports
 # (they already refuse to run on a verify failure, so reaching this point means they printed/ran
 # fine even if the earlier bundled verify had failed and was overridden via the escape hatch).

--- a/scripts/deploy/cutover.sh
+++ b/scripts/deploy/cutover.sh
@@ -12,7 +12,8 @@
 # SAFETY MODEL (mirrors the runbook's "Federico-run" rule — nothing here touches AWS/prod unless
 # a human explicitly opts in):
 #   --verify-only   (DEFAULT) runs the real parity CLI (`scripts/parity/cli.ts verify[-write]`).
-#                   Safe, non-mutating, genuinely runnable today given creds + a live C# service.
+#                   Genuinely runnable today given creds + a live C# service. READ-ONLY IN EFFECT,
+#                   with two documented caveats — see "what --verify-only actually touches" below.
 #   --flip-backend  prints the exact `aws apprunner update-service` recipe that would flip the
 #                   `Platform:<Surface>Enabled` flag to true. DRY-RUN (print only) unless --yes.
 #   --rollback      same shape, flips the flag back to `false` + prints the FE Vercel revert
@@ -153,7 +154,8 @@ MODES (default: --verify-only)
   --verify-only              Run the real parity CLI (`verify`/`verify-write`) for <surface> and
                               report pass/fail. Non-mutating. Needs scripts/parity/.env populated
                               (Supabase creds) + a live, reachable C# service — see
-                              scripts/parity/README.md. Safe to run today with zero risk.
+                              scripts/parity/README.md. Read-only in effect; see the caveats block
+                              above run_verify before treating it as literally side-effect-free.
 
   --flip-backend              Print (default) or run (--yes) the exact `aws apprunner
                               update-service` recipe that flips Platform:<Surface>Enabled to
@@ -225,7 +227,32 @@ print_list() {
 # ---------------------------------------------------------------------------------------------
 # --verify-only: shells out to the real parity CLI. Read surfaces use `verify <key>`; write
 # surfaces use `verify-write <key>` (scripts/parity/cli.ts dispatch — see cli.ts:296-311). This
-# is the ONLY mode that talks to a live C#/Supabase endpoint, and it is entirely non-mutating.
+# is the ONLY mode that talks to a live C#/Supabase endpoint.
+#
+# WHAT --verify-only ACTUALLY TOUCHES (corrected 2026-08-11; this block used to say "entirely
+# non-mutating", which was false for one row before today and is now false for two more).
+#
+#  1. `verify-write <key>` IS MUTATING BY DESIGN. It performs real writes and reads them back —
+#     cli.ts:241-244 says so. That has always been true and the old blanket claim never covered it.
+#
+#  2. `verify access-review` TRIGGERS A SECURITY-AUDIT INSERT, which is then rejected. GET
+#     /access-review and /access-review/export each call ISecurityEventWriter
+#     (AccessReviewEndpoints.cs:50, :91), so a run attempts 4 INSERTs into `audit_logs`. Every one
+#     FAILS and nothing is persisted, for a specific and verified reason: the surface pins the
+#     non-existent org id 00000000-0000-0000-0000-000000000000, and `audit_logs.organization_id`
+#     carries an enforced FK to `organizations(id)` — constraint `audit_logs_organization_id_fkey`,
+#     measured against the live database on 2026-08-11, with no organizations row holding that id.
+#     SecurityEventWriter.WriteAsync then swallows the violation fail-soft (SecurityEventWriter.cs:36).
+#     Net effect: no rows, but a warning per call in the service log. Pinned by
+#     AccessReviewEndpointAuthTests.PlatformOwner_Reads_Are200_ForNonExistentOrg, which asserts zero
+#     audit_logs rows for that org id — so if the FK is ever dropped, that test fails before a run does.
+#
+#  3. `verify audit-log` EGRESSES CROSS-TENANT DATA TO WHOEVER RUNS IT. /audit/logs returns the 20
+#     most recent audit rows across EVERY org and /audit/logs/export up to 1000, each carrying actor
+#     email, IP address and metadata. Both are fetched twice per run (parity probe + RBAC allow).
+#     Nothing is printed — report.ts renders only check/endpoint/role/detail, never a body — but the
+#     payload does reach the operator's machine. Run it somewhere you would be willing to hold
+#     production audit data, and do not pipe its output anywhere it would be retained.
 # ---------------------------------------------------------------------------------------------
 run_verify() {
   local surface="$1" row kind pcmd pkey
@@ -236,9 +263,13 @@ run_verify() {
 
   echo "==> verify-only: ${surface} (kind=${kind})"
   if [ "$pcmd" = "NONE" ]; then
-    echo "    No parity command registered for \"${surface}\" — its TS router was deleted outright,"
-    echo "    so there is no TS side left to diff against (see --list for detail). Treating this as"
-    echo "    trivially passed: nothing to verify."
+    echo "    No parity SURFACE is registered for \"${surface}\" — its entry was removed from"
+    echo "    scripts/parity/surfaces.ts (see --list for detail). Treating this as trivially passed:"
+    echo "    nothing to verify. DO NOT read this as a pass — it is a did-not-run."
+    echo "    NOTE: a deleted TS side is NOT by itself a reason for this state. tsProcedure is"
+    echo "    optional, so a surface with no TS side can still be registered C#-only and still"
+    echo "    assert RBAC against the live C# route — audit-log and access-review were restored"
+    echo "    that way on 2026-08-11. If you are here, the fix is to re-register, not to accept 0."
     return 0
   fi
   echo "    npx tsx ${PARITY_CLI} ${pcmd} ${pkey}"

--- a/scripts/parity/cli.ts
+++ b/scripts/parity/cli.ts
@@ -119,13 +119,17 @@ async function mintTokens(
   // (2950a06c / 18282f96), and was corrected on 2026-08-10 (#195) to say the branch was reachable
   // only from write-surfaces.ts's access-review surface.
   //
-  // CURRENT STATE, 2026-08-11: both READ surfaces were RE-REGISTERED C#-only, and both set
-  // probeRole: 'platform_owner' — so this branch is reachable from surfaces.ts again, from three
-  // callers now (SURFACES['audit-log'], SURFACES['access-review'], WRITE_SURFACES['access-review']).
-  // They CAN probe with the org-less identity precisely because they have no TS side left: a
-  // C#-only parity check never mints the org-B token this branch would otherwise demand. The
-  // `organization` read surface, which still has live TS procedures, deliberately probes with the
-  // org-scoped `org_admin` instead — see its comment in surfaces.ts.
+  // CURRENT STATE, 2026-08-11. `mintTokens` has exactly ONE call site — `runChecks` at :140, the
+  // READ path. `cmdVerifyWrite` mints its own tokens inline (:263-269) and never reaches here, so no
+  // WRITE_SURFACES entry is a caller of this branch, whatever its probeRole. THREE read surfaces now
+  // set probeRole 'platform_owner' and are the only callers: SURFACES['audit-log'],
+  // SURFACES['access-review'] (both re-registered C#-only today) and SURFACES['organization'].
+  //
+  // Do not restate the reason as "because they have no TS side left". The guard below keys on the
+  // ROLE and nothing else — a C#-only surface with an org-scoped probeRole would still be required
+  // to have an org-B token, and a TS-having surface with `platform_owner` still skips it, which is
+  // precisely why `organization` (live TS procedures) can and does use it. The real reason is
+  // narrower: a platform owner is org-less, so no org-B counterpart exists to demand.
   if (!orgBToken && primaryRole !== 'platform_owner') {
     throw new Error(`mintTokens: failed to mint org-B token for role "${primaryRole}"`);
   }

--- a/scripts/parity/cli.ts
+++ b/scripts/parity/cli.ts
@@ -113,14 +113,19 @@ async function mintTokens(
   // org-less identity, seeded once purely to hang the token cache off of) — an org-B counterpart
   // structurally does not exist, so don't require one.
   //
-  // CORRECTED 2026-08-10 (#195): this comment used to say "every surface that uses platform_owner as
-  // probeRole (access-review, audit-log) has globalScope:true", which is stale twice over. Both of
-  // those READ surfaces were REMOVED from surfaces.ts on 2026-07-31 (18282f96) and neither has
-  // existed since; and no surface in surfaces.ts uses platform_owner as probeRole at all — the
-  // platform-owner surfaces deliberately probe with an ORG-SCOPED role (org_admin), because an
-  // org-less identity has no org-B counterpart to probe with. This branch is therefore currently
-  // unreachable from surfaces.ts and is reached only via write-surfaces.ts's access-review surface,
-  // which does set probeRole: 'platform_owner'. Kept, because that is a real caller.
+  // History, because this comment has been wrong twice and the reason matters. It once said "every
+  // surface that uses platform_owner as probeRole (access-review, audit-log) has globalScope:true";
+  // that went stale on 2026-07-31 when both of those READ surfaces were REMOVED from surfaces.ts
+  // (2950a06c / 18282f96), and was corrected on 2026-08-10 (#195) to say the branch was reachable
+  // only from write-surfaces.ts's access-review surface.
+  //
+  // CURRENT STATE, 2026-08-11: both READ surfaces were RE-REGISTERED C#-only, and both set
+  // probeRole: 'platform_owner' — so this branch is reachable from surfaces.ts again, from three
+  // callers now (SURFACES['audit-log'], SURFACES['access-review'], WRITE_SURFACES['access-review']).
+  // They CAN probe with the org-less identity precisely because they have no TS side left: a
+  // C#-only parity check never mints the org-B token this branch would otherwise demand. The
+  // `organization` read surface, which still has live TS procedures, deliberately probes with the
+  // org-scoped `org_admin` instead — see its comment in surfaces.ts.
   if (!orgBToken && primaryRole !== 'platform_owner') {
     throw new Error(`mintTokens: failed to mint org-B token for role "${primaryRole}"`);
   }

--- a/scripts/parity/seed.ts
+++ b/scripts/parity/seed.ts
@@ -92,8 +92,11 @@ const ORG_KEYS: readonly ('a' | 'b')[] = ['a', 'b'];
  * (2950a06c / 18282f96) — at "`organization`, which probes with org_admin, so no read surface uses
  * platform_owner as its probeRole". Both statements are now stale: audit-log and access-review were
  * RE-REGISTERED C#-only on 2026-08-11 and both DO use platform_owner as probeRole, which is exactly
- * the case the `orgKey === 'b'` skip below has to keep supporting. Three READ surfaces list the role
- * today — audit-log, access-review, organization — plus write-surfaces.ts's access-review.) */
+ * the case the `orgKey === 'b'` skip below has to keep supporting — as does `organization`, whose
+ * probeRole was corrected to platform_owner the same day. Census of everything that lists the role,
+ * because `planSeed` is called from BOTH the read path (cli.ts:140) and the write path (cli.ts:265):
+ * three READ surfaces (audit-log, access-review, organization) and two WRITE surfaces
+ * (write-surfaces.ts's access-review and organization).) */
 export function planSeed(roles: string[]): SeedPlan {
   const users: SeededUser[] = [];
   for (const orgKey of ORG_KEYS)

--- a/scripts/parity/seed.ts
+++ b/scripts/parity/seed.ts
@@ -88,9 +88,12 @@ const ORG_KEYS: readonly ('a' | 'b')[] = ['a', 'b'];
  * `organizationId` is otherwise irrelevant to this identity.
  *
  * (This used to point at "the `audit-log` surface in surfaces.ts, the only surface that uses this
- * role". Stale since 2026-07-31: audit-log and access-review were both REMOVED from surfaces.ts in
- * 18282f96. Today the only READ surface listing `platform_owner` in its roles is `organization`, and
- * it probes with org_admin — no read surface uses platform_owner as its probeRole.) */
+ * role", then — after audit-log and access-review were REMOVED from surfaces.ts on 2026-07-31
+ * (2950a06c / 18282f96) — at "`organization`, which probes with org_admin, so no read surface uses
+ * platform_owner as its probeRole". Both statements are now stale: audit-log and access-review were
+ * RE-REGISTERED C#-only on 2026-08-11 and both DO use platform_owner as probeRole, which is exactly
+ * the case the `orgKey === 'b'` skip below has to keep supporting. Three READ surfaces list the role
+ * today — audit-log, access-review, organization — plus write-surfaces.ts's access-review.) */
 export function planSeed(roles: string[]): SeedPlan {
   const users: SeededUser[] = [];
   for (const orgKey of ORG_KEYS)

--- a/scripts/parity/surfaces.test.ts
+++ b/scripts/parity/surfaces.test.ts
@@ -13,6 +13,76 @@ describe('SURFACES', () => {
     expect(SURFACES['compensation'].probeRole).toBe('super_admin');
   });
 
+  // ── Registry-level invariants (added 2026-08-11) ─────────────────────────────────────────────
+  // These three did not exist before, and their absence let a real defect ship: #203 registered
+  // `organization` with probeRole 'org_admin', a role the surface answers 403 to, which makes
+  // `verify organization` fail both parity legs and CRASH the TS one (trpc.ts:11 throws on a tRPC
+  // error). Nothing caught it because every guard here was per-surface and hand-written.
+  //
+  // write-surfaces.test.ts's registry pin carried a comment claiming this file "already guards
+  // against [that] on the read side". It did not — there was no Object.keys(SURFACES) assertion at
+  // all. That comment is corrected there; these are the guards it was describing.
+
+  it('pins the registered read surfaces — adding or DELETING one must be deliberate', () => {
+    // The read-side analogue of write-surfaces.test.ts's key-set pin. Deleting a surface is how the
+    // access-review and audit-log coverage silently vanished for eleven days in 2026; the per-surface
+    // describes below could not catch it, because a deleted surface takes its own test with it.
+    expect(Object.keys(SURFACES).sort()).toEqual([
+      'access-review',
+      'audit-log',
+      'compensation',
+      'dei',
+      'engagement',
+      'monitoring',
+      'ninebox',
+      'organization',
+    ]);
+  });
+
+  it('every surface probes with a role it actually grants 200 — the #203 defect class', () => {
+    // THE invariant. `cli.ts:161-163` calls BOTH stacks with the probeRole's token and expects
+    // success: checks/parity.ts:47-55 fails closed on a non-200 C# response, and on the TS side
+    // stripTrpcJson (trpc.ts:11) THROWS on an error response, taking the whole run down rather than
+    // reporting a FAIL. So a probeRole the surface denies does not degrade the check — it destroys it.
+    for (const [key, surface] of Object.entries(SURFACES)) {
+      const probe = surface.probeRole;
+      expect(probe, `${key} has no explicit probeRole`).toBeDefined();
+      expect(surface.roles, `${key}: probeRole "${probe}" is not in roles`).toContain(probe);
+      for (const ep of surface.endpoints) {
+        expect(
+          ep.expectedByRole[probe!],
+          `${key}/${ep.name}: probeRole "${probe}" expects ${ep.expectedByRole[probe!]}, but the parity probe requires 200`,
+        ).toBe(200);
+      }
+    }
+  });
+
+  it('an endpoint with no DENIED role is on a documented list — its RBAC check proves nothing', () => {
+    // Generalised from the monitoring-specific version below. An all-200 matrix cannot distinguish
+    // "the permission check ran and allowed" from "no permission check ran" — every assertion reads
+    // "200 means allowed".
+    //
+    // Five endpoints are in that state TODAY. That is pre-existing and NOT fixed here: inventing a
+    // denial without checking what the product actually returns would assert a behaviour rather than
+    // observe one, and a wrong 403 expectation fails a real verify run in Federico's hands. So this
+    // is an allowlist, not a pass — a NEW all-200 endpoint has to be added here deliberately, and
+    // adding one is the signal to go find its denied role.
+    const knownNoDenial = [
+      'compensation/market-comparison', // grant-only org catalogue read; all three seeded roles hold it
+      'ninebox/movement-history', // only two roles registered at all
+      'ninebox/simulate', // pure kernel
+      'ninebox/quadrant-plan', // pure kernel
+      'engagement/surveys', // grant-only list; hrbp@unit passes deliberately (see the surface note)
+    ];
+    const actual: string[] = [];
+    for (const [key, surface] of Object.entries(SURFACES)) {
+      for (const ep of surface.endpoints) {
+        if (Object.values(ep.expectedByRole).every((v) => v !== 403)) actual.push(`${key}/${ep.name}`);
+      }
+    }
+    expect(actual.sort()).toEqual(knownNoDenial.sort());
+  });
+
   it('every Tier-2 by-id endpoint sets idScopeKey and carries the {id} sentinel in path + input', () => {
     // The by-id Mode-A IDOR endpoints and the resource key each threads.
     // 2026-08-03 (#58): 'succession/critical-role' removed with the surface.
@@ -129,8 +199,11 @@ describe('SURFACES', () => {
     const s = SURFACES['organization'];
     expect(s.flag).toBe('Platform__PlatformOrganizationsReadEnabled');
     expect(s.roles).toEqual(['platform_owner', 'org_admin']);
-    // org-scoped probe role: a platform owner is org-less and has no org-B counterpart to probe with.
-    expect(s.probeRole).toBe('org_admin');
+    // CORRECTED 2026-08-11: this asserted 'org_admin' from #203, pinning a defect rather than a
+    // decision — org_admin is 403 on both endpoints, so the parity probe could never succeed and the
+    // TS leg would throw (trpc.ts:11). The generalised probeRole-expects-200 invariant above is what
+    // makes this class of mistake unshippable; this line now just records the corrected value.
+    expect(s.probeRole).toBe('platform_owner');
 
     expect(s.endpoints.map((e) => e.name)).toEqual(['kpis', 'list']);
 
@@ -178,7 +251,7 @@ describe('SURFACES', () => {
     ).toBeDefined();
     expect(s.flag).toBe(flag);
     expect(s.roles).toEqual(['platform_owner', 'org_admin']);
-    // MUST be the allowed role: checks/parity.ts:25 fails a C#-only endpoint on any non-200, and
+    // MUST be the allowed role: checks/parity.ts:26-33 fails a C#-only endpoint on any non-200, and
     // cli.ts's mintTokens skips the org-B token requirement only for platform_owner.
     expect(s.probeRole).toBe('platform_owner');
     // Pinned by name and counted from the endpoints file, not auto-discovered: dropping a route
@@ -203,8 +276,17 @@ describe('SURFACES', () => {
     // seeded org id instead would turn these into by-id endpoints and collide with the globalScope
     // invariant above — which is precisely why getOrganization is still unregistered.
     const s = SURFACES['access-review'];
+    // Paths pinned EXACTLY, not by substring. An earlier revision asserted only
+    // `.toContain('organizationId=...')`, which left the route itself unpinned — a mutation to
+    // `/access-review/EXPORT-TYPO?organizationId=...` kept the whole file green. Nothing else in this
+    // repo compares a registry csharpPath to a real deployed route, so this assertion is the only
+    // thing standing between a C# route rename and a verify run that 404s in Federico's hands.
+    expect(s.endpoints.map((e) => e.csharpPath)).toEqual([
+      '/access-review?organizationId=00000000-0000-0000-0000-000000000000',
+      '/access-review/export?organizationId=00000000-0000-0000-0000-000000000000',
+      '/access-review/attestations?organizationId=00000000-0000-0000-0000-000000000000',
+    ]);
     for (const ep of s.endpoints) {
-      expect(ep.csharpPath, ep.name).toContain('organizationId=00000000-0000-0000-0000-000000000000');
       expect(ep.csharpPath, `${ep.name} must not use the by-id sentinel`).not.toContain('{id}');
       expect(ep.input, ep.name).toEqual({ organizationId: '00000000-0000-0000-0000-000000000000' });
     }

--- a/scripts/parity/surfaces.test.ts
+++ b/scripts/parity/surfaces.test.ts
@@ -54,7 +54,7 @@ describe('SURFACES', () => {
         expect(ep.idScopeKey, `${key}/${ep.name} is globalScope AND by-id`).toBeUndefined();
       }
     }
-    // Documented state, 4 endpoints across 2 surfaces. The loop above is the invariant; this pins the
+    // Documented state, 9 endpoints across 4 surfaces. The loop above is the invariant; this pins the
     // count so a NEW globalScope endpoint has to be looked at deliberately — and so that the loop
     // going empty (which would make the invariant unenforced while still reading as enforced) fails
     // here.
@@ -68,10 +68,16 @@ describe('SURFACES', () => {
     //     tenant boundary and Mode B's identical-payload heuristic would fire on the correct
     //     behaviour. `list` enumerates every tenant by definition. RBAC (org_admin 403 on both) is
     //     what proves the boundary here, not RLS.
+    //   audit-log logs + export and access-review report + export + attestations — SAME
+    //     platform-owner justification as organization (2026-08-11, re-registered C#-only). Both
+    //     surfaces carried `globalScope: true` before they were deleted on 2026-07-31, so this is
+    //     the pre-existing disposition restored, not a new claim of org-independence. access-review's
+    //     three routes pin a FIXED non-existent org id in the query string rather than a seeded id —
+    //     a literal, not the `{id}` sentinel — so the by-id invariant above is not being sidestepped.
     //
-    // Neither of the two new ones is by-id, so the invariant above still bites for them unchanged —
+    // None of the seven is by-id, so the invariant above still bites for them unchanged —
     // `getOrganization` was left unregistered rather than weaken it (see surfaces.ts).
-    expect(seen).toBe(4);
+    expect(seen).toBe(9);
   });
 
   // ── #195 AC1: the monitoring read surface (2026-08-10) ───────────────────────────────────────
@@ -102,7 +108,10 @@ describe('SURFACES', () => {
     const s = SURFACES['monitoring'];
     for (const ep of s.endpoints) {
       const denied = Object.entries(ep.expectedByRole).filter(([, v]) => v === 403);
-      expect(denied.map(([r]) => r), `${ep.name} has no denied role`).toEqual(['org_admin']);
+      expect(
+        denied.map(([r]) => r),
+        `${ep.name} has no denied role`,
+      ).toEqual(['org_admin']);
     }
   });
 
@@ -144,6 +153,69 @@ describe('SURFACES', () => {
     const names = SURFACES['organization'].endpoints.map((e) => e.name);
     expect(names).not.toContain('detail');
     expect(SURFACES['organization'].endpoints.some((e) => e.idScopeKey)).toBe(false);
+  });
+
+  // ── The two platform-owner READ surfaces re-registered C#-only on 2026-08-11 ──────────────────
+  // Both were REMOVED on 2026-07-31 (audit-log in 2950a06c, access-review in 18282f96) on the
+  // reasoning "the TS procedures are deleted, so there is nothing left to diff". `tsProcedure`
+  // became optional on 2026-08-06 (efb7553f) — SIX DAYS LATER — which is what makes that reasoning
+  // obsolete rather than merely debatable. These tests pin the RESTORATION the same way the nine-box
+  // and dei tests pin theirs: a future cleanup that deletes either surface "because the TS is gone"
+  // fails here, with the reason attached.
+  //
+  // What the restoration buys, stated narrowly on purpose: the RBAC deny assertion and the
+  // C#-returns-200 liveness check against a flag that is LIVE in prod. It does NOT buy a cross-tenant
+  // probe — every endpoint on both surfaces is globalScope, and was before deletion too, so the RLS
+  // check is a documented N/A now exactly as it was then.
+  it.each([
+    ['audit-log', 'Platform__AuditLogReadEnabled', ['logs', 'export']],
+    ['access-review', 'Platform__AccessReviewReadEnabled', ['report', 'export', 'attestations']],
+  ])('%s stays registered as a C#-only platform-owner surface', (key, flag, endpointNames) => {
+    const s = SURFACES[key];
+    expect(
+      s,
+      `the ${key} read surface was deleted — that retires its RBAC deny assertion on a LIVE flag`,
+    ).toBeDefined();
+    expect(s.flag).toBe(flag);
+    expect(s.roles).toEqual(['platform_owner', 'org_admin']);
+    // MUST be the allowed role: checks/parity.ts:25 fails a C#-only endpoint on any non-200, and
+    // cli.ts's mintTokens skips the org-B token requirement only for platform_owner.
+    expect(s.probeRole).toBe('platform_owner');
+    // Pinned by name and counted from the endpoints file, not auto-discovered: dropping a route
+    // must turn this red.
+    expect(s.endpoints.map((e) => e.name)).toEqual(endpointNames);
+
+    for (const ep of s.endpoints) {
+      // The TS routers are deleted. A re-added tsProcedure would mean a second live implementation.
+      expect(ep.tsProcedure, `${key}/${ep.name} must be C#-only — the TS router is deleted`).toBeUndefined();
+      // RBAC is the ENTIRE boundary proof on a principal-type gate, so the deny must be present.
+      expect(ep.expectedByRole, `${key}/${ep.name}`).toEqual({ platform_owner: 200, org_admin: 403 });
+      expect(ep.globalScope, `${key}/${ep.name}`).toBe(true);
+      expect(ep.idScopeKey, `${key}/${ep.name}`).toBeUndefined();
+    }
+  });
+
+  it('access-review pins a FIXED non-existent org id — not the {id} sentinel, and not a real org', () => {
+    // The three routes take a REQUIRED organizationId. The all-zeros UUID is deliberate: neither
+    // expectation depends on the org existing. The 403 comes from PlatformOwnerGate before any org
+    // lookup; the 200 is an EMPTY report, because AccessReviewService.BuildReportAsync has no
+    // org-exists precondition (only AttestAsync does, AccessReviewService.cs:35). Using a real
+    // seeded org id instead would turn these into by-id endpoints and collide with the globalScope
+    // invariant above — which is precisely why getOrganization is still unregistered.
+    const s = SURFACES['access-review'];
+    for (const ep of s.endpoints) {
+      expect(ep.csharpPath, ep.name).toContain('organizationId=00000000-0000-0000-0000-000000000000');
+      expect(ep.csharpPath, `${ep.name} must not use the by-id sentinel`).not.toContain('{id}');
+      expect(ep.input, ep.name).toEqual({ organizationId: '00000000-0000-0000-0000-000000000000' });
+    }
+  });
+
+  it('audit-log registers BOTH deployed routes, including the export the original entry missed', () => {
+    // Counted from AuditReadEndpoints.cs (MapGet at :32 and :63), not carried over from the deleted
+    // entry, which registered only `logs`. /audit/logs/export sits behind the same live flag and the
+    // same gate and had never had an RBAC assertion at all.
+    const paths = SURFACES['audit-log'].endpoints.map((e) => e.csharpPath);
+    expect(paths).toEqual(['/audit/logs', '/audit/logs/export']);
   });
 
   // ── Coverage-audit additions (2026-07-27) ────────────────────────────────────────────────────

--- a/scripts/parity/surfaces.ts
+++ b/scripts/parity/surfaces.ts
@@ -188,12 +188,25 @@ export const SURFACES: Record<string, Surface> = {
   // RLS — that proves it, via the org_admin 403 on every endpoint. Same disposition and same reason
   // as the access-review / audit-log read surfaces below.
   //
-  // probeRole is `org_admin`, not `platform_owner`: a platform owner is org-less and seeded only
-  // under org A (seed.ts:84), so it has no org-B counterpart to probe with. NOTE this DIVERGES from
-  // access-review/audit-log below, which probe with `platform_owner` — they can, because they have
-  // no TS side left, so `mintTokens` never needs an org-B token for them (cli.ts skips that
-  // requirement for `platform_owner`). This surface still has live TS procedures and must produce a
-  // real byte diff, so it needs the org-scoped identity that exists in both orgs.
+  // probeRole is `platform_owner`. It was `org_admin` from #203 (2026-08-10) until 2026-08-11, and
+  // THAT WAS A BUG THAT MADE `verify organization` UNRUNNABLE — caught by the review panel on this
+  // change, which found the comment here justifying it as deliberate.
+  //
+  // Why it could not work: the probe identity's token is what the parity leg calls BOTH stacks with
+  // (cli.ts:161-163), and `org_admin` expects 403 on every endpoint of this surface. On the C# side
+  // `checks/parity.ts:47-55` fails closed on any non-200, so both endpoints report
+  // "C# returned HTTP 403 (expected 200)". On the TS side it is worse than a FAIL: `stripTrpcJson`
+  // (trpc.ts:11) THROWS on a tRPC error response, so the run crashes rather than reporting. That is
+  // exactly the hazard the removed access-review entry documented in 2026-07-31 ("pointing probeRole
+  // at a denied role takes down the whole verify run") — the note was deleted with the surface and
+  // the lesson went with it, which is its own argument for keeping surfaces registered.
+  //
+  // The original rationale — "a platform owner is org-less and seeded only under org A (seed.ts:86),
+  // so it has no org-B counterpart to probe with" — is a true fact that does not imply the
+  // conclusion. `mintTokens` skips the org-B requirement for exactly this role (cli.ts:129), and
+  // both endpoints here are `globalScope`, so no org-B token is ever needed. `probeRole` must simply
+  // be a role the surface grants 200; that invariant is now asserted for EVERY surface in
+  // surfaces.test.ts, so this class of defect cannot ship again unnoticed.
   //
   // `getOrganization` (the by-id detail read) is DELIBERATELY NOT REGISTERED HERE, and that is the
   // honest answer rather than a shortcut. It needs two things at once — a real org id bound into
@@ -213,7 +226,7 @@ export const SURFACES: Record<string, Surface> = {
     key: 'organization',
     flag: 'Platform__PlatformOrganizationsReadEnabled',
     roles: ['platform_owner', 'org_admin'],
-    probeRole: 'org_admin', // org-scoped role — RLS/cross-tenant probing is N/A here; see globalScope.
+    probeRole: 'platform_owner', // the only role this surface answers 200 to — see the note above.
     endpoints: [
       {
         name: 'kpis',
@@ -387,11 +400,24 @@ export const SURFACES: Record<string, Surface> = {
   //
   // STANDING DEBT, 2026-08-11: that reasoning is the same one that removed audit-log and
   // access-review, and both were re-registered C#-only on 2026-08-11 because it does not survive
-  // `tsProcedure` becoming optional (efb7553f). The 5 surfaces still deleted on it — succession,
-  // team-intel, reporting, billing-read/billing-usage, evaluation360 — are deployed C# reads with
-  // no RBAC assertion in this harness. They were NOT restored in the same change because, unlike
-  // the two platform-owner surfaces, each is org-scoped RBAC and needs its own seeded grant fixture
-  // to prove anything (the #166 false-FAIL failure mode). Tracked in #195, not fixed here.
+  // `tsProcedure` becoming optional (efb7553f). SIX surfaces are still deleted on it — succession,
+  // team-intel, reporting, billing-read, billing-usage, evaluation360 (enumerated from
+  // `cutover.sh --list`, which shows exactly those six with parity_command NONE; counted, because an
+  // earlier draft of this comment wrote "5" and then listed six). They are deployed C# reads with no
+  // RBAC assertion in this harness. They were NOT restored in the same change because, unlike the two
+  // platform-owner surfaces, each is org-scoped RBAC and needs its own seeded grant fixture to prove
+  // anything (the #166 false-FAIL failure mode). Tracked in #195, not fixed here.
+  //
+  // AND THAT IS THE SMALLER HALF OF THE GAP. Those six are merely the surfaces that were once
+  // registered and then removed. Counting deployed ROUTES instead of surfaces, measured 2026-08-11:
+  // `services/Tims.Platform/src/Tims.Api/**/*.cs` contains 132 `.MapGet/Post/Patch/Put/Delete(`
+  // registrations and zero `MapGroup`, while SURFACES + WRITE_SURFACES hold 49 endpoints (23 + 26).
+  // The difference is not exactly the uncovered count — nothing here proves a 1:1 route-to-endpoint
+  // correspondence, and some Map calls are infra rather than domain routes — but the order of the gap
+  // is unambiguous, and it includes whole domains that were NEVER registered (external-vendor,
+  // billing self-serve/webhook writes, `/internal/alert-metrics`) plus most routes inside surfaces
+  // that ARE registered (engagement registers 2 endpoints against 14 deployed reads; dei 2 of 11).
+  // Do not read "the surface is registered" as "the domain is covered". #195 is the tracking issue.
   //
   // `verify succession` is therefore now a NO-OP. That is a genuine reduction in this harness's
   // coverage and is recorded as such in scripts/deploy/cutover.sh's `succession` row — do NOT
@@ -442,7 +468,7 @@ export const SURFACES: Record<string, Surface> = {
     roles: ['platform_owner', 'org_admin'],
     // MUST be the ALLOWED role (200), not the denied one: the parity check always calls probeRole's
     // token expecting success — including on the C#-only path, which fails the endpoint outright on
-    // any non-200 (checks/parity.ts:25) — so pointing probeRole at a denied role would fail every
+    // any non-200 (checks/parity.ts:26-33) — so pointing probeRole at a denied role would fail every
     // endpoint. org_admin (403) is still fully covered by the separate RBAC check via `tokensByRole`.
     // cli.ts's mintTokens deliberately skips the org-B token requirement for this role.
     probeRole: 'platform_owner',
@@ -472,6 +498,14 @@ export const SURFACES: Record<string, Surface> = {
       },
     ],
   },
+  // OPERATIONAL WARNING for whoever runs `verify audit-log` — it EGRESSES CROSS-TENANT DATA to the
+  // machine it runs on. `/audit/logs` returns the 20 most recent audit rows across EVERY org and
+  // `/audit/logs/export` up to 1000 (AuditReadRepository's ExportCap), each carrying actor email, IP
+  // address and metadata; both are fetched twice per run (parity probe + RBAC allow). Nothing is
+  // PRINTED — report.ts renders only check/endpoint/role/detail and never a response body — but the
+  // payload is still pulled over the wire. Run it somewhere you would be willing to hold production
+  // audit data. This is a property of the endpoints, not of the registration, and it was equally true
+  // before 2026-07-31; it is written down here because nobody had written it down.
   // ── access-review ────────────────────────────────────────────────────────────────────────
   // RE-REGISTERED 2026-08-11, C#-only. Removed on 2026-07-31 (18282f96) for the same reason, on the
   // same day, and reinstated on the same rationale as `audit-log` above — see that entry's
@@ -488,14 +522,37 @@ export const SURFACES: Record<string, Surface> = {
   // is exactly the property `getOrganization` lacks (it 404s on an unknown org), which is why THAT
   // read is still unregistered ~200 lines above.
   //
-  // The two report routes also write a security event with the bogus org id. That cannot 500 the
-  // read: SecurityEventWriter.WriteAsync wraps the insert in a fail-soft try/catch
-  // (SecurityEventWriter.cs:36) precisely so a lost audit row never blocks the caller.
+  // THE PINNED ID COLLIDES WITH A SENTINEL IN THIS DOMAIN'S OWN CODE, and that is worth knowing
+  // rather than discovering. `AccessReviewService.cs:65` coalesces a NULL `users.organization_id` to
+  // `Guid.Empty` — the SAME all-zeros value — and the rows with a NULL org are exactly the
+  // platform-owner accounts. Today that is harmless: the repository filters with a plain
+  // `u.OrganizationId == organizationId`, and in SQL `NULL = '000…'` is never true, so the report is
+  // empty. But a future refactor to a coalescing or left-joined form would make this id select the
+  // platform-owner roster, and every assertion in the registry would stay green. That outcome is
+  // therefore PINNED, not assumed: AccessReviewEndpointAuthTests asserts zero rows and a zero
+  // summary for this exact id.
   //
-  // `globalScope` is therefore correct here for the same reason as `audit-log`, and it does NOT
-  // collide with the `idScopeKey` guard in surfaces.test.ts — the org id is a fixed literal, not a
-  // seeded resource id threaded through the `{id}` sentinel, so there is no Mode-A probe being
-  // suppressed.
+  // THE TWO REPORT ROUTES WRITE A SECURITY EVENT, so `verify access-review` is not literally
+  // side-effect-free — it ATTEMPTS 4 INSERTs into `audit_logs` per run. None lands, and the reason is
+  // measured rather than hoped: `audit_logs.organization_id` carries an enforced FK to
+  // `organizations(id)` (`audit_logs_organization_id_fkey`, checked against the live database on
+  // 2026-08-11, with no organizations row holding the all-zeros id), so every insert is rejected and
+  // SecurityEventWriter.WriteAsync swallows it fail-soft (SecurityEventWriter.cs:36) rather than
+  // 500ing the read. Two consequences, both now guarded: the integration test asserts ZERO
+  // audit_logs rows for this org id, so dropping that FK fails CI instead of quietly making
+  // `--verify-only` mutating; and cutover.sh's safety block documents the attempt, because a command
+  // advertised as non-mutating must not have an undocumented write path.
+  //
+  // `globalScope` is correct here, but NOT for identical reasons to `audit-log`, and collapsing the
+  // two would set the wrong precedent. `/audit/logs` takes no org parameter and is cross-org by
+  // construction — the paradigm case. These three take a REQUIRED, CALLER-SUPPLIED `organizationId`
+  // and read that org's rows, which is the "no tenant boundary for THIS CALLER" category the
+  // `organization` entry above warns must never be confused with "pure kernel". They qualify only
+  // because the pinned id resolves to no org at all, so there is no per-org payload to compare and
+  // Mode B would be comparing two empty bodies. It does NOT collide with the `idScopeKey` guard —
+  // the id is a fixed literal, never the `{id}` sentinel, so no Mode-A probe is being suppressed.
+  // A version of this surface bound to a REAL org id would need the by-id platform-owner marker that
+  // `getOrganization` is still waiting on; it must not simply inherit `globalScope` from here.
   //
   // The WRITE surface (attestAccessReview) was never affected by any of this — write-surfaces.ts's
   // WRITE_SURFACES['access-review'] hits the C# endpoint directly via raw SQL + HTTP and has no

--- a/scripts/parity/surfaces.ts
+++ b/scripts/parity/surfaces.ts
@@ -186,11 +186,14 @@ export const SURFACES: Record<string, Surface> = {
   // report a documented N/A (it short-circuits at rls.ts:189, BEFORE the `idScopeKey` branch at :199)
   // rather than a spurious FAIL. The authorization boundary here is the GATE, and it is RBAC — not
   // RLS — that proves it, via the org_admin 403 on every endpoint. Same disposition and same reason
-  // as the access-review read surface that used to live here.
+  // as the access-review / audit-log read surfaces below.
   //
   // probeRole is `org_admin`, not `platform_owner`: a platform owner is org-less and seeded only
-  // under org A (seed.ts:84), so it has no org-B counterpart to probe with. Precedent verbatim from
-  // the removed access-review entry.
+  // under org A (seed.ts:84), so it has no org-B counterpart to probe with. NOTE this DIVERGES from
+  // access-review/audit-log below, which probe with `platform_owner` — they can, because they have
+  // no TS side left, so `mintTokens` never needs an org-B token for them (cli.ts skips that
+  // requirement for `platform_owner`). This surface still has live TS procedures and must produce a
+  // real byte diff, so it needs the org-scoped identity that exists in both orgs.
   //
   // `getOrganization` (the by-id detail read) is DELIBERATELY NOT REGISTERED HERE, and that is the
   // honest answer rather than a shortcut. It needs two things at once — a real org id bound into
@@ -200,8 +203,8 @@ export const SURFACES: Record<string, Surface> = {
   // "pure kernel, org-independent computation" (nine-box simulate/quadrant-plan), whereas this
   // endpoint reads org-specific rows and merely has no tenant boundary FOR THIS CALLER. Those are
   // different properties, and overloading one flag for both is precisely what would silently
-  // disable a real IDOR probe on some future surface. The removed access-review entry sidestepped
-  // it with a fixed non-existent org id, which cannot work here — `getOrganization` 404s on an
+  // disable a real IDOR probe on some future surface. The access-review entry below sidesteps it
+  // with a fixed non-existent org id, which cannot work here — `getOrganization` 404s on an
   // unknown org (organizations.ts:100), so the platform_owner case would assert 404, not 200.
   // Registering it needs a distinct, explicit concept (a platform-owner "no IDOR by design" marker,
   // the read-side analogue of write-surfaces.ts's documented omission of `buildIdor` on
@@ -289,7 +292,9 @@ export const SURFACES: Record<string, Surface> = {
   // 2026-07-29 pass had already removed the other 7 registered reads (grid, calibrations,
   // my-calibrations, bench-strength, dashboard-kpis, employee, calibration).
   //
-  // WHY THIS IS NOT DELETED, unlike succession/team-intel/billing-usage/reporting/evaluation360/audit-log.
+  // WHY THIS IS NOT DELETED, unlike succession/team-intel/billing-usage/reporting/evaluation360.
+  // (audit-log and access-review used to be on that list; both were RE-REGISTERED C#-only on
+  // 2026-08-11 on exactly the reasoning below — see their entries.)
   // Deleting the surface was the first instinct here and it was WRONG: only `checks/parity.ts` reads
   // `tsProcedure`. `checks/rls.ts` and `checks/rbac.ts` take `callCsharp` alone, so removing the surface
   // does not retire a stale TS comparison — it retires the RLS Mode-A cross-tenant IDOR probe and the
@@ -378,7 +383,15 @@ export const SURFACES: Record<string, Surface> = {
   // dashboard-kpis, suggested-successors, simulate-exit); `getCriticalRole` was kept then ONLY
   // because its TS implementation was still live, which is what made `verify succession` a real
   // check. It no longer is, so this surface follows team-intel/billing-usage/reporting/
-  // evaluation360/audit-log and is removed rather than left registered-but-no-op.
+  // evaluation360 and is removed rather than left registered-but-no-op.
+  //
+  // STANDING DEBT, 2026-08-11: that reasoning is the same one that removed audit-log and
+  // access-review, and both were re-registered C#-only on 2026-08-11 because it does not survive
+  // `tsProcedure` becoming optional (efb7553f). The 5 surfaces still deleted on it — succession,
+  // team-intel, reporting, billing-read/billing-usage, evaluation360 — are deployed C# reads with
+  // no RBAC assertion in this harness. They were NOT restored in the same change because, unlike
+  // the two platform-owner surfaces, each is org-scoped RBAC and needs its own seeded grant fixture
+  // to prove anything (the #166 false-FAIL failure mode). Tracked in #195, not fixed here.
   //
   // `verify succession` is therefore now a NO-OP. That is a genuine reduction in this harness's
   // coverage and is recorded as such in scripts/deploy/cutover.sh's `succession` row — do NOT
@@ -393,30 +406,132 @@ export const SURFACES: Record<string, Surface> = {
   // all 5 writes.
   //
   // ── audit-log ────────────────────────────────────────────────────────────────────────────
-  // REMOVED (TS-deletion, 2026-07-31): this surface's only endpoint (`logs`,
-  // tsProcedure `platform.getCrossOrgAuditLogs`) was deleted from
-  // packages/api/src/routers/platform/system.ts once NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP was
-  // confirmed live in prod and the FE wrapper (apps/web/lib/platform-api/audit-log.ts) moved to
-  // calling the C# service unconditionally — there is no TS side left to diff against. See
-  // scripts/deploy/cutover.sh's `audit-log` row (status TS_DELETED) for the cutover-tooling
-  // side of this change.
+  // RE-REGISTERED 2026-08-11, C#-only. Removed on 2026-07-31 (2950a06c) with the reason "no TS side
+  // left to diff against"; the endpoints were never removed from the deployed service.
   //
+  // WHY THE REMOVAL WAS WRONG UNDER TODAY'S RULES, stated precisely so this is not undone again:
+  // `tsProcedure` became OPTIONAL on 2026-08-06 (efb7553f) — SIX DAYS AFTER this surface was
+  // deleted (`git merge-base --is-ancestor 2950a06c efb7553f` confirms the order). At deletion time
+  // the field was mandatory and a dangling procedure ref really would have crashed `verify` at
+  // runtime, so removal was the only option available THEN. It is not the only option now: omitting
+  // the field keeps the endpoint registered, parity reports `[WEAK]` with a reason, and — the part
+  // that actually matters — the RBAC deny assertions keep running against the live C# path. That is
+  // exactly the disposition nine-box got in #57 and dei got in #60.
+  //
+  // WHAT THIS RESTORES, AND WHAT IT DOES NOT. It restores the RBAC platform-owner-vs-org_admin
+  // assertions and the C#-returns-200 liveness check. It does NOT restore an RLS Mode-A IDOR probe:
+  // every endpoint here is `globalScope`, so `checks/rls.ts` reports a documented N/A — that was
+  // true of the deleted entry too (it set `globalScope: true` on `logs`), so no cross-tenant probe
+  // was lost in 2026-07-31 and none is regained here. On a surface whose gate is PRINCIPAL TYPE
+  // rather than tenancy, RBAC is the entire boundary proof, which is what makes the deny assertion
+  // the whole point rather than a nice-to-have.
+  //
+  // URGENCY: `Platform__AuditLogReadEnabled=true` is LIVE on the App Runner service (measured
+  // 2026-08-10), so this is a surface serving production traffic that has had no automated
+  // permission assertion since 2026-07-31.
+  //
+  // Gate shape: PRINCIPAL TYPE (platform owner vs everyone else — `users.is_platform_owner`, see
+  // PlatformOwnerGate.cs + TS `platformProcedure`), independent of any org. Rather than add a new
+  // harness concept it reuses `roles`/`expectedByRole` with two role keys seed.ts already seeds:
+  // `platform_owner` (a real, org-less platform-owner identity — planSeed's comment) and `org_admin`
+  // (an ordinary seeded role) as the denied probe. org_admin needs no grant fixture here: the gate
+  // rejects it on the `is_platform_owner` bit BEFORE any permission lookup.
+  'audit-log': {
+    key: 'audit-log',
+    flag: 'Platform__AuditLogReadEnabled',
+    roles: ['platform_owner', 'org_admin'],
+    // MUST be the ALLOWED role (200), not the denied one: the parity check always calls probeRole's
+    // token expecting success — including on the C#-only path, which fails the endpoint outright on
+    // any non-200 (checks/parity.ts:25) — so pointing probeRole at a denied role would fail every
+    // endpoint. org_admin (403) is still fully covered by the separate RBAC check via `tokensByRole`.
+    // cli.ts's mintTokens deliberately skips the org-B token requirement for this role.
+    probeRole: 'platform_owner',
+    endpoints: [
+      {
+        name: 'logs',
+        csharpPath: '/audit/logs',
+        // tsProcedure omitted: `platform.getCrossOrgAuditLogs` was deleted 2026-07-31 (2950a06c).
+        input: {},
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        // Intentionally cross-org (a platform owner sees every org's rows) — Mode B's "identical
+        // payload across orgs ⇒ leak" heuristic asserts the opposite of the requirement here. The
+        // RLS check is a documented N/A, not a leak signal.
+        globalScope: true,
+      },
+      // NEW COVERAGE, not a restoration: `/audit/logs/export` (AuditReadEndpoints.cs:63) was NEVER
+      // registered, in the original entry or since, so it has never had an RBAC deny assertion
+      // despite being deployed behind the same live flag and the same gate. Counted from the
+      // endpoints file (2 routes), not carried over from the deleted entry (1).
+      {
+        name: 'export',
+        csharpPath: '/audit/logs/export',
+        // tsProcedure omitted: `platform.exportAuditLogsCsv` was deleted in the same commit.
+        input: {},
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        globalScope: true,
+      },
+    ],
+  },
   // ── access-review ────────────────────────────────────────────────────────────────────────
-  // READ surface REMOVED (TS-deletion, 2026-07-31): report/export/attestations
-  // (getAccessReview/exportAccessReviewCsv/listAccessReviewAttestations) were deleted from
-  // packages/api/src/routers/platform/access-review.ts once NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP
-  // was confirmed live — there is no TS side left to diff against, so `verify access-review` is
-  // now a no-op (see cutover.sh's `access-review` row, status TS_DELETED). Its former
-  // principal-type-gate pattern (platform owner vs everyone else — see `PlatformOwnerGate.cs` +
-  // TS `platformProcedure`, independent of any org) is gone from this harness too.
+  // RE-REGISTERED 2026-08-11, C#-only. Removed on 2026-07-31 (18282f96) for the same reason, on the
+  // same day, and reinstated on the same rationale as `audit-log` above — see that entry's
+  // "WHY THE REMOVAL WAS WRONG" and "WHAT THIS RESTORES" notes rather than restating them.
+  // `Platform__AccessReviewReadEnabled=true` is likewise LIVE on App Runner (measured 2026-08-10).
   //
-  // The WRITE surface (attestAccessReview) is UNAFFECTED here even though its own TS procedure
-  // was ALSO deleted the same day (NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP confirmed live) —
-  // write-surfaces.ts's WRITE_SURFACES['access-review'] tests the C# endpoint directly via raw
-  // SQL + HTTP (no TS comparison, no tsProcedure field), so it has zero dependency on the TS
-  // procedure's existence and stays fully valid/registered forever. `verify-write access-review`
-  // still runs a real check (see cutover.sh's `access-review-write` row, status TS DELETED but
-  // parity CLI invocation still `verify-write access-review`, not `NONE`).
+  // THE FIXED ORG ID IS DELIBERATE AND IS NOT A BY-ID ENDPOINT. All three routes take a REQUIRED
+  // `organizationId` query param, and the all-zeros UUID below is a non-existent org, carried over
+  // verbatim from the deleted entry. Neither expectation depends on that org existing: the 403
+  // (org_admin) is produced by PlatformOwnerGate before any org lookup, and the 200
+  // (platform_owner) is an empty report — `AccessReviewService.BuildReportAsync` has no
+  // org-exists precondition (only `AttestAsync` does, AccessReviewService.cs:35), so an unknown org
+  // yields zero rows and a zero summary, not a 404. Verified against the source, not assumed: this
+  // is exactly the property `getOrganization` lacks (it 404s on an unknown org), which is why THAT
+  // read is still unregistered ~200 lines above.
+  //
+  // The two report routes also write a security event with the bogus org id. That cannot 500 the
+  // read: SecurityEventWriter.WriteAsync wraps the insert in a fail-soft try/catch
+  // (SecurityEventWriter.cs:36) precisely so a lost audit row never blocks the caller.
+  //
+  // `globalScope` is therefore correct here for the same reason as `audit-log`, and it does NOT
+  // collide with the `idScopeKey` guard in surfaces.test.ts — the org id is a fixed literal, not a
+  // seeded resource id threaded through the `{id}` sentinel, so there is no Mode-A probe being
+  // suppressed.
+  //
+  // The WRITE surface (attestAccessReview) was never affected by any of this — write-surfaces.ts's
+  // WRITE_SURFACES['access-review'] hits the C# endpoint directly via raw SQL + HTTP and has no
+  // `tsProcedure` concept at all, so `verify-write access-review` has run a real check throughout.
+  'access-review': {
+    key: 'access-review',
+    flag: 'Platform__AccessReviewReadEnabled',
+    roles: ['platform_owner', 'org_admin'],
+    probeRole: 'platform_owner', // see the audit-log entry's probeRole comment — same fix, same reason.
+    endpoints: [
+      {
+        name: 'report',
+        csharpPath: '/access-review?organizationId=00000000-0000-0000-0000-000000000000',
+        // tsProcedure omitted: `platform.getAccessReview` was deleted 2026-07-31 (18282f96).
+        input: { organizationId: '00000000-0000-0000-0000-000000000000' },
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        globalScope: true,
+      },
+      {
+        name: 'export',
+        csharpPath: '/access-review/export?organizationId=00000000-0000-0000-0000-000000000000',
+        // tsProcedure omitted: `platform.exportAccessReviewCsv` was deleted in the same commit.
+        input: { organizationId: '00000000-0000-0000-0000-000000000000' },
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        globalScope: true,
+      },
+      {
+        name: 'attestations',
+        csharpPath: '/access-review/attestations?organizationId=00000000-0000-0000-0000-000000000000',
+        // tsProcedure omitted: `platform.listAccessReviewAttestations` was deleted in the same commit.
+        input: { organizationId: '00000000-0000-0000-0000-000000000000' },
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        globalScope: true,
+      },
+    ],
+  },
   // ── engagement ──────────────────────────────────────────────────────────────────────────────
   // Coverage-audit addition (2026-07-27): the C# `EngagementReadEndpoints` (Phase-5 Slice 11, 14
   // read routes) has been mapped/dark since PR history predating this audit, and the `engagement`
@@ -508,8 +623,9 @@ export const SURFACES: Record<string, Surface> = {
   // `checks/parity.ts:24` reports an explicit `[WEAK]` did-not-run instead of a silent pass, while
   // `checks/rbac.ts` (hrbp 403 / hr_admin 200 against the LIVE C# route) and `checks/rls.ts`
   // (Mode B cross-org payload comparison) keep running. Deleting the whole surface — the treatment
-  // the team-intel / reporting / billing-read / billing-usage / evaluation360 / audit-log /
-  // access-review / succession entries got — would silently retire that RBAC + RLS coverage, which
+  // the team-intel / reporting / billing-read / billing-usage / evaluation360 / succession entries
+  // got, and that audit-log / access-review got before being re-registered C#-only on 2026-08-11 —
+  // would silently retire that RBAC + RLS coverage, which
   // for org-wide demographic rollups is a security-coverage regression, not a cleanup.
   // So: `verify dei` still runs REAL RBAC + RLS checks; only the parity diff is gone. Its parity
   // coverage now lives in services/Tims.Platform/tests/Tims.IntegrationTests/Dei/

--- a/scripts/parity/write-surfaces.test.ts
+++ b/scripts/parity/write-surfaces.test.ts
@@ -506,8 +506,12 @@ describe('WRITE_SURFACES ninebox', () => {
 
 // Registry-level pin. There was none before #195: adding or DELETING an entire write surface tripped
 // nothing, so the per-surface describes below could silently stop covering a live surface — the exact
-// "an assertion that cannot run is not a guard" failure surfaces.test.ts already guards against on the
-// read side. Changing this list must be deliberate.
+// "an assertion that cannot run is not a guard" failure. CORRECTED 2026-08-11: this comment used to
+// end "...surfaces.test.ts already guards against on the read side". It did not — there was no
+// `Object.keys(SURFACES)` assertion there at all, which is part of why the access-review and
+// audit-log read surfaces could be deleted in 2026-07-31 and stay gone unnoticed. The read side has
+// its own key-set pin now, plus a probeRole-expects-200 invariant that caught a real defect.
+// Changing this list must be deliberate.
 describe('WRITE_SURFACES registry', () => {
   it('pins the registered write surfaces', () => {
     expect(Object.keys(WRITE_SURFACES).sort()).toEqual(
@@ -552,14 +556,24 @@ describe('WRITE_SURFACES organization', () => {
     // turning one write check into a cross-surface outage. This pins the safety choice so it cannot be
     // "fixed" into a real suspension by someone who reads suspend:false as a typo.
     const suspend = s.endpoints.find((e) => e.name === 'suspend')!;
-    const built = suspend.buildParity({ base: '', orgA: 'ORG_A', orgAdminUserId: 'X', platformOwnerUserId: 'Y' } as never);
+    const built = suspend.buildParity({
+      base: '',
+      orgA: 'ORG_A',
+      orgAdminUserId: 'X',
+      platformOwnerUserId: 'Y',
+    } as never);
     expect(built.body).toEqual({ suspend: false });
     expect(built.path).toBe('/platform/organizations/ORG_A/suspend');
   });
 
   it('update writes only name — never slug, which every other surface resolves org A by', () => {
     const update = s.endpoints.find((e) => e.name === 'update')!;
-    const built = update.buildParity({ base: '', orgA: 'ORG_A', orgAdminUserId: 'X', platformOwnerUserId: 'Y' } as never);
+    const built = update.buildParity({
+      base: '',
+      orgA: 'ORG_A',
+      orgAdminUserId: 'X',
+      platformOwnerUserId: 'Y',
+    } as never);
     expect(Object.keys(built.body as object)).toEqual(['name']);
   });
 });

--- a/scripts/parity/write-surfaces.ts
+++ b/scripts/parity/write-surfaces.ts
@@ -1419,8 +1419,9 @@ const ACCESS_REVIEW_NOTES_MARKER = 'parity';
 // Coverage-audit addition (2026-07-27): 1 write under Platform__AccessReviewWriteEnabled.
 // `attest` = PlatformOwnerGate + an unconditional insert into `access_reviews`. (This comment used to
 // point at "the access-review READ surface in surfaces.ts" for the gate rationale; that surface was
-// REMOVED on 2026-07-31 (18282f96) and the pointer dangled until #195. The same gate is now described
-// by the `organization` read surface in surfaces.ts.) UNLIKE every other
+// REMOVED on 2026-07-31 (18282f96) and the pointer dangled until #195, which repointed it at the
+// `organization` read surface. As of 2026-08-11 the access-review READ surface is back, C#-only, so
+// the original pointer is valid again — see SURFACES['access-review'] in surfaces.ts.) UNLIKE every other
 // write surface here, this one has NO cross-org IDOR concept: a platform owner is INTENTIONALLY
 // cross-org (they attest ANY org's access review by design — the same reason the read surface's
 // RLS check is `globalScope` rather than a leak signal), so `buildIdor` is correctly omitted —
@@ -1538,7 +1539,8 @@ const platformOrganizationsSurface: WriteSurface<PlatformOrganizationsWriteResol
         const o = asObj(b);
         if (!o) return 'response is not an object';
         if (typeof o.id !== 'string' || !UUID_RE.test(o.id)) return `expected a uuid id, got ${JSON.stringify(o.id)}`;
-        if (o.name !== ORG_WRITE_NAME_MARKER) return `expected name ${ORG_WRITE_NAME_MARKER}, got ${JSON.stringify(o.name)}`;
+        if (o.name !== ORG_WRITE_NAME_MARKER)
+          return `expected name ${ORG_WRITE_NAME_MARKER}, got ${JSON.stringify(o.name)}`;
         return null;
       },
       // The column write AND the fail-closed audit row, together — the audit is the half a

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewEndpointAuthTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewEndpointAuthTests.cs
@@ -194,12 +194,20 @@ public sealed class AccessReviewEndpointAuthTests(AccessReviewFixture fixture)
     /// 200 with an EMPTY report for a non-existent organization, so the harness can pin a fixed
     /// all-zeros org id and assert `platform_owner: 200` without seeding or resolving a real org.
     ///
-    /// Two behaviours make that true and both are load-bearing, so both are asserted here rather
-    /// than inferred from the source: (1) <see cref="Tims.Application.AccessReview.AccessReviewService.BuildReportAsync"/>
-    /// has NO org-exists precondition — only <c>AttestAsync</c> does, which is why
+    /// Two behaviours make that true and both are load-bearing:
+    /// (1) <see cref="Tims.Application.AccessReview.AccessReviewService.BuildReportAsync"/> has NO
+    /// org-exists precondition — only <c>AttestAsync</c> does, which is why
     /// <see cref="Attest_Is404_WhenOrgDoesNotExist"/> above expects 404 while these expect 200;
     /// (2) the security-event write that <c>report</c>/<c>export</c> perform with that bogus org id
-    /// cannot fail the request, because <c>SecurityEventWriter.WriteAsync</c> is fail-soft.
+    /// cannot fail the request, because <c>SecurityEventWriter.WriteAsync</c> is fail-soft — and, in
+    /// turn, cannot LEAVE A ROW either, because <c>audit_logs.organization_id</c> carries an enforced
+    /// FK to <c>organizations(id)</c> (verified against production 2026-08-11; see the fixture's own
+    /// note). That second half is what keeps <c>cutover.sh --verify-only</c> genuinely side-effect-free.
+    ///
+    /// All three are asserted below, not inferred — an earlier revision of this comment claimed the
+    /// fail-soft property was asserted when the fixture had no <c>audit_logs</c> table at all, so the
+    /// write threw on every path and the test could not tell fail-soft from success. The table (with
+    /// its FK) was added to the fixture for exactly this reason.
     ///
     /// The literal below is the SAME id the registry pins. If a future change makes an unknown org
     /// 404 here — the behaviour <c>getOrganization</c> already has, which is exactly why THAT read
@@ -217,6 +225,64 @@ public sealed class AccessReviewEndpointAuthTests(AccessReviewFixture fixture)
         var response = await Get(client, $"{path}?organizationId={ParityHarnessOrgId}", Mint(AccessReviewFixture.PlatformOwnerSub));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // The report is EMPTY, not merely a 200 — the specific claim the registry comment makes.
+        // (attestations returns a bare array; report/export carry the row set.)
+        var body = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        if (path == ReportPath)
+        {
+            Assert.Empty(json.RootElement.GetProperty("rows").EnumerateArray());
+            Assert.Equal(0, json.RootElement.GetProperty("summary").GetProperty("userCount").GetInt32());
+        }
+        else if (path == ExportPath)
+        {
+            Assert.Equal(0, json.RootElement.GetProperty("count").GetInt32());
+        }
+        else
+        {
+            Assert.Empty(json.RootElement.EnumerateArray());
+        }
+
+        // Fail-soft did not merely avoid throwing — it left NOTHING behind. The FK rejects the insert,
+        // so a `--verify-only` run against a live service writes no audit row. Asserting zero rows for
+        // the bogus org is the whole point; asserting "no exception" would have been vacuous.
+        Assert.Equal(0, await CountAuditLogsForOrg(ParityHarnessOrgId));
+    }
+
+    /// <summary>
+    /// The other side of the same control, and a genuine gap before 2026-08-11: nothing anywhere
+    /// proved that "a platform owner viewed org X's access review" is actually RECORDED. With no
+    /// <c>audit_logs</c> table in the fixture, <c>SecurityEventWriter</c>'s fail-soft catch swallowed
+    /// every write and the suite passed identically whether the control worked or not — a hollow
+    /// tripwire on a SOX-relevant trail. This asserts the row lands for a REAL org, which is also what
+    /// makes the zero-row assertion above meaningful rather than trivially true.
+    /// </summary>
+    [Fact]
+    public async Task PlatformOwner_Report_WritesTheAccessReviewViewedSecurityEvent()
+    {
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var before = await CountAuditLogsForOrg(AccessReviewFixture.OrgA.ToString(), "access_review_viewed");
+
+        var response = await Get(client, $"{ReportPath}?organizationId={AccessReviewFixture.OrgA}", Mint(AccessReviewFixture.PlatformOwnerSub));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.Equal(before + 1, await CountAuditLogsForOrg(AccessReviewFixture.OrgA.ToString(), "access_review_viewed"));
+    }
+
+    private async Task<int> CountAuditLogsForOrg(string organizationId, string? action = null)
+    {
+        await using var connection = new Npgsql.NpgsqlConnection(_fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = action is null
+            ? "SELECT count(*) FROM audit_logs WHERE organization_id = @org"
+            : "SELECT count(*) FROM audit_logs WHERE organization_id = @org AND action = @action";
+        command.Parameters.AddWithValue("org", Guid.Parse(organizationId));
+        if (action is not null) command.Parameters.AddWithValue("action", action);
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
     }
 
     /// <summary>

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewEndpointAuthTests.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewEndpointAuthTests.cs
@@ -26,6 +26,12 @@ public sealed class AccessReviewEndpointAuthTests(AccessReviewFixture fixture)
     private const string AttestPath = "/access-review/attest";
     private const string HistoryPath = "/access-review/attestations";
 
+    // The fixed, deliberately NON-EXISTENT organization id that scripts/parity/surfaces.ts's
+    // `access-review` surface pins into all three read paths. Not kept in sync by tooling — if the
+    // registry ever changes the value, PlatformOwner_Reads_Are200_ForNonExistentOrg below still
+    // proves the PROPERTY the registration depends on, just for a different id.
+    private const string ParityHarnessOrgId = "00000000-0000-0000-0000-000000000000";
+
     private static readonly RSA SigningRsa = RSA.Create(2048);
     private static readonly RsaSecurityKey PrivateKey = new(SigningRsa) { KeyId = "access-review-test-key" };
 
@@ -180,6 +186,54 @@ public sealed class AccessReviewEndpointAuthTests(AccessReviewFixture fixture)
         var response = await Get(client, $"{HistoryPath}?organizationId={AccessReviewFixture.OrgA}", Mint(AccessReviewFixture.PlatformOwnerSub));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Pins the assumption the parity harness's `access-review` surface registration rests on
+    /// (scripts/parity/surfaces.ts, re-registered C#-only 2026-08-11): all three READ routes answer
+    /// 200 with an EMPTY report for a non-existent organization, so the harness can pin a fixed
+    /// all-zeros org id and assert `platform_owner: 200` without seeding or resolving a real org.
+    ///
+    /// Two behaviours make that true and both are load-bearing, so both are asserted here rather
+    /// than inferred from the source: (1) <see cref="Tims.Application.AccessReview.AccessReviewService.BuildReportAsync"/>
+    /// has NO org-exists precondition — only <c>AttestAsync</c> does, which is why
+    /// <see cref="Attest_Is404_WhenOrgDoesNotExist"/> above expects 404 while these expect 200;
+    /// (2) the security-event write that <c>report</c>/<c>export</c> perform with that bogus org id
+    /// cannot fail the request, because <c>SecurityEventWriter.WriteAsync</c> is fail-soft.
+    ///
+    /// The literal below is the SAME id the registry pins. If a future change makes an unknown org
+    /// 404 here — the behaviour <c>getOrganization</c> already has, which is exactly why THAT read
+    /// is still unregistered — this test fails instead of the parity run failing in Federico's hands.
+    /// </summary>
+    [Theory]
+    [InlineData(ReportPath)]
+    [InlineData(ExportPath)]
+    [InlineData(HistoryPath)]
+    public async Task PlatformOwner_Reads_Are200_ForNonExistentOrg(string path)
+    {
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, $"{path}?organizationId={ParityHarnessOrgId}", Mint(AccessReviewFixture.PlatformOwnerSub));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The other half of the registry's expectation matrix on the same fixed id: `org_admin` (any
+    /// ordinary org user) is refused by <c>PlatformOwnerGate</c> BEFORE any org lookup, so the 403
+    /// does not depend on the org existing either. Without this, a green RBAC run on the harness
+    /// could not distinguish "the gate denied" from "the unknown org happened to error".
+    /// </summary>
+    [Fact]
+    public async Task OrdinaryOrgUser_Report_Is403_ForNonExistentOrg()
+    {
+        await using var factory = EnabledFactory();
+        using var client = factory.CreateClient();
+
+        var response = await Get(client, $"{ReportPath}?organizationId={ParityHarnessOrgId}", Mint(AccessReviewFixture.OrgUserSub));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     /// <summary>

--- a/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewFixture.cs
+++ b/services/Tims.Platform/tests/Tims.IntegrationTests/AccessReview/AccessReviewFixture.cs
@@ -122,6 +122,35 @@ public sealed class AccessReviewFixture : IAsyncLifetime
             unit_scope uuid NULL,
             expires_at timestamp NULL
         );
+        -- audit_logs was ABSENT from this fixture until 2026-08-11, which made the whole
+        -- access-review security-audit trail untestable: `/access-review` and `/access-review/export`
+        -- each call ISecurityEventWriter (AccessReviewEndpoints.cs:50, :91), SecurityEventWriter is
+        -- fail-soft (SecurityEventWriter.cs:36), and with no table every write threw and was silently
+        -- swallowed — so the suite passed identically whether or not `access_review_viewed` /
+        -- `platform_export` were ever recorded. A compliance control with no possible test.
+        --
+        -- The FK on organization_id is DELIBERATE and mirrors production, measured 2026-08-11 against
+        -- the live DB: constraint `audit_logs_organization_id_fkey`, FOREIGN KEY (organization_id)
+        -- REFERENCES organizations(id), enforced and not deferrable. It is what makes a read against a
+        -- NON-EXISTENT org id write nothing at all rather than leave an orphan row — the property the
+        -- parity harness's fixed all-zeros org id depends on, and the one that keeps
+        -- `cutover.sh --verify-only` free of side effects. Without the FK here the fixture could not
+        -- reproduce that, and the assertion in PlatformOwner_Reads_Are200_ForNonExistentOrg would be
+        -- testing nothing.
+        CREATE TABLE audit_logs (
+            id uuid PRIMARY KEY,
+            organization_id uuid NOT NULL REFERENCES organizations (id),
+            user_id uuid NULL,
+            actor_id uuid NULL,
+            action text NOT NULL,
+            entity text NOT NULL,
+            entity_id text NULL,
+            changes jsonb NULL,
+            metadata jsonb NULL,
+            ip_address text NULL,
+            user_agent text NULL,
+            created_at timestamp NOT NULL DEFAULT now()
+        );
         CREATE TABLE permissions (id uuid PRIMARY KEY, module text NOT NULL, action text NOT NULL);
         CREATE TABLE role_permissions (
             id uuid PRIMARY KEY,

--- a/tests/governance/cutover-table-matches-script.test.ts
+++ b/tests/governance/cutover-table-matches-script.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * scripts/deploy/README-cutover.md carries a surface table that duplicates scripts/deploy/cutover.sh's
+ * `surface_row` catalog, and the README's own header says it is "cross-checked directly against"
+ * that script. Nothing checked it.
+ *
+ * On 2026-08-11 an adversarial review found FOUR rows disagreeing with the script — the worst being
+ * `succession`, where the README advertised a `verify succession` command that the script sets to
+ * NONE and that surfaces.ts documents as a deliberate no-op. A reader following the README would run
+ * a command that silently exits 0 having verified nothing, which is precisely the class of failure
+ * .claude/rules/verification.md exists to prevent.
+ *
+ * This asserts the two stay in sync on the fields that change behaviour: the parity command a reader
+ * would copy, and the status label they would act on. It is deliberately a STRING comparison against
+ * the script's own catalog rather than a re-derivation, so the script stays the single source of
+ * truth and the README is the thing required to follow it.
+ */
+
+const ROOT = join(__dirname, '..', '..');
+const SCRIPT = readFileSync(join(ROOT, 'scripts/deploy/cutover.sh'), 'utf8');
+const README = readFileSync(join(ROOT, 'scripts/deploy/README-cutover.md'), 'utf8');
+
+interface ScriptRow {
+  surface: string;
+  parityCommand: string;
+  parityKey: string;
+  status: string;
+}
+
+/** Parses `surface_row`'s `case` arms: a `<name>)` label followed by `echo "kind|flag|pcmd|pkey|fe|status|note"`. */
+function parseScriptRows(): ScriptRow[] {
+  const rows: ScriptRow[] = [];
+  const lines = SCRIPT.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const label = /^\s{4}([a-z0-9-]+)\)\s*$/.exec(lines[i]);
+    if (!label) continue;
+    const echo = /^\s*echo "([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|/.exec(lines[i + 1] ?? '');
+    if (!echo) continue;
+    rows.push({ surface: label[1], parityCommand: echo[3], parityKey: echo[4], status: echo[6] });
+  }
+  return rows;
+}
+
+/** Human-readable status label, mirroring cutover.sh's `status_label`. */
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'CONFIRMED_LIVE':
+      return 'CONFIRMED LIVE';
+    case 'FLIP_READY':
+      return 'FLIP-READY';
+    case 'TS_DELETED':
+      return 'TS DELETED';
+    default:
+      return status;
+  }
+}
+
+describe('cutover.sh <-> README-cutover.md surface table', () => {
+  const rows = parseScriptRows();
+
+  it('parses every surface the script defines — a broken parser must not silently pass', () => {
+    // Non-vacuity floor. If the case-arm shape ever changes, this fails loudly instead of the
+    // per-row assertions below iterating zero times and reporting green.
+    const declared = /^ALL_SURFACES="(.+)"$/m.exec(SCRIPT)?.[1].split(' ') ?? [];
+    expect(declared.length).toBeGreaterThan(0);
+    expect(rows.map((r) => r.surface).sort()).toEqual([...declared].sort());
+  });
+
+  it.each(parseScriptRows().map((r) => [r.surface, r] as const))(
+    'README row for %s matches the script',
+    (surface, row) => {
+      const line = README.split('\n').find((l) => l.startsWith(`| \`${surface}\``));
+      expect(line, `no README table row for "${surface}"`).toBeDefined();
+
+      // The parity command a reader would copy. NONE rows must NOT advertise a runnable command —
+      // that was the succession defect.
+      if (row.parityCommand === 'NONE') {
+        expect(line, `${surface}: README advertises a parity command the script does not have`).not.toMatch(
+          /\|\s*`verify(-write)? /,
+        );
+      } else {
+        expect(line, `${surface}: README parity command disagrees with cutover.sh`).toContain(
+          `\`${row.parityCommand} ${row.parityKey}\``,
+        );
+      }
+
+      // The status a reader would act on.
+      expect(
+        line,
+        `${surface}: README status disagrees with cutover.sh (expected "${statusLabel(row.status)}")`,
+      ).toContain(statusLabel(row.status));
+    },
+  );
+});


### PR DESCRIPTION
Restores the two platform-owner READ surfaces deleted from `scripts/parity/surfaces.ts` on
2026-07-31 — `audit-log` (`2950a06c`) and `access-review` (`18282f96`) — as **C#-only** entries.
Both flags are live in production and neither surface has had an automated permission assertion for
eleven days.

Part of **#195**. The second commit is a tier-3 review-panel correction pass and contains the more
important change: **a defect already live on `main`**.

## Why the 2026-07-31 removals were right then and wrong now

They were removed because their `tsProcedure` refs "would break `verify` at runtime". `tsProcedure`
became **optional** in `efb7553f` on 2026-08-06 — six days later, and the ordering is measured, not
assumed (`git merge-base --is-ancestor` puts both deletions strictly before it and not the reverse).
Omitting the field keeps an endpoint registered C#-only: parity reports `[WEAK]`, and RBAC keeps
asserting. That is the disposition nine-box got in #57 and dei in #60.

## What this restores — and what it does not

**Restores:** the RBAC deny assertions (`platform_owner` 200 / `org_admin` 403 at `PlatformOwnerGate`)
and a C#-returns-200 liveness check, on two flags measured live on App Runner on 2026-08-10.

**Does NOT restore an RLS Mode-A cross-tenant probe**, and #195's own comment (mine) said otherwise.
Both deleted entries **already carried `globalScope: true` on every endpoint** — visible in the
deletion diffs — and `checks/rls.ts:189` short-circuits on that flag before the `idScopeKey` branch.
The RLS check was a documented N/A before and is one now. Nothing cross-tenant was lost in July or
regained here. On a principal-type gate, RBAC *is* the authorization boundary, so the deny assertion
is the point rather than a consolation prize.

**New coverage, not restoration:** `/audit/logs/export` is registered for the first time — same live
flag, same gate, never had an RBAC assertion. Route counts come from the endpoints files (audit-log
2, access-review 3 reads + 1 write), not from the deleted entries.

## The defect this uncovered, live on `main`

`SURFACES['organization']` — registered yesterday in #203 — sets `probeRole: 'org_admin'` while every
endpoint expects `org_admin: 403`. The probe token is what the parity leg calls **both** stacks with
and it requires success, so the C# leg fails closed and the TS leg **throws** (`trpc.ts:11`).
`verify organization` could never have passed. Corrected to `platform_owner`.

The panel found it because commit 1 of this branch wrote a comment *justifying* that value as
deliberate. Three registry-level invariants now exist so the class cannot recur — probeRole must
expect 200 everywhere, probeRole ∈ roles, and an `Object.keys(SURFACES)` key-set pin. The write side's
pin claimed this file "already guards against [deletion] on the read side"; it did not, which is part
of why these two surfaces could vanish unnoticed.

## `--verify-only` is not literally side-effect-free

It was documented four times as "entirely non-mutating". `verify-write` mutates by design, and
`verify access-review` attempts 4 `audit_logs` INSERTs (both report routes call `ISecurityEventWriter`).
**None lands**, checked against the live database rather than reasoned about:
`audit_logs_organization_id_fkey` is an enforced FK and no org holds the pinned all-zeros id, so each
insert is rejected and swallowed fail-soft. Now documented where an operator reads it **and pinned** —
the fixture gained `audit_logs` with that FK and the test asserts zero rows, so dropping the FK fails
CI instead of quietly turning a read-only command into a writer. `verify audit-log` also egresses up
to ~2000 cross-tenant audit rows (actor emails, IPs) to the machine running it; nothing is printed,
but that is now written down.

## Also fixed (pre-existing)

- **Four README rows contradicted `cutover.sh`** — worst: `succession` advertised `verify succession`,
  which the script sets to `NONE`. A reader would run a command that exits 0 having verified nothing.
  New guard `tests/governance/cutover-table-matches-script.test.ts` parses the script's catalog and
  asserts the README follows it, with a non-vacuity floor.
- `run_verify`'s **printed** message still asserted the conflation this PR declares false.
- A hollow tripwire: the access-review fixture had no `audit_logs` table, so nothing could prove the
  `access_review_viewed` compliance row is ever written. Now asserted.
- `docs/REMAINING-WORK.md` + slice-19/20 docs said the registry covers "4 of ~15 domains" and that
  step 5 on organizations is "unrunnable by anyone". It holds 8 keys now.
- A README claim that was **false when written**: `write-surfaces.ts`'s access-review *write* entry
  "was removed". It never was.

## Scope deliberately not taken

Six surfaces remain deleted on the same bad reasoning (`team-intel`, `reporting`, `billing-read`,
`billing-usage`, `evaluation360`, `succession` — enumerated from `--list`). Unlike these two, each is
org-scoped RBAC and needs its own seeded grant fixture; a missing one produces the #166 false-FAIL.
And the gap is larger than surfaces: `src/Tims.Api` maps **132** routes against **49** registered
endpoints. Recorded in `surfaces.ts`, tracked in #195, not fixed here.

## Verification

| Check | Result |
| --- | --- |
| vitest | **3084 / 311 files** (main: 3058 / 310) |
| C# unit | **916** (unchanged) |
| C# integration | **1182** (main: 1177) |
| `tsc --noEmit` @tims/api + apps/web | clean |
| `dotnet build -c Release` | succeeds, **no OpenAPI drift** (no route changed) |
| `bash -n` + `--list` on cutover.sh | clean |
| Mutation proofs | **7/7** on `surfaces.ts`, **4/4** on the new cutover-table test |

**Cross-model verification: NOT RUN.** `/gate` check 15 exited **2** for the 21st time — Codex is
quota-blocked, and the refusal now reads **"try again at Sep 9th, 2026"**, not the 2026-08-15 recorded
in `.claude/rules/verification.md`. Tier 2 (OmniRoute) correctly refuses with `OMNIROUTE_MODEL` unset.

**Tier 3 ran instead** — a 3-lens same-model adversarial panel (security/tenant-isolation, claim
auditor, coverage), each prompted to refute and to re-read source. It falsified six claims in my own
first commit, proved one guard gap by mutation, and found the `verify organization` defect. Per the
rule: this is **same-model** review and is weaker than cross-model — it shares the author's blind
spots. **Nothing in this PR is cross-model verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
