### PR TITLE
feat(parity): probe-viability preflight (#206) + route-coverage guard and by-id platform-owner marker (#195)

### DIFF
--- a/scripts/parity/checks/preflight.test.ts
+++ b/scripts/parity/checks/preflight.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runProbePreflight, diagnoseProbeViability } from './preflight';
+import { TrpcError } from '../trpc';
+import type { EndpointDef } from '../surfaces';
+
+// Zero network: both callers are injected, mirroring checks/parity.test.ts:19-30.
+const ep: EndpointDef = {
+  name: 'kpis',
+  csharpPath: '/platform/organizations/kpis',
+  tsProcedure: 'platform.getOrganizationKpis',
+  input: {},
+  expectedByRole: { platform_owner: 200, org_admin: 403 },
+};
+
+const ok200 = async () => ({ status: 200, body: { a: 1 } });
+const okTs = async () => ({ a: 1 });
+
+const FLAG = 'Platform__PlatformOrganizationsReadEnabled';
+
+/** Runs the preflight with the org-A probe identity's (fake) credentials. */
+function run(
+  endpoint: EndpointDef,
+  csharp: (base: string, path: string, token: string) => Promise<{ status: number; body: unknown }>,
+  ts: (base: string, proc: string, input: unknown, cookie: string) => Promise<unknown>,
+  role = 'platform_owner',
+  checkTs = true,
+) {
+  return runProbePreflight({
+    ep: endpoint,
+    surfaceKey: 'organization',
+    surfaceFlag: FLAG,
+    probeRole: role,
+    csharpBase: 'http://csharp.local',
+    tsBase: 'http://ts.local',
+    orgAToken: 'tok',
+    orgACookie: 'ck',
+    checkTs,
+    csharp,
+    ts,
+  });
+}
+
+describe('runProbePreflight — the probe identity is viable', () => {
+  it('C# 200 + TS resolves ⇒ ok, with no detail (a precondition that held says nothing)', async () => {
+    const r = await run(ep, ok200, okTs);
+    expect(r).toEqual({ check: 'preflight', endpoint: 'kpis', ok: true });
+    expect(r.detail).toBeUndefined();
+  });
+});
+
+// The verdict tests below all injected zero-parameter fakes, so NOTHING asserted what the runner
+// actually did with the base, path or credentials it was handed. Live-verified 2026-08-11: swapping
+// `orgAToken` for `orgACookie` on the C# call left the entire 408-test suite green, while in
+// production it would bail every surface with a false "PROBE IDENTITY NOT VIABLE". Fail-closed and
+// loud, so lower severity than a false green — but the runner's CALLS were untested, not just
+// under-tested.
+describe('runProbePreflight — the calls it issues (not just the verdicts it returns)', () => {
+  it('hands each stack its OWN base, path/procedure, input and credential — Bearer to C#, cookie to TS', async () => {
+    const csharp = vi.fn(ok200);
+    const ts = vi.fn(okTs);
+    await run(ep, csharp, ts);
+    expect(csharp).toHaveBeenCalledTimes(1);
+    // C#: the csharpBase, the endpoint's REST path, and the Bearer access token. Not the cookie.
+    expect(csharp).toHaveBeenCalledWith('http://csharp.local', '/platform/organizations/kpis', 'tok');
+    expect(ts).toHaveBeenCalledTimes(1);
+    // TS: the tsBase, the tRPC procedure, the endpoint's input, and the session cookie. Not the token.
+    expect(ts).toHaveBeenCalledWith('http://ts.local', 'platform.getOrganizationKpis', ep.input, 'ck');
+  });
+
+  it('probes the SUBSTITUTED endpoint it is given — a by-id probe must carry a real id, not `{id}`', async () => {
+    // `preflightSurface` (cli.ts) binds the org-A id before calling in; this pins that the runner
+    // uses the endpoint object handed to it rather than re-deriving anything from the registry.
+    const bound: EndpointDef = {
+      ...ep,
+      name: 'detail',
+      csharpPath: '/platform/organizations/2f1a0000-0000-4000-8000-00000000000a',
+      tsProcedure: 'platform.getOrganization',
+      input: { id: '2f1a0000-0000-4000-8000-00000000000a' },
+    };
+    const csharp = vi.fn(ok200);
+    const ts = vi.fn(okTs);
+    await run(bound, csharp, ts);
+    expect(csharp).toHaveBeenCalledWith(
+      'http://csharp.local',
+      '/platform/organizations/2f1a0000-0000-4000-8000-00000000000a',
+      'tok',
+    );
+    expect(ts).toHaveBeenCalledWith(
+      'http://ts.local',
+      'platform.getOrganization',
+      { id: '2f1a0000-0000-4000-8000-00000000000a' },
+      'ck',
+    );
+  });
+
+  it('checkTs:false issues NO TS call at all — rls/rbac must not depend on the TS stack', async () => {
+    // `rls`/`rbac` have never called TS. Probing it for them would let a Vercel outage abort a
+    // pure-C# run with zero checks executed — a coupling introduced by the guard, not by the defect.
+    const ts = vi.fn(okTs);
+    const r = await run(ep, ok200, ts, 'platform_owner', false);
+    expect(ts).not.toHaveBeenCalled();
+    expect(r.ok).toBe(true);
+  });
+
+  it('checkTs:false does NOT suppress the C# verdict', async () => {
+    const r = await run(ep, async () => ({ status: 403, body: '' }), okTs, 'platform_owner', false);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('403');
+  });
+});
+
+describe('runProbePreflight — the LIVE gate disagrees with the registry (#205, #206)', () => {
+  it('C# 403 while the registry says 200 ⇒ FAIL naming surface, endpoint, role, status and the crash it prevents', async () => {
+    const r = await run(ep, async () => ({ status: 403, body: 'Forbidden' }), okTs);
+    expect(r.ok).toBe(false);
+    // Every element an operator needs to act WITHOUT reading this file. `organization/kpis`
+    // rather than a bare `organization`/`kpis`, both of which the csharpPath alone satisfies.
+    expect(r.detail).toContain('verify organization:'); // the command that just bailed
+    expect(r.detail).toContain('organization/kpis'); // surface key + endpoint name
+    expect(r.detail).toContain('403'); // what actually happened
+    expect(r.detail).toContain('platform_owner'); // the probeRole
+    expect(r.detail).toContain('expectedByRole'); // what the registry claims
+    expect(r.detail).toContain('stripTrpcJson'); // what running anyway would have done
+  });
+
+  it('a 404 sends the operator to the FLAG first, not to the registry — every read surface is dark today', async () => {
+    // The previous version of this test asserted only `toContain('404')`, which pinned the presence
+    // of a number and said nothing about whether the ADVICE was right. A 404 from an unflipped flag
+    // is the expected FIRST experience of this feature, not an edge case, and "fix the registry or
+    // the seeded grant" is the wrong next step for it.
+    const r = await run(ep, async () => ({ status: 404, body: '' }), okTs);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('404');
+    expect(r.detail).toContain('AMBIGUOUS');
+    expect(r.detail).toContain(FLAG); // the surface's own flag, by name
+    expect(r.detail).toContain('CHECK THE FLAG FIRST');
+  });
+});
+
+describe('runProbePreflight — it can NEVER throw (that is the entire point)', () => {
+  it('a TS TrpcError RESOLVES as a FAIL carrying the message and the JSON-RPC code', async () => {
+    const r = await run(ep, ok200, async () => {
+      throw new TrpcError('No tienes permiso para realizar esta acción', -32003);
+    });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('No tienes permiso');
+    expect(r.detail).toContain('-32003');
+    // The code is JSON-RPC, not HTTP — saying so stops an operator hunting for a 32003 status.
+    expect(r.detail).toContain('JSON-RPC');
+    // A real tRPC rejection IS a registry/grant question, so this branch keeps the remediation.
+    expect(r.detail).toContain('do NOT change probeRole');
+  });
+
+  it('a raw SyntaxError from a non-JSON TS response is diagnosed as TRANSPORT, not as a grant', async () => {
+    // The C# side has always distinguished its transport failure from its verdicts; the TS side did
+    // not, so a mid-redeploy Vercel app answering a 502 HTML page produced "Fix the registry or the
+    // seeded grant" — pointing the operator at grants for an outage.
+    const r = await run(ep, ok200, async () => {
+      throw new SyntaxError('Unexpected token < in JSON at position 0');
+    });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('Unexpected token');
+    expect(r.detail).toContain('transport/config failure, not a grant failure');
+    expect(r.detail).toContain('tsBase');
+    // No JSON-RPC code exists on a SyntaxError — the clause must not be fabricated...
+    expect(r.detail).toContain('JSON-RPC code (trpc.ts:11)');
+    expect(r.detail).not.toContain('JSON-RPC code -');
+    // ...and the registry remediation must NOT be attached to a transport failure.
+    expect(r.detail).not.toContain('do NOT change probeRole');
+  });
+
+  it('a C# transport failure RESOLVES as a FAIL and is diagnosed as transport, not as a grant', async () => {
+    const r = await run(
+      ep,
+      async () => {
+        throw new Error('fetch failed: ECONNREFUSED');
+      },
+      okTs,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('ECONNREFUSED');
+    expect(r.detail).toContain('could not reach');
+  });
+});
+
+describe('runProbePreflight — a C#-only endpoint', () => {
+  it('never calls the TS side when tsProcedure is absent, and still applies the C# verdict', async () => {
+    let tsCalls = 0;
+    const csharpOnly: EndpointDef = { ...ep, tsProcedure: undefined };
+    const countingTs = async () => {
+      tsCalls++;
+      return {};
+    };
+    const pass = await run(csharpOnly, ok200, countingTs);
+    expect(tsCalls).toBe(0);
+    expect(pass.ok).toBe(true);
+
+    const fail = await run(csharpOnly, async () => ({ status: 403, body: '' }), countingTs);
+    expect(tsCalls).toBe(0);
+    expect(fail.ok).toBe(false);
+    expect(fail.detail).toContain('403');
+  });
+});
+
+describe('runProbePreflight — the registry is self-inconsistent', () => {
+  it('no expectedByRole entry for the probeRole ⇒ FAIL even when C# answers 200', async () => {
+    const r = await run(ep, ok200, okTs, 'role_that_is_not_in_the_map');
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('NO expectedByRole entry');
+    expect(r.detail).toContain('role_that_is_not_in_the_map');
+  });
+
+  it('expectedByRole says 403 for the probeRole ⇒ FAIL even when C# answers 200 (the #205 shape)', async () => {
+    const r = await run(ep, ok200, okTs, 'org_admin');
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('The registry itself says');
+    expect(r.detail).toContain('403');
+    // Name the guard that should have made this unreachable, so the reader knows where to look.
+    expect(r.detail).toContain('every surface probes with a role it actually grants 200');
+  });
+});
+
+// The pure verdict function, exercised directly for the ordering rules that the live runner
+// cannot reach (it never produces two failing conditions it does not already short-circuit).
+describe('diagnoseProbeViability (pure)', () => {
+  const base = {
+    surfaceKey: 'organization',
+    surfaceFlag: FLAG,
+    probeRole: 'platform_owner',
+    endpointName: 'kpis',
+    csharpPath: '/platform/organizations/kpis',
+    tsProcedure: 'platform.getOrganizationKpis',
+    registryExpectation: 200 as const,
+  };
+
+  it('returns null — and ONLY null — when everything held', () => {
+    expect(diagnoseProbeViability({ ...base, csharpStatus: 200, ts: { ok: true } })).toBeNull();
+    expect(diagnoseProbeViability({ ...base, csharpStatus: 200 })).toBeNull();
+  });
+
+  it('a registry defect is reported ahead of a live-gate status — it is the more actionable fact', () => {
+    const d = diagnoseProbeViability({ ...base, registryExpectation: 403, csharpStatus: 403 });
+    expect(d).toContain('The registry itself says');
+    expect(d).not.toContain('disagrees with the LIVE gate');
+  });
+
+  it('a transport failure is reported ahead of the TS leg — a stack that was never reached has no verdict', () => {
+    const d = diagnoseProbeViability({
+      ...base,
+      csharpStatus: { failed: 'ECONNREFUSED' },
+      ts: { ok: false, message: 'irrelevant' },
+    });
+    expect(d).toContain('could not reach');
+    expect(d).not.toContain('irrelevant');
+  });
+
+  // The previous version of this test was HOLLOW: it was titled "every FAIL diagnosis carries the
+  // remediation clause" and asserted only the "PROBE IDENTITY NOT VIABLE" header. Live-verified
+  // 2026-08-11 — stripping `${REMEDIATION}` from three of the four branches it enumerates left the
+  // file GREEN (13/13). The clause itself is now asserted, in BOTH directions.
+  it('every registry/grant FAIL carries the remediation clause — a diagnosis without a next step is a stack trace', () => {
+    const REMEDIATION_HEAD = 'Fix the registry or the seeded grant';
+    const REMEDIATION_TAIL = 'do NOT change probeRole to another role the product also denies';
+    const cases: Array<[string, Parameters<typeof diagnoseProbeViability>[0]]> = [
+      ['1: no expectedByRole entry', { ...base, registryExpectation: undefined, csharpStatus: 200 }],
+      ['2: registry says 403', { ...base, registryExpectation: 403 as const, csharpStatus: 200 }],
+      ['4a: dark route 404', { ...base, csharpStatus: 404 }],
+      ['4b: live gate denies', { ...base, csharpStatus: 403 }],
+      [
+        '5b: TS rejects with a tRPC code',
+        { ...base, csharpStatus: 200, ts: { ok: false as const, message: 'x', code: -32003 } },
+      ],
+    ];
+    for (const [label, c] of cases) {
+      const d = diagnoseProbeViability(c);
+      expect(d, label).not.toBeNull();
+      expect(d, label).toContain('PROBE IDENTITY NOT VIABLE — no check ran');
+      expect(d, label).toContain(REMEDIATION_HEAD);
+      expect(d, label).toContain(REMEDIATION_TAIL);
+      expect(d, label).toContain('stripTrpcJson');
+    }
+  });
+
+  it('the three NON-registry FAILs deliberately withhold it — wrong advice is worse than none', () => {
+    // Sending an operator to the grants for a DNS error, an unflipped flag or a 502 HTML page is the
+    // wrong next step in each case. Each of these three names its OWN next step instead.
+    const notRegistry: Array<[string, Parameters<typeof diagnoseProbeViability>[0], string]> = [
+      ['3: C# transport', { ...base, csharpStatus: { failed: 'ECONNREFUSED' } }, 'check csharpBase'],
+      [
+        '5a: TS transport/parse',
+        { ...base, csharpStatus: 200, ts: { ok: false as const, message: 'Unexpected token <' } },
+        'check tsBase',
+      ],
+    ];
+    for (const [label, c, ownAdvice] of notRegistry) {
+      const d = diagnoseProbeViability(c);
+      expect(d, label).toContain('PROBE IDENTITY NOT VIABLE — no check ran');
+      expect(d, label).not.toContain('Fix the registry or the seeded grant');
+      expect(d, label).not.toContain('do NOT change probeRole');
+      expect(d, label).toContain(ownAdvice);
+    }
+    // 4a (404) is the in-between case: it DOES carry the remediation, but only after naming the flag
+    // as the thing to check FIRST. Pinned so a future edit cannot demote the flag to a footnote.
+    const dark = diagnoseProbeViability({ ...base, csharpStatus: 404 })!;
+    expect(dark.indexOf('CHECK THE FLAG FIRST')).toBeLessThan(dark.indexOf('Fix the registry'));
+  });
+});

--- a/scripts/parity/checks/preflight.ts
+++ b/scripts/parity/checks/preflight.ts
@@ -1,0 +1,245 @@
+import type { EndpointDef } from '../surfaces';
+
+export interface CheckResult {
+  check: 'preflight';
+  endpoint: string;
+  ok: boolean;
+  detail?: string;
+}
+
+/** What the TS leg did. `callTs` (callers.ts:93-106) returns no status — a tRPC
+ *  error becomes a THROWN TrpcError (trpc.ts:11) — so the outcome is modelled as a
+ *  discriminated union here rather than as an HTTP status.
+ *
+ *  `code` is the DISCRIMINATOR between two very different failures, not decoration.
+ *  `stripTrpcJson` (trpc.ts:11) attaches the JSON-RPC code from the tRPC error envelope, so a
+ *  code PRESENT means the TS app answered with a real tRPC rejection (authz, validation, …).
+ *  A code ABSENT means no tRPC envelope came back at all — `res.json()` threw on an HTML/502
+ *  body (callers.ts:104, which has no try/catch, unlike callCsharp at callers.ts:57-61), or the
+ *  request never completed. Those two get different diagnoses and different next steps. */
+export type TsProbeOutcome = { ok: true } | { ok: false; message: string; code?: number };
+
+export interface ProbeViabilityInput {
+  surfaceKey: string;
+  /** The surface's feature flag (`Surface.flag`). Named in the 404 diagnosis, because on a DARK
+   *  surface — which every registered read surface is, wholly or partly, today — an unmounted
+   *  route 404s indistinguishably from a denied one, and the flag is the first thing to check. */
+  surfaceFlag: string;
+  probeRole: string;
+  endpointName: string;
+  csharpPath: string;
+  tsProcedure?: string;
+  /** `ep.expectedByRole[probeRole]` — deliberately allowed to be `undefined`. */
+  registryExpectation: 200 | 403 | undefined;
+  csharpStatus: number | { failed: string };
+  ts?: TsProbeOutcome;
+}
+
+/** Shared remediation clause. Used by every branch whose cause really IS the registry or the
+ *  seeded grant — branches 1, 2, 4b and 5b. It is deliberately NOT used by the branches whose
+ *  cause is elsewhere (3 transport, 4a dark flag, 5a TS transport/parse): pointing an operator
+ *  at grants for a DNS error or an unflipped flag is the wrong next step, and a diagnosis that
+ *  is confidently wrong is worse than none. preflight.test.ts asserts BOTH directions — that
+ *  every registry/grant branch carries this string, and that no other branch does. */
+const REMEDIATION =
+  'Fix the registry or the seeded grant — do NOT change probeRole to another role the product also ' +
+  'denies. (Running anyway crashes inside stripTrpcJson (trpc.ts:11) instead of reporting a FAIL, ' +
+  'discarding every result and skipping rls/rbac entirely.)';
+
+/**
+ * PURE. Returns `null` when the probe identity is viable, else a one-paragraph
+ * diagnosis naming surface, endpoint, role, observed status and the registry's claim.
+ *
+ * WHY THIS EXISTS. surfaces.test.ts asserts `expectedByRole[probeRole] === 200`
+ * for every surface — but that checks the REGISTRY AGAINST ITSELF. A registry that is
+ * internally consistent and WRONG ABOUT THE PRODUCT (a role marked 200 that the live
+ * gate 403s) has the same blast radius as #205 and nothing catches it: checks/parity.ts:
+ * 49-56 fails closed on a non-200 C# response, and on the TS side stripTrpcJson
+ * (trpc.ts:11) THROWS, so the run CRASHES out through main's catch with a
+ * single line naming neither the surface nor the role, discarding every result gathered
+ * so far and never running rls/rbac at all.
+ *
+ * Verdict order is FIRST MATCH WINS, and the order is deliberate: a registry that is
+ * self-inconsistent (branches 1-2) is reported as a registry defect even if the live
+ * gate happens to answer 200 today, because the harness would then be probing with an
+ * identity nothing in the registry claims is viable.
+ *
+ * SCOPE, so a green preflight is not read as more than it is: this validates the probe
+ * IDENTITY against ONE endpoint of the surface (see `preflightSurface` in cli.ts). It does
+ * not prove every endpoint of that surface answers the identity 200, and it says nothing
+ * about resource ids. Those residual exposures are enumerated at `preflightSurface`.
+ */
+export function diagnoseProbeViability(i: ProbeViabilityInput): string | null {
+  const where = `${i.surfaceKey}/${i.endpointName}`;
+  const head = `verify ${i.surfaceKey}: PROBE IDENTITY NOT VIABLE — no check ran.`;
+
+  // 1. The registry says nothing at all about this role on this endpoint. `expectedByRole`
+  //    is a plain Record, so a typo'd or removed role reads as `undefined`, not as an error.
+  if (i.registryExpectation === undefined) {
+    return (
+      `${head} The registry has NO ` +
+      `expectedByRole entry for probeRole "${i.probeRole}" on ${where} (GET ${i.csharpPath}), so ` +
+      `nothing declares the parity probe's required 200 for the identity every check is about to ` +
+      `use. ${REMEDIATION}`
+    );
+  }
+
+  // 2. The registry contradicts itself: it names an expectation for the probe role, and it is
+  //    not 200. surfaces.test.ts's probeRole-expects-200 invariant exists to make this
+  //    unreachable — reaching it means that guard did not run or was weakened, which is worth
+  //    saying out loud.
+  if (i.registryExpectation !== 200) {
+    return (
+      `${head} The registry itself says ` +
+      `probeRole "${i.probeRole}" expects ${i.registryExpectation} on ${where} (GET ${i.csharpPath}) ` +
+      `— the parity probe requires 200 (surfaces.test.ts's "every surface probes with a role it ` +
+      `actually grants 200" invariant should have caught this; it did not run or was weakened). ` +
+      `${REMEDIATION}`
+    );
+  }
+
+  // 3. The harness could not reach the C# stack at all — a transport failure, not a verdict.
+  //    Distinguished from a status so the operator is not sent to look at grants for a DNS error.
+  if (typeof i.csharpStatus === 'object') {
+    return (
+      `${head} The C# probe call itself ` +
+      `FAILED (${i.csharpStatus.failed}) — the harness could not reach ${i.csharpPath} on the ` +
+      `configured C# base for ${where}. This is a transport/config failure, not a grant failure: ` +
+      `check csharpBase and network reachability before touching the registry.`
+    );
+  }
+
+  // 4a. A 404 is AMBIGUOUS and the flag is the first thing to check, not the registry. Every read
+  //     surface registered today is dark or partly dark, and an UNMOUNTED route 404s exactly like a
+  //     denied one — so sending the operator to the grants here would misdirect on the common case.
+  //     (`cmdVerifyWrite`'s mounted-route preflight in cli.ts already gets this right for writes;
+  //     this is the read-side equivalent.) The registry/grant clause is offered only as the
+  //     SECOND step, conditional on the route being provably mounted.
+  if (i.csharpStatus === 404) {
+    return (
+      `${head} probeRole "${i.probeRole}" got HTTP 404 on ${where} (GET ${i.csharpPath}). ` +
+      `A 404 is AMBIGUOUS: an UNMOUNTED (dark) route 404s indistinguishably from a denied one, and ` +
+      `this surface is gated by ${i.surfaceFlag}. CHECK THE FLAG FIRST — flip ${i.surfaceFlag}=true ` +
+      `at canary, or point csharpBase at an environment where it is already on, and re-run. Only if ` +
+      `the route is provably MOUNTED is this a registry or grant problem, and only then: ${REMEDIATION}`
+    );
+  }
+
+  // 4b. The headline case: the LIVE gate denies the identity the registry claims it allows.
+  if (i.csharpStatus !== 200) {
+    return (
+      `${head} probeRole ` +
+      `"${i.probeRole}" got HTTP ${i.csharpStatus} on ${where} (GET ${i.csharpPath}), but SURFACES ` +
+      `says expectedByRole["${i.probeRole}"] === 200. The registry disagrees with the LIVE gate. ` +
+      `${REMEDIATION}`
+    );
+  }
+
+  if (i.ts && i.ts.ok === false) {
+    // 5a. The TS app did not answer with a tRPC envelope at all. `stripTrpcJson` always attaches a
+    //     JSON-RPC code to a real tRPC rejection, so its ABSENCE means the failure happened before
+    //     any authorization verdict existed — a 502/HTML page (callers.ts:104 `res.json()` throws
+    //     SyntaxError), DNS, TLS, a mid-deploy Vercel app. This is the TS-side twin of branch 3 and
+    //     must NOT carry the registry/grant remediation: an operator running `parity organization`
+    //     while the Next.js deployment is rolling would otherwise be sent to look at seeded grants
+    //     for an outage.
+    if (i.ts.code === undefined) {
+      return (
+        `${head} C# returned 200 for probeRole "${i.probeRole}" on ${where}, but the TS call FAILED ` +
+        `WITHOUT a tRPC error response: "${i.ts.message}". A tRPC rejection always carries a ` +
+        `JSON-RPC code (trpc.ts:11); its absence means no tRPC envelope came back at all — an ` +
+        `HTML/502 body (callers.ts:104 res.json() throws), DNS, TLS, or a mid-deploy app. This is a ` +
+        `transport/config failure, not a grant failure: check tsBase and the Next.js deployment's ` +
+        `health before touching the registry.`
+      );
+    }
+    // 5b. C# allowed the identity but the TS side REJECTED it with a real tRPC error. Same blast
+    //     radius as branch 4b: this rejection is exactly the throw this preflight exists to pre-empt.
+    return (
+      `${head} C# returned 200 for ` +
+      `probeRole "${i.probeRole}" on ${where}, but the TS leg REJECTED the probe: ` +
+      `"${i.ts.message}" (JSON-RPC code ${i.ts.code} — trpc.ts:2 declares a JSON-RPC code, NOT an ` +
+      `HTTP status). SURFACES says expectedByRole["${i.probeRole}"] === 200 and ` +
+      `tsProcedure "${i.tsProcedure ?? '(none)'}" is registered. ${REMEDIATION}`
+    );
+  }
+
+  return null;
+}
+
+/** Everything the live runner needs. An options object rather than a positional list: the
+ *  argument count crossed the point where a mis-ordered `orgAToken`/`orgACookie` pair would
+ *  type-check silently, and that mutation was live-verified to leave the whole suite green. */
+export interface ProbePreflightRun {
+  ep: EndpointDef;
+  surfaceKey: string;
+  surfaceFlag: string;
+  probeRole: string;
+  csharpBase: string;
+  tsBase: string;
+  /** C# Bearer access token for the org-A probe identity. */
+  orgAToken: string;
+  /** TS `sb-<ref>-auth-token` session cookie for the SAME identity. */
+  orgACookie: string;
+  /** Exercise the TS leg at all. FALSE for `rls`/`rbac`, which never call the TS stack — see
+   *  `preflightSurface` in cli.ts for why coupling them to it would be a regression. */
+  checkTs: boolean;
+  csharp: (base: string, path: string, token: string) => Promise<{ status: number; body: unknown }>;
+  ts: (base: string, proc: string, input: unknown, cookie: string) => Promise<unknown>;
+}
+
+/**
+ * Live runner. Issues ONE C# call and — only when `checkTs` AND `ep.tsProcedure` is set — ONE TS
+ * call, both with the org-A probe identity's credentials: the same two callers the parity leg
+ * builds in cli.ts (`csharpCaller`/`tsCaller`). BOTH are wrapped in try/catch: the preflight must
+ * be incapable of throwing, since its entire purpose is to replace a throw with a report.
+ * (The TS leg is also where a non-JSON response crashes today — callers.ts:104 has no
+ * try/catch, unlike callCsharp at callers.ts:57-61.)
+ *
+ * The C# call runs FIRST and short-circuits the TS call when it fails at transport level:
+ * branch 3 of `diagnoseProbeViability` already wins in that case, so a second doomed call
+ * would add latency and a second confusing error to the operator's console, not evidence.
+ */
+export async function runProbePreflight(r: ProbePreflightRun): Promise<CheckResult> {
+  const { ep } = r;
+  let csharpStatus: number | { failed: string };
+  try {
+    csharpStatus = (await r.csharp(r.csharpBase, ep.csharpPath, r.orgAToken)).status;
+  } catch (err) {
+    csharpStatus = { failed: err instanceof Error ? err.message : String(err) };
+  }
+
+  let tsOutcome: TsProbeOutcome | undefined;
+  if (r.checkTs && ep.tsProcedure !== undefined && typeof csharpStatus === 'number') {
+    try {
+      await r.ts(r.tsBase, ep.tsProcedure, ep.input, r.orgACookie);
+      tsOutcome = { ok: true };
+    } catch (err) {
+      // A TrpcError carries a JSON-RPC `code`; a raw SyntaxError (non-JSON response body,
+      // callers.ts:104) carries none. Both are reported, neither is rethrown, and the two get
+      // DIFFERENT diagnoses — see branches 5a/5b above.
+      const code = (err as { code?: unknown })?.code;
+      tsOutcome = {
+        ok: false,
+        message: err instanceof Error ? err.message : String(err),
+        code: typeof code === 'number' ? code : undefined,
+      };
+    }
+  }
+
+  const detail = diagnoseProbeViability({
+    surfaceKey: r.surfaceKey,
+    surfaceFlag: r.surfaceFlag,
+    probeRole: r.probeRole,
+    endpointName: ep.name,
+    csharpPath: ep.csharpPath,
+    tsProcedure: ep.tsProcedure,
+    registryExpectation: ep.expectedByRole[r.probeRole],
+    csharpStatus,
+    ts: tsOutcome,
+  });
+
+  return detail === null
+    ? { check: 'preflight', endpoint: ep.name, ok: true }
+    : { check: 'preflight', endpoint: ep.name, ok: false, detail };
+}

--- a/scripts/parity/checks/rls.test.ts
+++ b/scripts/parity/checks/rls.test.ts
@@ -407,4 +407,48 @@ describe('runRlsEndpoint', () => {
       expect(fake).not.toHaveBeenCalled();
     });
   });
+
+  // ── Mode C (#195, 2026-08-11) ────────────────────────────────────────────────────────────────
+  describe('noTenantBoundaryForCaller — by-id endpoint behind a principal-type gate', () => {
+    const ep: EndpointDef = {
+      name: 'detail',
+      csharpPath: '/platform/organizations/{id}',
+      tsProcedure: 'platform.getOrganization',
+      input: { id: '{id}' },
+      idScopeKey: 'organization',
+      noTenantBoundaryForCaller: true,
+      expectedByRole: { platform_owner: 200, org_admin: 403 },
+    };
+
+    it('short-circuits to a documented N/A WITHOUT probing — Mode A would assert the opposite of the requirement', async () => {
+      // A platform owner reading org B is the FEATURE. Mode A would fire org-A's token at org-B's id
+      // and read the (correct) 200-with-body as a breach. `orgBResourceId` is supplied here precisely
+      // so the test proves the short-circuit, not the absence of an id.
+      const fake = vi.fn();
+      const r = await runRlsEndpoint(
+        ep,
+        { base: 'http://csharp.local', orgAToken: 'org-a-token', orgBResourceId: 'org-b-id' },
+        fake,
+      );
+      expect(r.ok).toBe(true);
+      expect(r.inconclusive).toBe(true);
+      expect(fake).not.toHaveBeenCalled();
+    });
+
+    it('reports a reason DISTINCT from globalScope — the two dispositions must be tellable apart', async () => {
+      // The globalScope N/A claims the PAYLOAD is org-independent. This one claims only that the
+      // CALLER crosses no boundary; the payload IS org-specific. A report reader who cannot tell them
+      // apart cannot tell "no per-org data here" from "per-org data that this caller may all see".
+      const r = await runRlsEndpoint(ep, { base: 'http://csharp.local', orgAToken: 'org-a-token' }, vi.fn());
+      expect(r.detail).not.toContain('globalScope');
+      expect(r.detail).toContain('principal-type gate');
+    });
+
+    it('globalScope still wins when both are set (the registry forbids it; the runtime must be deterministic)', async () => {
+      // surfaces.test.ts forbids the combination, so this is unreachable from the registry — but the
+      // runtime ordering is pinned anyway, the same way the globalScope-over-idScopeKey precedence is.
+      const r = await runRlsEndpoint({ ...ep, globalScope: true }, { base: 'http://c', orgAToken: 'a' }, vi.fn());
+      expect(r.detail).toContain('globalScope');
+    });
+  });
 });

--- a/scripts/parity/checks/rls.ts
+++ b/scripts/parity/checks/rls.ts
@@ -6,9 +6,13 @@ export interface CheckResult {
   ok: boolean;
   detail?: string;
   /** Set when an `ok:true` RLS verdict is NOT a strong cross-tenant proof, in
-   *  one of two cases: (1) Mode B's both-orgs-200-and-empty case (no cross-tenant
-   *  data existed to compare); or (2) a `globalScope` endpoint, where the payload
-   *  is deliberately org-independent so there is no tenant isolation to prove.
+   *  one of THREE cases: (1) Mode B's both-orgs-200-and-empty case (no cross-tenant
+   *  data existed to compare); (2) a `globalScope` endpoint, where the payload
+   *  is deliberately org-independent so there is no tenant isolation to prove; or
+   *  (3) a `noTenantBoundaryForCaller` by-id endpoint, where the caller crosses no
+   *  tenant boundary because its gate is principal TYPE rather than tenancy (#195,
+   *  2026-08-11). Cases 2 and 3 carry DISTINCT detail strings on purpose — they are
+   *  different dispositions and a report reader must be able to tell them apart.
    *  Never set alongside `ok:false`. `report.ts` renders this distinctly (`[WEAK]`)
    *  so report-green doesn't silently imply a real comparison happened. */
   inconclusive?: boolean;
@@ -142,7 +146,19 @@ function buildProbePath(csharpPath: string, orgBResourceId: string): string {
  * Live RLS check: makes a cross-tenant probe call via C# through the real
  * `callCsharp(base, path, token)` caller (scripts/parity/callers.ts).
  *
- * Two modes, chosen by `ep.idScopeKey`:
+ * THREE modes. `globalScope` and `noTenantBoundaryForCaller` short-circuit first
+ * (in that order); otherwise the mode is chosen by `ep.idScopeKey`:
+ *
+ * Mode C — no tenant boundary FOR THIS CALLER (`ep.noTenantBoundaryForCaller`):
+ * a by-id endpoint served by a platform-owner gate (TS `platformProcedure` / C#
+ * `PlatformOwnerGate`) over the UNSCOPED client. Reaching org B's row is the
+ * FEATURE, so Mode A would assert the opposite of the requirement — and could
+ * not run anyway, since `mintTokens` mints no org-B token for an org-less
+ * platform owner (cli.ts), which would fail Mode A's positive control closed.
+ * Reported as a documented N/A (`inconclusive` → `[WEAK]`) with its OWN reason
+ * string, distinct from the globalScope one: that flag claims the PAYLOAD is
+ * org-independent, which is false here. Parity and RBAC still run unchanged, and
+ * on such a surface the RBAC denied-role 403 is the ENTIRE boundary proof.
  *
  * Mode A — by-id IDOR probe (`ep.idScopeKey` set): org-A's token attempts to
  * reach org-B's resource id on `ep.csharpPath`. Two calls:
@@ -193,6 +209,26 @@ export async function runRlsEndpoint(ep: EndpointDef, ctx: RlsContext, callCshar
       ok: true,
       inconclusive: true,
       detail: 'N/A: globalScope (non-tenant) endpoint — no cross-tenant isolation to prove',
+    };
+  }
+
+  // noTenantBoundaryForCaller — Mode C. A BY-ID endpoint behind a PRINCIPAL-TYPE gate: reaching
+  // another org's row is the product requirement, not a breach, so Mode A below would assert the
+  // exact opposite of it (org-A's platform-owner token SHOULD get a 200 carrying org-B's body,
+  // which `assertIsolated` correctly reads as a leak). Report a documented N/A with a reason of its
+  // OWN — deliberately NOT the globalScope wording above, because this endpoint's payload IS
+  // org-specific, and a report reader must not conflate "there is no per-org data here" with "there
+  // is per-org data here and this caller may see all of it". Placed AFTER the globalScope branch so
+  // that flag keeps its precedence (rls.test.ts pins that ordering), and BEFORE `idScopeKey` so the
+  // Mode-A probe never runs.
+  if (ep.noTenantBoundaryForCaller) {
+    return {
+      check: 'rls',
+      endpoint: ep.name,
+      ok: true,
+      inconclusive: true,
+      detail:
+        'N/A: principal-type gate, not a tenant boundary — this caller reads any org by design, so a Mode-A IDOR probe would assert the opposite of the requirement. The payload IS org-specific (org-independence is NOT claimed). The boundary here is proved by the RBAC denied-role 403, not by RLS.',
     };
   }
 

--- a/scripts/parity/cli.test.ts
+++ b/scripts/parity/cli.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { dispatch, resolveProbeRole } from './cli';
-import type { Surface } from './surfaces';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { dispatch, resolveProbeRole, preflightSurface, writeProbeRoleDenials, type ProbePreflightRunner } from './cli';
+import type { Surface, EndpointDef } from './surfaces';
+import { WRITE_SURFACES, type AnyWriteSurface } from './write-surfaces';
+import type { CheckResult as PreflightCheckResult, ProbePreflightRun } from './checks/preflight';
 
 // Only the pure arg-parsing branches of `dispatch` are exercised here — every
 // path below returns before touching `loadConfig()`/network, so this suite
@@ -60,5 +64,206 @@ describe('resolveProbeRole (pure, no network)', () => {
   it('falls back to roles[0] when probeRole is not set, with usedFallback:true', () => {
     const surface: Surface = { ...base };
     expect(resolveProbeRole(surface)).toEqual({ role: 'super_admin', usedFallback: true });
+  });
+});
+
+// ── The probe-viability preflight (#206) ─────────────────────────────────────────────────────────
+// `runChecks` itself still cannot be unit-tested (it mints Supabase tokens and makes HTTP calls),
+// but the preflight is no longer buried inside it. `preflightSurface` is exported and takes an
+// INJECTED runner, so the thing the old source-text guard could not express — that the runner is
+// actually REACHED — is now a behavioural assertion.
+//
+// This matters because the old guard was weaker than its own comment claimed. Live-verified
+// 2026-08-11: mutating the enclosing condition to
+// `if (probeCandidate && cfg.csharpBase.startsWith('zzz'))` disabled deliverable A entirely and left
+// `npx vitest run scripts/parity tests/governance` at 408/408 with tsc clean, because all four
+// substrings the guard looked for survived untouched. Its apparent strength was coincidental: the
+// near-miss mutation `&& command === 'parity'` only went red by shifting an `indexOf`.
+describe('preflightSurface (behavioural, injected runner — no network)', () => {
+  const okRun: PreflightCheckResult = { check: 'preflight', endpoint: 'kpis', ok: true };
+  const creds = { csharpBase: 'http://csharp.local', tsBase: 'http://ts.local', orgAToken: 'tok', orgACookie: 'ck' };
+  const identity = (e: EndpointDef) => e;
+
+  const tier1: EndpointDef = {
+    name: 'kpis',
+    csharpPath: '/platform/organizations/kpis',
+    tsProcedure: 'platform.getOrganizationKpis',
+    input: {},
+    expectedByRole: { platform_owner: 200, org_admin: 403 },
+  };
+  const byId: EndpointDef = {
+    name: 'detail',
+    csharpPath: '/platform/organizations/{id}',
+    tsProcedure: 'platform.getOrganization',
+    input: { id: '{id}' },
+    idScopeKey: 'organization',
+    expectedByRole: { platform_owner: 200, org_admin: 403 },
+  };
+  const surface: Surface = {
+    key: 'organization',
+    flag: 'Platform__PlatformOrganizationsReadEnabled',
+    roles: ['platform_owner', 'org_admin'],
+    probeRole: 'platform_owner',
+    endpoints: [byId, tier1],
+  };
+
+  /** A typed spy: records exactly what `preflightSurface` handed the runner. Written by hand rather
+   *  than as `vi.fn(async () => …)` because that infers a ZERO-ARG signature, which makes
+   *  `mock.calls[0][0]` a type error and would have pushed these assertions towards `any`. */
+  function captureRunner(result: PreflightCheckResult = okRun) {
+    const calls: ProbePreflightRun[] = [];
+    const runner: ProbePreflightRunner = async (r) => {
+      calls.push(r);
+      return result;
+    };
+    return { runner, calls };
+  }
+
+  it('CALLS the runner — the reachability a source-text substring check cannot prove', async () => {
+    const { runner, calls } = captureRunner();
+    await preflightSurface('verify', surface, identity, creds, runner);
+    expect(calls.length).toBe(1);
+  });
+
+  it('prefers a Tier-1 endpoint over a by-id one, and passes the surface key, flag and probeRole', async () => {
+    const { runner, calls } = captureRunner();
+    await preflightSurface('verify', surface, identity, creds, runner);
+    const arg = calls[0];
+    expect(arg.ep.name).toBe('kpis'); // not `detail`, which is listed FIRST
+    expect(arg.surfaceKey).toBe('organization');
+    expect(arg.surfaceFlag).toBe('Platform__PlatformOrganizationsReadEnabled');
+    expect(arg.probeRole).toBe('platform_owner');
+    expect(arg.csharpBase).toBe('http://csharp.local');
+    expect(arg.tsBase).toBe('http://ts.local');
+    expect(arg.orgAToken).toBe('tok');
+    expect(arg.orgACookie).toBe('ck');
+  });
+
+  it('binds a REAL id through `bind` when every endpoint is by-id — never the {id} sentinel', async () => {
+    // The reason this call sits AFTER resource resolution in `runChecks`. A surface with no Tier-1
+    // endpoint must still probe a substituted path, or the preflight 404s on `/…/{id}` literally.
+    const allById: Surface = { ...surface, endpoints: [byId] };
+    const { runner, calls } = captureRunner();
+    let bound = 0;
+    const bind = (e: EndpointDef) => {
+      bound++;
+      return { ...e, csharpPath: '/platform/organizations/org-a-uuid' };
+    };
+    await preflightSurface('verify', allById, bind, creds, runner);
+    expect(bound).toBe(1);
+    expect(calls[0].ep.csharpPath).toBe('/platform/organizations/org-a-uuid');
+  });
+
+  it('exercises the TS leg for parity/verify and NOT for rls/rbac', async () => {
+    // `rls`/`rbac` have never touched the TS stack (see the file docblock). If the preflight probed
+    // it unconditionally, a Vercel outage would abort a pure-C# run with zero checks executed.
+    for (const cmd of ['parity', 'verify'] as const) {
+      const { runner, calls } = captureRunner();
+      await preflightSurface(cmd, surface, identity, creds, runner);
+      expect(calls[0].checkTs, cmd).toBe(true);
+    }
+    for (const cmd of ['rls', 'rbac'] as const) {
+      const { runner, calls } = captureRunner();
+      await preflightSurface(cmd, surface, identity, creds, runner);
+      expect(calls[0].checkTs, cmd).toBe(false);
+    }
+  });
+
+  it('returns the FAILING result (so the caller can abort), and null when it passed', async () => {
+    const fail: PreflightCheckResult = { check: 'preflight', endpoint: 'kpis', ok: false, detail: 'denied' };
+    expect(await preflightSurface('verify', surface, identity, creds, captureRunner(fail).runner)).toEqual(fail);
+    expect(await preflightSurface('verify', surface, identity, creds, captureRunner(okRun).runner)).toBeNull();
+  });
+
+  it('a zero-endpoint surface probes nothing and does not crash', async () => {
+    const { runner, calls } = captureRunner();
+    const empty: Surface = { ...surface, endpoints: [] };
+    expect(await preflightSurface('verify', empty, identity, creds, runner)).toBeNull();
+    expect(calls.length).toBe(0);
+  });
+});
+
+// The write side's equivalent. `verify-write` never reaches `preflightSurface` — it is a separate
+// dispatch branch — so all 26 write endpoints across 7 write surfaces carried the #205 defect class
+// with nothing checking for it. A live probe is impossible there (a write's success probe MUTATES),
+// so what is checked is the registry's own claim, with no network at all.
+describe('writeProbeRoleDenials (pure) — the #205 defect class on the write side', () => {
+  const ep = (name: string, expectedByRole: Record<string, 'allow' | 'deny'>) =>
+    ({ name, expectedByRole }) as unknown as AnyWriteSurface['endpoints'][number];
+  const surfaceWith = (probeRole: string, endpoints: AnyWriteSurface['endpoints']) =>
+    ({ key: 'w', flag: 'F', probeRole, roles: [probeRole], endpoints }) as unknown as AnyWriteSurface;
+
+  it('is empty when the probe role is allowed everywhere', () => {
+    const s = surfaceWith('super_admin', [ep('create', { super_admin: 'allow', hrbp: 'deny' })]);
+    expect(writeProbeRoleDenials(s)).toEqual([]);
+  });
+
+  it('names the endpoint AND the declared expectation for a DENIED probe role', () => {
+    // The #205 shape, write side. On the read side this crashes the run; here it is worse — a denied
+    // identity 403s every call and `runWriteIdor` reads 403 as isolation-held, so the IDOR line goes
+    // GREEN for a fixture reason.
+    const s = surfaceWith('hrbp', [
+      ep('create', { super_admin: 'allow', hrbp: 'deny' }),
+      ep('approve', { super_admin: 'allow', hrbp: 'allow' }),
+    ]);
+    expect(writeProbeRoleDenials(s)).toEqual(['create=deny']);
+  });
+
+  it('treats an UNDECLARED probe role as a denial, not as a pass', () => {
+    // `expectedByRole` is a plain Record: a typo'd or removed role reads as `undefined`. Defaulting
+    // that to "allowed" would reproduce branch 1 of the read-side preflight as a silent green.
+    const s = surfaceWith('ghost_role', [ep('create', { super_admin: 'allow' })]);
+    expect(writeProbeRoleDenials(s)).toEqual(['create=undeclared']);
+  });
+
+  it('every REGISTERED write surface passes it today — 7 surfaces, 26 endpoints', () => {
+    // The registry-level invariant, the write-side analogue of surfaces.test.ts's
+    // "every surface probes with a role it actually grants 200". Non-vacuity: the counts are pinned,
+    // so an empty registry cannot make this loop iterate zero times and still read as enforced.
+    let endpoints = 0;
+    for (const [key, s] of Object.entries(WRITE_SURFACES)) {
+      endpoints += s.endpoints.length;
+      expect(writeProbeRoleDenials(s), `${key}: probeRole "${s.probeRole}" is not 'allow' everywhere`).toEqual([]);
+    }
+    expect(Object.keys(WRITE_SURFACES).length).toBe(7);
+    expect(endpoints).toBe(26);
+  });
+});
+
+// Still source-text, and still worth keeping: the ORDER of the call inside `runChecks` (which needs
+// live credentials to execute) is not reachable behaviourally. Both assertions pin EXACT lines, so a
+// mutation that wraps either in a condition changes the string and goes red — the specific weakness
+// that let the `startsWith('zzz')` mutation through when the block was inline.
+describe('probe-viability preflight wiring in cli.ts (source-order check)', () => {
+  const src = readFileSync(join(__dirname, 'cli.ts'), 'utf8');
+
+  it('the preflight is called BEFORE the parity loop, unconditionally', () => {
+    const pf = src.indexOf('const pf = await preflightSurface(command, surface, orgAEndpoint, {');
+    const parity = src.indexOf("if (command === 'parity' || command === 'verify') {");
+    expect(pf, 'preflightSurface is not called from runChecks — deliverable A is unwired').toBeGreaterThan(-1);
+    expect(parity, 'the parity block was renamed — this guard is now blind').toBeGreaterThan(-1);
+    expect(pf).toBeLessThan(parity);
+  });
+
+  it('a failed preflight ABORTS the run — it is not merely appended to the results', () => {
+    // `return [pf]` and not `results.push(pf)`: pushing it would let the three checks run on
+    // with a probe identity already known to be denied, which is the crash this prevents.
+    // `[]` would be worse still — renderReport's allGreen is vacuously true on an empty list.
+    expect(src).toContain('\n  if (pf) return [pf];\n');
+  });
+
+  it('cmdVerifyWrite bails on a denied write probeRole BEFORE any check runs', () => {
+    // The write-side twin. `writeProbeRoleDenials` is behaviourally tested above; what is only
+    // reachable as source text is that `cmdVerifyWrite` actually consults it and RETURNS on it,
+    // rather than logging and carrying on into runWriteIdor's false green.
+    const call = src.indexOf('const probeDenied = writeProbeRoleDenials(surface);');
+    const bail = src.indexOf('  if (probeDenied.length > 0) {');
+    const firstCheck = src.indexOf('results.push(await runWriteIdor(');
+    expect(call, 'cmdVerifyWrite no longer consults writeProbeRoleDenials').toBeGreaterThan(-1);
+    expect(bail, 'the bail condition was rewritten — this guard is now blind').toBeGreaterThan(-1);
+    expect(firstCheck).toBeGreaterThan(-1);
+    expect(bail).toBeGreaterThan(call);
+    expect(bail).toBeLessThan(firstCheck);
+    expect(src).toContain('    );\n    return 1;\n  }\n\n  // Seed the surface');
   });
 });

--- a/scripts/parity/cli.ts
+++ b/scripts/parity/cli.ts
@@ -19,7 +19,11 @@
  * (scripts/parity/supabase.ts) and `callTs` sends it as a `Cookie:` header.
  * LIVE-VERIFIED against prod (super_admin→200, hrbp→403, no-cookie→401 on
  * teamIntel.getDashboardKpis). `rls`/`rbac` only ever call the C# REST side
- * (`callCsharp`, Bearer) and are unaffected.
+ * (`callCsharp`, Bearer) and are unaffected — INCLUDING their probe-viability
+ * preflight, which is why `preflightSurface` takes a `checkTs` flag rather than
+ * probing TS unconditionally. See that function for the reasoning; the short
+ * version is that a Vercel outage must not be able to abort a pure-C# `rls` run
+ * with zero checks executed.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 import { fileURLToPath } from 'node:url';
@@ -28,11 +32,16 @@ import { getToken, getSessionCookie, type TokenCache, type CookieCache } from '.
 import { planSeed, seed, teardown, resolveResources, openReadback, type SeedResources } from './seed';
 import { callCsharp, callCsharpWrite, callTs } from './callers';
 import { SURFACES, type Surface, type EndpointDef } from './surfaces';
-import { WRITE_SURFACES, type WriteResolvedBase } from './write-surfaces';
+import { WRITE_SURFACES, type WriteResolvedBase, type AnyWriteSurface } from './write-surfaces';
 import { substituteEndpointId } from './ids';
 import { runParityEndpoint } from './checks/parity';
 import { runRlsEndpoint, type RlsContext } from './checks/rls';
 import { runRbacEndpoint, type RbacContext } from './checks/rbac';
+import {
+  runProbePreflight,
+  type ProbePreflightRun,
+  type CheckResult as PreflightCheckResult,
+} from './checks/preflight';
 import { runWriteParity, runWriteIdor, runWriteRbac, runWriteExtraProbe } from './checks/writes';
 import { renderReport, type CheckResult } from './report';
 
@@ -119,8 +128,8 @@ async function mintTokens(
   // (2950a06c / 18282f96), and was corrected on 2026-08-10 (#195) to say the branch was reachable
   // only from write-surfaces.ts's access-review surface.
   //
-  // CURRENT STATE, 2026-08-11. `mintTokens` has exactly ONE call site — `runChecks` at :140, the
-  // READ path. `cmdVerifyWrite` mints its own tokens inline (:263-269) and never reaches here, so no
+  // CURRENT STATE, 2026-08-11. `mintTokens` has exactly ONE call site — `runChecks` at :145, the
+  // READ path. `cmdVerifyWrite` mints its own tokens inline (:312-314) and never reaches here, so no
   // WRITE_SURFACES entry is a caller of this branch, whatever its probeRole. THREE read surfaces now
   // set probeRole 'platform_owner' and are the only callers: SURFACES['audit-log'],
   // SURFACES['access-review'] (both re-registered C#-only today) and SURFACES['organization'].
@@ -135,6 +144,81 @@ async function mintTokens(
   }
   if (!orgACookie) throw new Error(`mintTokens: failed to mint org-A session cookie for role "${primaryRole}"`);
   return { orgAToken, orgBToken, orgACookie, tokensByRole };
+}
+
+/** The live `runProbePreflight`, as an injectable shape so `preflightSurface` can be unit-tested
+ *  BEHAVIOURALLY (it is the reachability of the call that matters, and a source-text assertion
+ *  cannot prove that — see cli.test.ts). */
+export type ProbePreflightRunner = (r: ProbePreflightRun) => Promise<PreflightCheckResult>;
+
+/**
+ * PROBE-VIABILITY PREFLIGHT (#206). Returns the failing `CheckResult` when the probe identity is
+ * NOT viable, and `null` when it is (or when there is nothing to probe). Extracted from `runChecks`
+ * ON PURPOSE: while it was an inline `if (probeCandidate) { … }` block, the ONLY automated coverage
+ * of it was a source-text substring check in cli.test.ts, and that check could not tell reachable
+ * code from unreachable code — mutating the condition to `if (probeCandidate && cfg.csharpBase
+ * .startsWith('zzz'))` disabled the entire deliverable with 408/408 tests and tsc green
+ * (live-verified 2026-08-11). As a function with an injected runner, "it is actually called" is a
+ * behavioural assertion.
+ *
+ * WHY IT RUNS BEFORE ANY CHECK. The probe identity's token is what parity calls BOTH stacks with
+ * (see `csharpCaller`/`tsCaller` below) and what rls/rbac call C# with. A denied probeRole does not
+ * degrade those checks, it destroys them: parity fails closed on the C# side (checks/parity.ts:49-56)
+ * and THROWS on the TS side (stripTrpcJson, trpc.ts:11), taking the whole run down; and RLS Mode A
+ * silently degrades, because org-A's 403 is read as "isolation held" by `assertIsolated`
+ * (checks/rls.ts:92-93) for the WRONG reason, and the run then FAILs at the positive control
+ * (checks/rls.ts:270-277) with a message pointing the operator at the org-B seed rather than the
+ * registry.
+ *
+ * WHY `checkTs` IS COMMAND-DEPENDENT. `rls` and `rbac` have never called the TS stack. Probing it
+ * for them would make a Next.js outage, a 502 HTML body (callers.ts:104 `res.json()` throws
+ * SyntaxError) or a mid-deploy redirect abort a pure-C# run with zero checks executed — a new
+ * coupling, introduced by the guard rather than by the thing it guards. So the TS leg runs for
+ * `parity`/`verify` only, which are the commands whose crash it exists to pre-empt.
+ *
+ * ENDPOINT CHOICE. Prefer a Tier-1 endpoint (no extra id semantics); fall back to `endpoints[0]`
+ * bound through `bind`, which is why the caller resolves resources first — a surface whose every
+ * endpoint is by-id must still probe with a REAL id, not the `{id}` sentinel.
+ *
+ * WHAT THIS DOES NOT COVER, stated so a green preflight is not over-read:
+ *   - ONE endpoint per surface. A registry that is right about `kpis` and wrong about `detail`
+ *     still crashes on `detail` in exactly the #205 shape. Probing every endpoint would double the
+ *     call count of every run for a defect class the per-surface probeRole invariant already makes
+ *     hard; the residual is accepted and written down rather than implied.
+ *   - RESOURCE IDS. `organization/detail` and `compensation/employee` resolve their id from
+ *     DATABASE_URL, and the TS app reads its OWN database. Point the harness at a locally-seeded DB
+ *     and `tsBase` at prod and `platform.getOrganization` will 404 an id it has never seen, which
+ *     stripTrpcJson turns back into a throw. That is a config mismatch the preflight cannot see,
+ *     because the probe endpoint (`kpis`) takes no id.
+ *   - `verify-write`. It does not reach here at all — see `cmdVerifyWrite`, which carries its own
+ *     (different, route-mounted-ness) preflight and its own registry-level probe-role guard.
+ */
+export async function preflightSurface(
+  command: CheckCommand,
+  surface: Surface,
+  bind: (ep: EndpointDef) => EndpointDef,
+  creds: { csharpBase: string; tsBase: string; orgAToken: string; orgACookie: string },
+  runner: ProbePreflightRunner = runProbePreflight,
+): Promise<PreflightCheckResult | null> {
+  // A surface with ZERO endpoints has nothing to probe. That is a pre-existing vacuity (every loop
+  // in `runChecks` iterates zero times and `renderReport` reports an empty run), and it belongs to
+  // whatever guard owns it — not to this one, which must not crash on it.
+  const probeCandidate = surface.endpoints.find((e) => !e.idScopeKey) ?? surface.endpoints[0];
+  if (!probeCandidate) return null;
+  const pf = await runner({
+    ep: bind(probeCandidate),
+    surfaceKey: surface.key,
+    surfaceFlag: surface.flag,
+    probeRole: resolveProbeRole(surface).role,
+    checkTs: command === 'parity' || command === 'verify',
+    csharpBase: creds.csharpBase,
+    tsBase: creds.tsBase,
+    orgAToken: creds.orgAToken,
+    orgACookie: creds.orgACookie,
+    csharp: callCsharp,
+    ts: callTs,
+  });
+  return pf.ok ? null : pf;
 }
 
 /** Runs the requested check(s) over every endpoint of `surface`, returning the
@@ -157,6 +241,30 @@ async function runChecks(command: CheckCommand, cfg: HarnessConfig, surface: Sur
     return pair;
   };
   const orgAEndpoint = (ep: EndpointDef): EndpointDef => (ep.idScopeKey ? substituteEndpointId(ep, pairFor(ep).a) : ep);
+
+  // PROBE-VIABILITY PREFLIGHT (#206), BEFORE any check. Sits AFTER resource resolution so an
+  // all-by-id surface probes with a REAL id. The rationale, the command-dependent TS leg and the
+  // residual exposures are all documented on `preflightSurface` above.
+  //
+  // The FAIL is returned as the SOLE result rather than thrown or dropped. `[]` would exit 0 —
+  // renderReport's allGreen is vacuously true on an empty list. A PASSING preflight is deliberately
+  // NOT pushed onto `results`: it is a precondition, not a check, and counting it would inflate the
+  // pass count of every run.
+  //
+  // EXIT CODE. This bail returns 1, like every other could-not-run path in this file
+  // (`cmdVerifyWrite`'s mounted-route preflight, and `main`'s catch-all which collapses every throw
+  // to 1). `.claude/rules/verification.md` establishes a 0/1/2 contract where 2 means "could not
+  // run", and this bail is exactly that shape — but adopting 2 HERE ONLY would make one
+  // could-not-run path distinguishable while `mintTokens`/`resolveResources`/`loadConfig` failures
+  // stay indistinguishable, which misleads more than no contract at all. Adopting it across every
+  // such path in this file at once is tracked as its own change: issue #210.
+  const pf = await preflightSurface(command, surface, orgAEndpoint, {
+    csharpBase: cfg.csharpBase,
+    tsBase: cfg.tsBase,
+    orgAToken,
+    orgACookie,
+  });
+  if (pf) return [pf];
 
   if (command === 'parity' || command === 'verify') {
     // Bind base + the org-A probe identity's credentials into the (path,input)/
@@ -241,6 +349,32 @@ async function cmdCheck(command: CheckCommand, surfaceKey: string | undefined): 
 }
 
 /**
+ * PURE. Returns one `name=expectation` string per endpoint on which the write surface's own
+ * `probeRole` is NOT declared `'allow'` — empty when the probe identity is viable per the registry.
+ *
+ * THE GAP THIS CLOSES. `runProbePreflight` (#206) covers `verify`/`parity`/`rls`/`rbac`. It does NOT
+ * cover `verify-write`, and cannot: a write's success probe is a MUTATION, so there is no
+ * non-mutating way to ask the LIVE gate whether the probe identity is allowed. That left all 26
+ * write endpoints across 7 write surfaces exposed to the #205 defect class, with a WORSE disposition
+ * than the read side rather than a better one:
+ *   - `cmdVerifyWrite` only ever checked that the probe token MINTED, never that it is granted.
+ *   - `runWriteIdor` (checks/writes.ts) counts any status in `idorDeniedStatuses` (default
+ *     [403, 404]) as isolation-held. A probeRole the product denies returns 403 to EVERY call, so
+ *     the write-IDOR line reports `[PASS]` for a FIXTURE reason, not a product one.
+ *   - Only `runWriteParity` fails closed on the non-200, and it runs LAST per endpoint. The run does
+ *     go red overall, but the report still carries greens that prove nothing — the exact shape this
+ *     harness exists to stop.
+ * The registry's own claim needs no network, so it is checked before anything runs. Kept PURE and
+ * exported for the same reason `preflightSurface` was extracted: a guard buried inside a function
+ * that needs live Supabase credentials has no behavioural coverage at all.
+ */
+export function writeProbeRoleDenials(surface: AnyWriteSurface): string[] {
+  return surface.endpoints
+    .filter((ep) => ep.expectedByRole[surface.probeRole] !== 'allow')
+    .map((ep) => `${ep.name}=${ep.expectedByRole[surface.probeRole] ?? 'undeclared'}`);
+}
+
+/**
  * Live write-verification for a WRITE surface (checks/writes.ts). Per endpoint runs
  * the two NON-mutating checks first (write-IDOR, write-RBAC-deny) then the single
  * mutating light-parity, so the precondition is intact when the non-mutating checks
@@ -271,6 +405,35 @@ async function cmdVerifyWrite(surfaceKey: string | undefined): Promise<number> {
   }
   const probeToken = tokensByRole[surface.probeRole];
   if (!probeToken) throw new Error(`verify-write: no probe token for role "${surface.probeRole}"`);
+
+  // PROBE-ROLE VIABILITY, WRITE SIDE — see `writeProbeRoleDenials`. `verify-write` deliberately
+  // does NOT run `runProbePreflight`,
+  // and cannot: a write's success probe is a MUTATION, so there is no non-mutating way to ask the
+  // LIVE gate whether this identity is allowed. What can be checked with no call at all is the
+  // registry's own claim — the write-side analogue of surfaces.test.ts's probeRole-expects-200
+  // invariant, closing the same #205 defect class on the 26 write endpoints the read preflight
+  // never sees.
+  //
+  // The write side's disposition on a denied probeRole is WORSE than the read side's, which is why
+  // this is fail-closed rather than a warning: `runWriteIdor` (checks/writes.ts) counts any status
+  // in `idorDeniedStatuses` (default [403, 404]) as isolation-held, so an identity the product
+  // refuses returns 403 to EVERY call and the IDOR line reports `[PASS]` for a FIXTURE reason
+  // rather than a product one. The run does still go red overall — `runWriteParity` fails closed on
+  // the non-200 — but a green that proves nothing is exactly what this harness exists to prevent.
+  // Above the token check, not below it, would be pointless: minting proves the user exists, never
+  // that it is granted.
+  const probeDenied = writeProbeRoleDenials(surface);
+  if (probeDenied.length > 0) {
+    console.error(
+      `verify-write ${surface.key}: PROBE IDENTITY NOT VIABLE — no check ran. The registry says probeRole ` +
+        `"${surface.probeRole}" is NOT 'allow' on ${probeDenied.length} of ${surface.endpoints.length} ` +
+        `endpoints (${probeDenied.join(', ')}). ` +
+        `Fix the registry or the seeded grant — do NOT pick another role the product also denies. ` +
+        `(Running anyway makes runWriteIdor report [PASS] for a fixture reason: a denied identity 403s ` +
+        `every call, and 403 is a documented isolation-held status.)`,
+    );
+    return 1;
+  }
 
   // Seed the surface's write-verify-only preconditions (kept out of the shared read seed so they
   // can't degrade the read RLS checks — see seed(). Each surface owns its hook). Idempotent.

--- a/scripts/parity/report.ts
+++ b/scripts/parity/report.ts
@@ -2,6 +2,7 @@ import type { CheckResult as ParityCheckResult } from './checks/parity';
 import type { CheckResult as RlsCheckResult } from './checks/rls';
 import type { CheckResult as RbacCheckResult } from './checks/rbac';
 import type { WriteCheckResult } from './checks/writes';
+import type { CheckResult as PreflightCheckResult } from './checks/preflight';
 
 /**
  * Union of every check runner's result shape (Tasks 8/9/10). `report.ts` is the only
@@ -14,8 +15,18 @@ import type { WriteCheckResult } from './checks/writes';
  * a C#-only endpoint whose TS procedure has been deleted. `renderLine` renders
  * those as `[WEAK]` instead of `[PASS]`, and `renderReport` counts them in a
  * separate `weak` bucket so the summary line cannot read as "N compared, N agreed".
+ *
+ * `PreflightCheckResult` (#206) deliberately has NO `inconclusive` member: a probe-viability
+ * preflight that could not run is a FAIL, never a `[WEAK]`. It is the precondition of every other
+ * check, so "could not establish the probe identity" and "there was nothing to compare" are not the
+ * same disposition — the first means no check ran at all.
  */
-export type CheckResult = ParityCheckResult | RlsCheckResult | RbacCheckResult | WriteCheckResult;
+export type CheckResult =
+  | ParityCheckResult
+  | RlsCheckResult
+  | RbacCheckResult
+  | WriteCheckResult
+  | PreflightCheckResult;
 
 function hasRole(r: CheckResult): r is RbacCheckResult | (WriteCheckResult & { role: string }) {
   return (r.check === 'rbac' || r.check === 'write-rbac') && 'role' in r && r.role !== undefined;

--- a/scripts/parity/seed.test.ts
+++ b/scripts/parity/seed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { planSeed, isParityTestEmail } from './seed';
+import { planSeed, isParityTestEmail, type SeedResources } from './seed';
+import { SURFACES } from './surfaces';
 
 describe('planSeed', () => {
   it('produces 2 orgs and a user per configured role, deterministic emails', () => {
@@ -22,5 +23,51 @@ describe('isParityTestEmail', () => {
     expect(isParityTestEmail('parity+c-x@tims.test')).toBe(false);
     expect(isParityTestEmail('parity+a-x@example.com')).toBe(false);
     expect(isParityTestEmail('')).toBe(false);
+  });
+});
+
+describe('SeedResources covers every idScopeKey the read registry uses', () => {
+  /**
+   * `cli.ts`'s `pairFor` looks a by-id endpoint's `idScopeKey` up in the resolved `SeedResources` bag
+   * with a `keyof SeedResources` cast, and THROWS at run time — mid-`verify`, against live prod —
+   * when the key is absent. Nothing checked the two agreed.
+   *
+   * This object is exhaustive BY TYPE: `Record<keyof SeedResources, true>` fails `tsc` if a key is
+   * added to the interface and not listed here, or listed here and not in the interface. The loop
+   * below then closes the other direction at run time.
+   *
+   * HALF OF THIS GUARD IS COMPILE-TIME ONLY, and that is worth stating rather than discovering.
+   * Deleting a key from `SeedResources` is caught by `tsc --noEmit` (two errors: here, and at
+   * `resolveResources`'s return literal) — NOT by vitest, which does not type-check. Both run in the
+   * gate, so the guard holds; but do not read a green vitest as having exercised it. The runtime half
+   * (the loop below) is what catches the other direction: a registry endpoint naming a key that does
+   * not exist. `resolveResources` itself cannot be unit-tested — it needs a live seeded DB.
+   */
+  const SEED_RESOURCE_KEYS: Record<keyof SeedResources, true> = {
+    employee: true,
+    'eval-cycle-staff': true,
+    'eval-cycle-self': true,
+    calibration: true,
+    'critical-role': true,
+    // #195, 2026-08-11 — threaded into SURFACES['organization'].detail.
+    organization: true,
+  };
+
+  it('every by-id endpoint names a resource key resolveResources actually returns', () => {
+    let seen = 0;
+    for (const [surfaceKey, surface] of Object.entries(SURFACES)) {
+      for (const ep of surface.endpoints) {
+        if (!ep.idScopeKey) continue;
+        seen++;
+        expect(
+          Object.prototype.hasOwnProperty.call(SEED_RESOURCE_KEYS, ep.idScopeKey),
+          `${surfaceKey}/${ep.name}: idScopeKey "${ep.idScopeKey}" is not a SeedResources key — cli.ts's pairFor would throw mid-verify`,
+        ).toBe(true);
+      }
+    }
+    // Non-vacuity: three by-id endpoints today (compensation/employee, ninebox/axis-breakdown,
+    // organization/detail — the same set surfaces.test.ts pins). If this loop goes empty the
+    // assertion above stops being a guard while still reading as one.
+    expect(seen).toBe(3);
   });
 });

--- a/scripts/parity/seed.ts
+++ b/scripts/parity/seed.ts
@@ -93,10 +93,20 @@ const ORG_KEYS: readonly ('a' | 'b')[] = ['a', 'b'];
  * platform_owner as its probeRole". Both statements are now stale: audit-log and access-review were
  * RE-REGISTERED C#-only on 2026-08-11 and both DO use platform_owner as probeRole, which is exactly
  * the case the `orgKey === 'b'` skip below has to keep supporting — as does `organization`, whose
- * probeRole was corrected to platform_owner the same day. Census of everything that lists the role,
- * because `planSeed` is called from BOTH the read path (cli.ts:140) and the write path (cli.ts:265):
- * three READ surfaces (audit-log, access-review, organization) and two WRITE surfaces
- * (write-surfaces.ts's access-review and organization).) */
+ * probeRole was corrected to platform_owner the same day.
+ *
+ * CENSUS, re-derived 2026-08-11 with `grep -rn 'planSeed(' scripts/` because the previous version of
+ * this comment — itself written to correct a stale census — got BOTH halves wrong. It said THREE
+ * call sites and named `cmdAuth` as "the only one that passes `allRoles()`". There are FOUR
+ * production call sites, named by SYMBOL rather than line because every previous line citation in
+ * this comment went stale within a commit or two:
+ *   - cli.ts `mintTokens`      — the read-check path: one surface's `roles`.
+ *   - cli.ts `cmdAuth`         — `allRoles()`.
+ *   - cli.ts `cmdVerifyWrite`  — the write path: one surface's `roles`.
+ *   - seed.ts `seed()` itself  — which cli.ts `cmdSeed` calls with `allRoles()`.
+ * So TWO of the four receive `allRoles()`, not one — `cmdAuth` and `seed()` — and between them they
+ * cover every role in the registry: three READ surfaces (audit-log, access-review, organization) and
+ * two WRITE surfaces (write-surfaces.ts's access-review and organization) list platform_owner.) */
 export function planSeed(roles: string[]): SeedPlan {
   const users: SeededUser[] = [];
   for (const orgKey of ORG_KEYS)
@@ -2273,6 +2283,15 @@ export interface SeedResources {
    *  it is harmless and stays for now — the succession read fixtures come out wholesale with the
    *  ownership flip (#69), which is where removing this belongs. */
   'critical-role': ResourcePair;
+  /** The parity harness's own orgs (`__parity_a` / `__parity_b`, ORG_SLUGS at :78), threaded into
+   *  `/platform/organizations/{id}` by SURFACES['organization'].detail.
+   *
+   *  The `b` id is RESOLVED BUT NEVER PROBED: that endpoint carries `noTenantBoundaryForCaller`, so
+   *  checks/rls.ts short-circuits (:224) before Mode A ever reads `orgBResourceId`. It is kept so the
+   *  ResourcePair shape stays uniform across every key — a one-sided variant would be a second shape
+   *  for `pairFor` (cli.ts) to handle for no gain. Costs zero extra queries: `orgA`/`orgB` are already
+   *  resolved below for the calibration and critical-role lookups. */
+  organization: ResourcePair;
 }
 
 async function orgIdBySlug(db: Client, slug: string): Promise<string> {
@@ -2323,6 +2342,7 @@ export async function resolveResources(cfg: HarnessConfig): Promise<SeedResource
         a: await criticalRoleIdByOrgTitle(db, orgA, 'Parity Critical Role A1'),
         b: await criticalRoleIdByOrgTitle(db, orgB, 'Parity Critical Role B1'),
       },
+      organization: { a: orgA, b: orgB },
     };
   } finally {
     await db.end();

--- a/scripts/parity/surfaces.test.ts
+++ b/scripts/parity/surfaces.test.ts
@@ -40,10 +40,14 @@ describe('SURFACES', () => {
   });
 
   it('every surface probes with a role it actually grants 200 — the #203 defect class', () => {
-    // THE invariant. `cli.ts:161-163` calls BOTH stacks with the probeRole's token and expects
-    // success: checks/parity.ts:47-55 fails closed on a non-200 C# response, and on the TS side
-    // stripTrpcJson (trpc.ts:11) THROWS on an error response, taking the whole run down rather than
-    // reporting a FAIL. So a probeRole the surface denies does not degrade the check — it destroys it.
+    // THE invariant. `runChecks` (cli.ts) calls BOTH stacks with the probeRole's token and expects
+    // success — the `csharpCaller`/`tsCaller` pair it builds for the parity loop. checks/parity.ts:
+    // 49-56 fails closed on a non-200 C# response, and on the TS side stripTrpcJson (trpc.ts:11)
+    // THROWS on an error response, taking the whole run down rather than reporting a FAIL. So a
+    // probeRole the surface denies does not degrade the check — it destroys it.
+    //
+    // This checks the REGISTRY AGAINST ITSELF and cannot see a registry that is internally
+    // consistent and wrong about the PRODUCT. checks/preflight.ts (#206) covers that at run time.
     for (const [key, surface] of Object.entries(SURFACES)) {
       const probe = surface.probeRole;
       expect(probe, `${key} has no explicit probeRole`).toBeDefined();
@@ -92,6 +96,11 @@ describe('SURFACES', () => {
       // C#-only after #57 (no tsProcedure), but STILL by-id and still the surface's cross-tenant
       // IDOR probe — which is exactly why the nine-box surface was kept rather than deleted.
       'ninebox/axis-breakdown': 'employee',
+      // #195, 2026-08-11. By-id like the two above, but it runs NO Mode-A probe: it carries
+      // `noTenantBoundaryForCaller`, so checks/rls.ts short-circuits to a documented N/A. The
+      // sentinel/idScopeKey requirements asserted below still apply to it unchanged — it still has to
+      // bind a REAL seeded org id for parity and RBAC.
+      'organization/detail': 'organization',
     };
     let byIdCount = 0;
     for (const [surfaceKey, surface] of Object.entries(SURFACES)) {
@@ -106,7 +115,9 @@ describe('SURFACES', () => {
         expect(JSON.stringify(ep.input), k).toContain('{id}');
       }
     }
-    expect(byIdCount).toBe(2);
+    // 2 → 3 on 2026-08-11 (#195): + organization/detail, the first by-id endpoint whose RLS mode is
+    // neither A nor B. Pinned so a by-id endpoint cannot appear without a line in `expected` above.
+    expect(byIdCount).toBe(3);
   });
 
   // Kept surface-agnostic (rather than nine-box-specific) so it keeps applying as surfaces come and
@@ -145,8 +156,15 @@ describe('SURFACES', () => {
     //     three routes pin a FIXED non-existent org id in the query string rather than a seeded id —
     //     a literal, not the `{id}` sentinel — so the by-id invariant above is not being sidestepped.
     //
-    // None of the seven is by-id, so the invariant above still bites for them unchanged —
-    // `getOrganization` was left unregistered rather than weaken it (see surfaces.ts).
+    // None of the NINE is by-id, so the invariant above still bites for them unchanged. (This line
+    // read "None of the seven" until 2026-08-11; the count was never re-derived when access-review's
+    // three routes were re-added, and the enumeration immediately above already listed 2+2+2+3 = 9.
+    // A superlative is a quantifier — count the set.)
+    //
+    // `getOrganization` is now registered (#195) under `noTenantBoundaryForCaller`, which is a
+    // DIFFERENT flag: it does not appear in this loop, `seen` stays 9, and this invariant is
+    // untouched. Setting `globalScope` on it instead would push `seen` to 10 AND trip the by-id
+    // assertion above — which is the proof that the guard was worked with rather than weakened.
     expect(seen).toBe(9);
   });
 
@@ -195,7 +213,7 @@ describe('SURFACES', () => {
   });
 
   // ── #195: the platform-organizations read surface (2026-08-10) ───────────────────────────────
-  it('organization is registered with its flag + the 3 reads, minus the by-id detail', () => {
+  it('organization is registered with its flag + ALL 3 deployed reads', () => {
     const s = SURFACES['organization'];
     expect(s.flag).toBe('Platform__PlatformOrganizationsReadEnabled');
     expect(s.roles).toEqual(['platform_owner', 'org_admin']);
@@ -205,27 +223,111 @@ describe('SURFACES', () => {
     // makes this class of mistake unshippable; this line now just records the corrected value.
     expect(s.probeRole).toBe('platform_owner');
 
-    expect(s.endpoints.map((e) => e.name)).toEqual(['kpis', 'list']);
+    // 2026-08-11 (#195): 'detail' added. PlatformOrganizationsReadEndpoints.cs maps exactly three
+    // GETs (:43 kpis, :65 list, :113 by-id), so this is now the whole deployed read surface.
+    expect(s.endpoints.map((e) => e.name)).toEqual(['kpis', 'list', 'detail']);
 
     for (const ep of s.endpoints) {
       // Both flags still dark, TS still the live path — so every endpoint MUST keep a tsProcedure and
       // produce a real byte diff. A [WEAK] here would mean the pre-flip readiness check proves nothing.
+      // (`detail` carries a KNOWN, source-derived divergence — C# `counts` vs Prisma `_count`. It
+      // keeps its tsProcedure anyway: dropping it to dodge a predicted red is how a gate is made
+      // unable to fail. See the endpoint comment in surfaces.ts.)
       expect(ep.tsProcedure, ep.name).toBeTruthy();
-      // RBAC is the boundary proof on a platform-owner surface, since RLS is N/A.
+      // RBAC is the boundary proof on a platform-owner surface, since RLS is N/A on all three.
       expect(ep.expectedByRole, ep.name).toEqual({ platform_owner: 200, org_admin: 403 });
-      expect(ep.globalScope, ep.name).toBe(true);
     }
+
+    // The RLS N/A is reached by TWO DIFFERENT flags, and conflating them is the mistake this
+    // asserts against. kpis/list are genuinely org-independent payloads; detail's payload is
+    // org-SPECIFIC and only its CALLER is boundary-free.
+    const byName = (n: string) => s.endpoints.find((e) => e.name === n)!;
+    for (const n of ['kpis', 'list']) {
+      expect(byName(n).globalScope, n).toBe(true);
+      expect(byName(n).noTenantBoundaryForCaller, n).toBeUndefined();
+      expect(byName(n).idScopeKey, n).toBeUndefined();
+    }
+    expect(byName('detail').globalScope, 'detail must NOT claim org-independence').toBeUndefined();
+    expect(byName('detail').noTenantBoundaryForCaller).toBe(true);
   });
 
-  it('getOrganization stays UNregistered until a by-id platform-owner endpoint can be expressed', () => {
-    // Pins a DELIBERATE omission so it reads as a decision, not an oversight. Registering it needs a
-    // real org id in `{id}` AND no Mode-A IDOR probe; the only way to express the second today is
-    // `globalScope`, which the invariant above forbids combining with `idScopeKey` — correctly, since
-    // that flag means "pure kernel", not "no tenant boundary for this caller". Overloading it would
-    // silently disable a genuine IDOR probe on some future surface.
-    const names = SURFACES['organization'].endpoints.map((e) => e.name);
-    expect(names).not.toContain('detail');
-    expect(SURFACES['organization'].endpoints.some((e) => e.idScopeKey)).toBe(false);
+  it('getOrganization is registered under the by-id platform-owner marker, NOT globalScope', () => {
+    // Replaces the pin on a DELIBERATE omission (which read: "stays UNregistered until a by-id
+    // platform-owner endpoint can be expressed"). It can now be expressed — by a NEW, explicitly-named
+    // field, not by overloading `globalScope`. The globalScope+idScopeKey guard above was left exactly
+    // as it was; this endpoint satisfies it rather than sidestepping it.
+    const s = SURFACES['organization'];
+    const names = s.endpoints.map((e) => e.name);
+    expect(names).toContain('detail');
+    const detail = s.endpoints.find((e) => e.name === 'detail')!;
+    expect(detail.idScopeKey, 'detail must bind a REAL seeded org id — the endpoint 404s on an unknown org').toBe(
+      'organization',
+    );
+    expect(detail.noTenantBoundaryForCaller).toBe(true);
+    expect(detail.globalScope, 'detail is NOT a pure kernel — its payload is org-specific').toBeUndefined();
+    // The deployed route is `/platform/organizations/{id:guid}`; the registry writes the harness's
+    // canonical sentinel, because ids.ts substitutes a concrete id rather than calling by template.
+    expect(detail.csharpPath).toBe('/platform/organizations/{id}');
+  });
+
+  it('noTenantBoundaryForCaller is by-id only, never globalScope, and denies EVERY non-platform-owner role', () => {
+    let seen = 0;
+    for (const [key, surface] of Object.entries(SURFACES)) {
+      for (const ep of surface.endpoints) {
+        if (!ep.noTenantBoundaryForCaller) continue;
+        seen++;
+        // (i) Only meaningful on a by-id endpoint — it suppresses RLS Mode A and nothing else. A
+        //     Tier-1 endpoint claiming it is a category error, and would read as a general Mode-B
+        //     suppressor, which is what globalScope is for.
+        expect(ep.idScopeKey, `${key}/${ep.name}: marker set without idScopeKey`).toBeDefined();
+        // (ii) Never both. They assert different things (payload vs caller); combining them is the
+        //      overload the globalScope guard above exists to prevent.
+        expect(ep.globalScope, `${key}/${ep.name}: marker AND globalScope`).toBeUndefined();
+        // (iii) RBAC is the ENTIRE boundary proof once RLS is N/A, so EVERY non-platform-owner role
+        //       must be denied — not merely "some role somewhere is denied".
+        //
+        //       An earlier version asserted `Object.values(...).toContain(403)`, which is the weaker
+        //       claim and survives the case that matters: a later slice makes an org's own admin able
+        //       to read its own org detail (`{platform_owner:200, org_admin:200, hrbp:403}`). A real
+        //       cross-tenant boundary would then exist again — org-A's admin reaching org-B's id —
+        //       while this marker keeps RLS Mode A suppressed, and the RBAC leg could not see it
+        //       either, since it only ever probes org A's OWN id. (On today's registry that specific
+        //       edit is caught by the organization-surface pin below, which pins the whole
+        //       expectedByRole map — but that pin is surface-specific and this invariant is the one a
+        //       FUTURE endpoint inherits, so it must carry the constraint itself.)
+        for (const [role, expectation] of Object.entries(ep.expectedByRole)) {
+          if (role === 'platform_owner') continue;
+          expect(
+            expectation,
+            `${key}/${ep.name}: role "${role}" is ${expectation}, but every non-platform-owner role must be 403 — ` +
+              'a role this endpoint answers 200 to is a tenant boundary that RLS Mode A is being told to skip',
+          ).toBe(403);
+        }
+        // ...and at least one such role must EXIST, or the loop above is vacuous.
+        expect(
+          Object.keys(ep.expectedByRole).filter((r) => r !== 'platform_owner'),
+          `${key}/${ep.name} declares no non-platform-owner role at all`,
+        ).not.toEqual([]);
+        // (iv) Only a platform-owner-gated surface qualifies — a constraint no org-scoped surface can
+        //      satisfy by accident. This is a PROXY, and worth naming as one: it reads a registry
+        //      field, not the deployed gate. Nothing in this repo verifies the marker's actual stated
+        //      precondition (served by a platform-owner gate over the UNSCOPED client) — and two
+        //      other registered surfaces (audit-log, access-review) already satisfy the proxy, so a
+        //      future by-id read added to either could carry the marker while in fact being served
+        //      through a tenant-scoped repository. THE COUNT PIN BELOW IS THE REAL BACKSTOP for that
+        //      case: it forces the edit to be deliberate and reviewed, which (iv) alone does not.
+        expect(surface.probeRole, `${key}: marker on a non-platform-owner surface`).toBe('platform_owner');
+      }
+    }
+    // Count pin with a reason PER ENDPOINT, so the loop going empty fails HERE instead of reading as
+    // an enforced invariant (the 2026-08-05 nine-box lesson recorded above). It is ALSO the only
+    // forcing function on the marker's unverifiable precondition — see (iv). Adding a second marked
+    // endpoint must be a deliberate edit here, with its own line, naming the gate it is served by.
+    //   organization/detail — GET /platform/organizations/{id}. platformProcedure / PlatformOwnerGate
+    //     over the unscoped db; a platform owner reading org B is the FEATURE, and it 404s on an
+    //     unknown org (organizations.ts:100), so the access-review fixed-non-existent-id trick cannot
+    //     apply and a real seeded id is required.
+    expect(seen).toBe(1);
   });
 
   // ── The two platform-owner READ surfaces re-registered C#-only on 2026-08-11 ──────────────────
@@ -274,7 +376,10 @@ describe('SURFACES', () => {
     // lookup; the 200 is an EMPTY report, because AccessReviewService.BuildReportAsync has no
     // org-exists precondition (only AttestAsync does, AccessReviewService.cs:35). Using a real
     // seeded org id instead would turn these into by-id endpoints and collide with the globalScope
-    // invariant above — which is precisely why getOrganization is still unregistered.
+    // invariant above — which is why this surface must NOT be rewritten to use a seeded id without
+    // moving to `noTenantBoundaryForCaller`, the marker `getOrganization` needed. (This sentence
+    // used to end "...which is precisely why getOrganization is still unregistered". It IS
+    // registered, as of 2026-08-11 (#195) — under that marker, not by weakening this invariant.)
     const s = SURFACES['access-review'];
     // Paths pinned EXACTLY, not by substring. An earlier revision asserted only
     // `.toContain('organizationId=...')`, which left the route itself unpinned — a mutation to

--- a/scripts/parity/surfaces.ts
+++ b/scripts/parity/surfaces.ts
@@ -25,6 +25,41 @@ export interface EndpointDef {
    *  target (`rls.ts`). Absent ⇒ a static-path (Tier-1) endpoint. When set,
    *  `csharpPath` and any id-carrying `input` value MUST use the `{id}` sentinel. */
   idScopeKey?: string;
+  /** Mode-A suppression for a BY-ID endpoint whose gate is PRINCIPAL TYPE, not tenancy.
+   *  Set ONLY together with `idScopeKey`, and only on an endpoint served by a
+   *  platform-owner gate (TS `platformProcedure` / C# `PlatformOwnerGate`) over the
+   *  UNSCOPED client: reaching another org's row IS the product requirement there, so a
+   *  Mode-A IDOR probe would assert the exact opposite of it — org-A's (platform-owner)
+   *  token SHOULD get a 200 carrying org-B's body, which `assertIsolated` correctly reads
+   *  as a breach. It could not run anyway: `mintTokens` deliberately mints no org-B token
+   *  for an org-less platform owner (cli.ts's `mintTokens`), so Mode A's positive control
+   *  fails closed (checks/rls.ts). `checks/rls.ts` therefore short-circuits to a documented
+   *  N/A (`inconclusive` → `[WEAK]`) at :224 with its OWN reason string, distinct from the
+   *  globalScope one at :205, so a report reader can tell the two dispositions apart.
+   *  Parity and RBAC still run UNCHANGED against the org-A id — and on a surface like this
+   *  RBAC is the ENTIRE boundary proof (the denied ordinary role's 403), which is why
+   *  surfaces.test.ts requires EVERY non-platform-owner role on an endpoint carrying this
+   *  flag to be 403 — not merely that some 403 exists somewhere in the map. A role this
+   *  endpoint answers 200 to would be a live tenant boundary that Mode A is being told to
+   *  skip.
+   *
+   *  THIS IS NOT `globalScope`, and the two must never be merged. `globalScope` asserts
+   *  the PAYLOAD is org-independent — a pure kernel or per-deploy config returning the
+   *  same bytes for every org — which is why Mode B's "identical payloads ⇒ leak"
+   *  heuristic is inverted for it and why surfaces.test.ts's "every globalScope endpoint
+   *  is a pure kernel" test forbids it on a by-id endpoint. (Deliberately named rather
+   *  than cited by line: this docblock's previous two line citations into that file were
+   *  both stale on the day they were written, because the same commit inserted lines above
+   *  the target.) This flag asserts nothing about the payload: the response IS org-specific
+   *  and a different id returns different data. It says only that THIS CALLER has no
+   *  tenant boundary to cross. Overloading `globalScope` to mean both is precisely what
+   *  would silently retire a genuine IDOR probe on a future org-scoped by-id endpoint.
+   *
+   *  The read-side analogue of write-surfaces.ts's documented omission of `buildIdor` on
+   *  access-review `attest`, reported the same way — except that the write side expresses
+   *  it by OMITTING a builder, which the read side cannot: absence of `idScopeKey` already
+   *  means "Tier-1 static path". Hence a POSITIVE marker. */
+  noTenantBoundaryForCaller?: boolean;
   /** Mode-A only. By default a by-id endpoint's CORRECT cross-tenant response is a
    *  denial STATUS (403/404) — so a 200 with an empty body is itself an anomaly (the
    *  route processed a cross-org id instead of 404ing = a possible missing-404 /
@@ -182,46 +217,59 @@ export const SURFACES: Record<string, Surface> = {
   // RLS IS N/A ON EVERY ENDPOINT, AND THAT IS THE CORRECT ANSWER, NOT A GAP. This surface is
   // `platformProcedure` on the TS side and `PlatformOwnerGate` on the C# side, over the UNSCOPED `db`
   // — it is cross-org BY DESIGN. A platform owner reading org B is the feature, so a Mode-A IDOR
-  // probe would assert the opposite of the requirement. `globalScope: true` makes `checks/rls.ts`
-  // report a documented N/A (it short-circuits at rls.ts:189, BEFORE the `idScopeKey` branch at :199)
-  // rather than a spurious FAIL. The authorization boundary here is the GATE, and it is RBAC — not
-  // RLS — that proves it, via the org_admin 403 on every endpoint. Same disposition and same reason
-  // as the access-review / audit-log read surfaces below.
+  // probe would assert the opposite of the requirement. The authorization boundary here is the GATE,
+  // and it is RBAC — not RLS — that proves it, via the org_admin 403 on every endpoint.
+  //
+  // N/A VIA TWO DIFFERENT FLAGS, AND THE DIFFERENCE IS THE WHOLE POINT (see `detail` below).
+  //   kpis + list  → `globalScope: true`. checks/rls.ts short-circuits at :205 with the
+  //                  "non-tenant endpoint" reason. Correct because the PAYLOAD really is
+  //                  org-independent: `list` enumerates every tenant by construction.
+  //   detail       → `noTenantBoundaryForCaller: true`. checks/rls.ts short-circuits at :224, BEFORE
+  //                  the `idScopeKey` branch at :235, with a DISTINCT reason. Its payload is
+  //                  emphatically org-SPECIFIC — a different `{id}` returns different data — so
+  //                  claiming globalScope for it would be a false statement about the endpoint that
+  //                  happens to produce the right verdict, which is how a flag gets overloaded until
+  //                  it silently retires a real IDOR probe somewhere else.
+  // The access-review / audit-log read surfaces below are the globalScope disposition, not this one.
   //
   // probeRole is `platform_owner`. It was `org_admin` from #203 (2026-08-10) until 2026-08-11, and
   // THAT WAS A BUG THAT MADE `verify organization` UNRUNNABLE — caught by the review panel on this
   // change, which found the comment here justifying it as deliberate.
   //
   // Why it could not work: the probe identity's token is what the parity leg calls BOTH stacks with
-  // (cli.ts:161-163), and `org_admin` expects 403 on every endpoint of this surface. On the C# side
-  // `checks/parity.ts:47-55` fails closed on any non-200, so both endpoints report
+  // (`csharpCaller`/`tsCaller` in cli.ts's `runChecks`), and `org_admin` expects 403 on every
+  // endpoint of this surface. On the C# side `checks/parity.ts:49-56` fails closed on any non-200,
+  // so both endpoints report
   // "C# returned HTTP 403 (expected 200)". On the TS side it is worse than a FAIL: `stripTrpcJson`
   // (trpc.ts:11) THROWS on a tRPC error response, so the run crashes rather than reporting. That is
   // exactly the hazard the removed access-review entry documented in 2026-07-31 ("pointing probeRole
   // at a denied role takes down the whole verify run") — the note was deleted with the surface and
   // the lesson went with it, which is its own argument for keeping surfaces registered.
   //
-  // The original rationale — "a platform owner is org-less and seeded only under org A (seed.ts:86),
+  // The original rationale — "a platform owner is org-less and seeded only under org A (seed.ts:83-88),
   // so it has no org-B counterpart to probe with" — is a true fact that does not imply the
-  // conclusion. `mintTokens` skips the org-B requirement for exactly this role (cli.ts:129), and
-  // both endpoints here are `globalScope`, so no org-B token is ever needed. `probeRole` must simply
-  // be a role the surface grants 200; that invariant is now asserted for EVERY surface in
+  // conclusion. `mintTokens` skips the org-B requirement for exactly this role (cli.ts), and no
+  // endpoint here runs an RLS mode that needs an org-B token, so none is ever required. `probeRole`
+  // must simply be a role the surface grants 200; that invariant is now asserted for EVERY surface in
   // surfaces.test.ts, so this class of defect cannot ship again unnoticed.
   //
-  // `getOrganization` (the by-id detail read) is DELIBERATELY NOT REGISTERED HERE, and that is the
-  // honest answer rather than a shortcut. It needs two things at once — a real org id bound into
-  // `{id}`, and no Mode-A IDOR probe — and the only existing way to express the second is
-  // `globalScope`, which surfaces.test.ts:46 explicitly forbids combining with `idScopeKey`
-  // ("no by-id endpoint may claim org-independence"). That guard is CORRECT: `globalScope` means
-  // "pure kernel, org-independent computation" (nine-box simulate/quadrant-plan), whereas this
-  // endpoint reads org-specific rows and merely has no tenant boundary FOR THIS CALLER. Those are
-  // different properties, and overloading one flag for both is precisely what would silently
-  // disable a real IDOR probe on some future surface. The access-review entry below sidesteps it
-  // with a fixed non-existent org id, which cannot work here — `getOrganization` 404s on an
-  // unknown org (organizations.ts:100), so the platform_owner case would assert 404, not 200.
-  // Registering it needs a distinct, explicit concept (a platform-owner "no IDOR by design" marker,
-  // the read-side analogue of write-surfaces.ts's documented omission of `buildIdor` on
-  // access-review `attest`). Filed rather than smuggled in under an existing flag.
+  // `getOrganization` IS NOW REGISTERED (2026-08-11, #195) — see the `detail` endpoint below. It was
+  // deliberately omitted until then, and the reason it was omitted is the reason the new flag exists
+  // rather than a reuse of an old one. It needs two things at once: a real org id bound into `{id}`,
+  // and no Mode-A IDOR probe. The only way to express the second used to be `globalScope`, which
+  // surfaces.test.ts's "every globalScope endpoint is a pure kernel" test forbids combining with
+  // `idScopeKey` — and that guard is
+  // CORRECT, so it was NOT weakened: `globalScope` means "pure kernel, org-independent computation"
+  // (nine-box simulate/quadrant-plan), whereas this endpoint reads org-specific rows and merely has
+  // no tenant boundary FOR THIS CALLER. Those are different properties; overloading one flag for both
+  // is what would silently disable a real IDOR probe on some future surface. The access-review entry
+  // below sidesteps the problem with a fixed NON-EXISTENT org id, which cannot work here —
+  // `getOrganization` 404s on an unknown org (organizations.ts:100 / the C# repository returns null at
+  // PlatformOrganizationsReadRepository.cs:151-156, mapped to Results.NotFound() at
+  // PlatformOrganizationsReadEndpoints.cs:133), so the platform_owner case would assert 404, not 200.
+  // The answer was a distinct, explicitly-named marker — `noTenantBoundaryForCaller`, the read-side
+  // analogue of write-surfaces.ts's documented omission of `buildIdor` on access-review `attest`
+  // (write-surfaces.ts:1447-1448) — not a smuggled reuse of an existing one.
   organization: {
     key: 'organization',
     flag: 'Platform__PlatformOrganizationsReadEnabled',
@@ -246,6 +294,61 @@ export const SURFACES: Record<string, Surface> = {
         expectedByRole: { platform_owner: 200, org_admin: 403 },
         normalize: { dropNullish: true },
         globalScope: true,
+      },
+      // getOrganization — REGISTERED 2026-08-11 (#195) via `noTenantBoundaryForCaller`, the distinct
+      // marker the old note above said this needed. NOT globalScope: this payload IS org-specific.
+      //
+      // The `{id}` sentinel is the harness's canonical placeholder, NOT the deployed route's spelling
+      // — the deployed template is `/platform/organizations/{id:guid}`
+      // (PlatformOrganizationsReadEndpoints.cs:114). That is not a mismatch: the harness never calls a
+      // route by template, it substitutes a concrete id and builds a real URL (ids.ts:5-11).
+      //
+      // KNOWN, PREDICTED PARITY FAIL — derived from source, not discovered at run time. C#
+      // `PlatformOrganizationDetail.Counts` (PlatformOrganizationsReadModels.cs:125) serialises to
+      // `counts` (JsonSerializerDefaults.Web camelCase; that file contains zero [JsonPropertyName] and
+      // Program.cs never calls ConfigureHttpJsonOptions), while TS returns Prisma's `_count`
+      // (organizations.ts:97). normalize.ts offers only dropNullish + sortArraysBy — no key rename —
+      // so this WILL report a real FAIL until the C# record is corrected. The `list` endpoint above
+      // has the SAME class of divergence three times over (`counts`/`_count`,
+      // `lastLoginAt`/`users[].lastLoginAt`, `pendingInvoices`/`invoices` —
+      // PlatformOrganizationsReadModels.cs:47-51 vs organizations.ts:64-77) and has simply never been
+      // observed, because `verify organization` has never successfully run (the #205 probeRole bug).
+      // All FOUR are filed as issue #211 (verified to exist, not asserted — the previous version of
+      // this sentence said "filed as their own issue" in the past tense when no such issue existed).
+      // Fixing them is NOT this change, and dropping `tsProcedure` here to dodge a known-red would be
+      // exactly the "make the gate unable to fail" move this harness exists to prevent.
+      //
+      // OPERATIONAL CONSEQUENCE 1 — THIS SURFACE IS NO LONGER DB-FREE, AND THE DEPENDENCY IS WIDER
+      // THAN THIS ENDPOINT. `cli.ts`'s `needsResources` now fires for `organization`, which calls
+      // `resolveResources` (seed.ts) — and that function resolves EVERY SeedResources key
+      // unconditionally and throws on the first missing one. So `verify organization` now requires
+      // DATABASE_URL plus the seeded employee users, the 2026-Q1 calibration sessions in BOTH orgs
+      // and the "Parity Critical Role A1"/"B1" rows in both orgs. An environment whose ninebox /
+      // succession fixtures were never seeded fails with e.g. `resolveResources: no seeded critical
+      // role "Parity Critical Role A1" in org <uuid>` — a failure with no relationship to the surface
+      // under test, and one that could not occur while this surface was Tier-1 only. Run
+      // `cli.ts seed` first. (The org ids themselves cost zero extra queries: `orgA`/`orgB` are
+      // already resolved for the calibration and critical-role lookups.)
+      //
+      // OPERATIONAL CONSEQUENCE 2 — a parity FAIL PRINTS DIFF VALUES (checks/parity.ts → normalize.ts
+      // `DiffEntry {path, a, b}` → report.ts → console.log), and this is the first registered read
+      // whose payload carries user records: `users[].email`, `firstName`, `lastName`, `jobTitle`,
+      // `lastLoginAt` (organizations.ts:93). Against the seeded `__parity_a` org that data is
+      // synthetic, so this is not a leak — but the harness now has a stdout/CI-log path for
+      // user-shaped records that it did not have before, and the predicted-red above GUARANTEES the
+      // diff branch executes. Do not point this endpoint at a real tenant's org id in a logged CI job.
+      {
+        name: 'detail',
+        csharpPath: '/platform/organizations/{id}',
+        tsProcedure: 'platform.getOrganization',
+        input: { id: ID_SENTINEL },
+        idScopeKey: 'organization',
+        noTenantBoundaryForCaller: true,
+        expectedByRole: { platform_owner: 200, org_admin: 403 },
+        // sortArraysBy is NOT cosmetic: both stacks order `users` by createdAt desc
+        // (organizations.ts:93; PlatformOrganizationsReadRepository.cs:175-177) and seeded users can
+        // share a created_at, making tie order nondeterministic across the two stacks.
+        normalize: { dropNullish: true, sortArraysBy: 'id' },
       },
     ],
   },
@@ -409,15 +512,24 @@ export const SURFACES: Record<string, Surface> = {
   // anything (the #166 false-FAIL failure mode). Tracked in #195, not fixed here.
   //
   // AND THAT IS THE SMALLER HALF OF THE GAP. Those six are merely the surfaces that were once
-  // registered and then removed. Counting deployed ROUTES instead of surfaces, measured 2026-08-11:
-  // `services/Tims.Platform/src/Tims.Api/**/*.cs` contains 132 `.MapGet/Post/Patch/Put/Delete(`
-  // registrations and zero `MapGroup`, while SURFACES + WRITE_SURFACES hold 49 endpoints (23 + 26).
-  // The difference is not exactly the uncovered count — nothing here proves a 1:1 route-to-endpoint
-  // correspondence, and some Map calls are infra rather than domain routes — but the order of the gap
-  // is unambiguous, and it includes whole domains that were NEVER registered (external-vendor,
-  // billing self-serve/webhook writes, `/internal/alert-metrics`) plus most routes inside surfaces
-  // that ARE registered (engagement registers 2 endpoints against 14 deployed reads; dei 2 of 11).
-  // Do not read "the surface is registered" as "the domain is covered". #195 is the tracking issue.
+  // registered and then removed. Counting deployed ROUTES instead of surfaces, MEASURED EXACTLY
+  // (2026-08-11) rather than estimated: `contracts/openapi/Tims.Api.json` declares 135
+  // GET/POST/PATCH/PUT/DELETE operations across 128 paths, while SURFACES + WRITE_SURFACES hold 50
+  // endpoints (24 + 26) resolving to 50 distinct VERB+path keys — leaving 85 deployed routes with no
+  // registry entry. That subtraction is now a real one, not an order-of-magnitude gesture: an earlier
+  // version of this note counted 132 `.MapGet/Post/Patch/Put/Delete(` call sites in
+  // `services/Tims.Platform/src/Tims.Api/**/*.cs` and correctly refused to subtract, because a call
+  // site is not a route (one `Evaluation360WriteEndpoints` site is invoked three times, one
+  // `AlertMetrics` site maps a `const`, and six `PlatformOrganizations*` sites put the literal on the
+  // next line). The 85 are enumerated with a reason per group in
+  // tests/governance/parity-registry-covers-deployed-routes.test.ts, which fails if a NEW deployed
+  // route appears in neither the registry nor that list.
+  //
+  // The gap includes whole domains that were NEVER registered (external-vendor, billing
+  // self-serve/webhook writes, `/internal/alert-metrics`) plus most routes inside surfaces that ARE
+  // registered (engagement registers 2 endpoints against 14 deployed GETs; dei 2 of 11; compensation
+  // 2 of 12; ninebox 4 of 11). Do not read "the surface is registered" as "the domain is covered".
+  // #195 is the tracking issue.
   //
   // `verify succession` is therefore now a NO-OP. That is a genuine reduction in this harness's
   // coverage and is recorded as such in scripts/deploy/cutover.sh's `succession` row — do NOT
@@ -520,7 +632,9 @@ export const SURFACES: Record<string, Surface> = {
   // org-exists precondition (only `AttestAsync` does, AccessReviewService.cs:35), so an unknown org
   // yields zero rows and a zero summary, not a 404. Verified against the source, not assumed: this
   // is exactly the property `getOrganization` lacks (it 404s on an unknown org), which is why THAT
-  // read is still unregistered ~200 lines above.
+  // read could not use this trick and needed a real seeded id plus the `noTenantBoundaryForCaller`
+  // marker instead. (This sentence read "...which is why THAT read is still unregistered ~200 lines
+  // above" until 2026-08-11; it was registered in the same change that added the marker.)
   //
   // THE PINNED ID COLLIDES WITH A SENTINEL IN THIS DOMAIN'S OWN CODE, and that is worth knowing
   // rather than discovering. `AccessReviewService.cs:65` coalesces a NULL `users.organization_id` to
@@ -551,8 +665,9 @@ export const SURFACES: Record<string, Surface> = {
   // because the pinned id resolves to no org at all, so there is no per-org payload to compare and
   // Mode B would be comparing two empty bodies. It does NOT collide with the `idScopeKey` guard —
   // the id is a fixed literal, never the `{id}` sentinel, so no Mode-A probe is being suppressed.
-  // A version of this surface bound to a REAL org id would need the by-id platform-owner marker that
-  // `getOrganization` is still waiting on; it must not simply inherit `globalScope` from here.
+  // A version of this surface bound to a REAL org id would need the by-id platform-owner marker
+  // `noTenantBoundaryForCaller` (which now exists — `getOrganization` uses it); it must not simply
+  // inherit `globalScope` from here.
   //
   // The WRITE surface (attestAccessReview) was never affected by any of this — write-surfaces.ts's
   // WRITE_SURFACES['access-review'] hits the C# endpoint directly via raw SQL + HTTP and has no

--- a/tests/governance/parity-registry-covers-deployed-routes.test.ts
+++ b/tests/governance/parity-registry-covers-deployed-routes.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { SURFACES } from '../../scripts/parity/surfaces';
+import { WRITE_SURFACES, type WriteResolvedBase } from '../../scripts/parity/write-surfaces';
+
+/**
+ * DEPLOYED ROUTE ↔ PARITY REGISTRY COVERAGE GUARD (#195).
+ *
+ * The parity harness (scripts/parity/) is the only automated thing that probes the LIVE C# service
+ * for cross-tenant isolation (checks/rls.ts) and permission denials (checks/rbac.ts). It can probe
+ * nothing that SURFACES + WRITE_SURFACES do not register — and nothing measured how much of the
+ * deployed service that is. Measured 2026-08-11: 50 registered endpoints against 135 deployed
+ * operations, leaving a gap of 85.
+ *
+ * THIS GUARD MEASURES REGISTRATION, NOT PROBE COVERAGE, and the two are not the same number. Of the
+ * 24 READ registrations, TEN issue no cross-tenant probe at all: 9 carry `globalScope` and 1 carries
+ * `noTenantBoundaryForCaller`, and checks/rls.ts returns `inconclusive` for both without calling
+ * anything. Those are correct dispositions — a platform-owner cross-org read has no tenant boundary
+ * to prove — but it means a route can move from the allowlist into the "covered" set without gaining
+ * a Mode-A probe. This change is its own worked example: `GET /platform/organizations/{id}` left
+ * allowlist group 3 and the gap pin dropped 86 → 85, which reads as progress, while that route's RLS
+ * disposition went from "unprobed" to "unprobed, documented". Read the headline numbers as
+ * "registered and therefore visible to the harness", never as "probed for cross-tenant isolation".
+ *
+ * WHAT THIS GUARD DOES AND DOES NOT DO. It does NOT register the gap — that is out of scope and must
+ * not be attempted here: each org-scoped surface needs its own SEEDED GRANT FIXTURE before it can be
+ * registered, and a missing grant produces #166's false FAIL (12 of 43 endpoints red for a fixture
+ * reason, not a product reason). What it does is make the gap VISIBLE and stop it growing silently:
+ * every deployed route must either be registered or appear on UNREGISTERED_ALLOWLIST under a group
+ * with a written reason, so a NEWLY deployed route has to be added deliberately.
+ *
+ * SOURCE OF TRUTH: contracts/openapi/Tims.Api.json, NOT the *Endpoints.cs files. This is a real
+ * decision, for four reasons:
+ *   1. A .cs regex cannot resolve 8 of the 133 `.Map{Get,Post,Patch,Put,Delete}(` call sites. Six
+ *      PlatformOrganizations* registrations put the route literal on the line AFTER the `app.Map*(`;
+ *      AlertMetricsEndpoints.cs:47 maps a `const RoutePath` (declared :43);
+ *      Evaluation360WriteEndpoints.cs:172 interpolates `{verb}` into the template and is itself
+ *      invoked three times, so 133 call sites are not 133 routes either. Even a next-line-aware
+ *      parser both under- and over-reports.
+ *   2. The OpenAPI document resolves all of them — it is emitted by the framework from the mapped
+ *      routes themselves, so it cannot disagree with what is mapped. What IS reproducible from this
+ *      repo is the arithmetic: `grep -rEo '\.Map(Get|Post|Patch|Put|Delete)\(' services/Tims.Platform
+ *      /src/Tims.Api --include='*.cs' | wc -l` = 133 call sites, minus the 1 inside the private
+ *      `MapTransition` helper (Evaluation360WriteEndpoints.cs:169, mapping at :172), plus its 3
+ *      invocations (Evaluation360WriteEndpoints.cs:78/:80/:82) = 135, which is
+ *      the operation count this file parses and pins. An earlier version of this line claimed the two
+ *      sets had "ZERO symmetric difference" as measured by a one-off script; that script was never
+ *      committed, so the claim was not reproducible and is not restated.
+ *   3. DARK endpoints are included BY DESIGN. Program.cs:937 computes `isOpenApiDocGeneration` and
+ *      every mapping guard is `if (flag || isOpenApiDocGeneration)`, so the document is a
+ *      flag-independent inventory — the only source describing routes a deployment will serve AFTER
+ *      a flip, which is precisely when an unregistered route becomes dangerous.
+ *   4. CI already guarantees freshness: .github/workflows/dotnet-platform.yml:60 builds `-c Release`
+ *      (Tims.Api.csproj:9-11 wires OpenApiGenerateDocumentsOnBuild) and :66 runs
+ *      `git diff --exit-code contracts/openapi/`. A new route cannot merge without updating this
+ *      file — exactly the trigger this guard needs.
+ *
+ * CAVEAT, stated rather than implied: `/health` and `/ready` (Program.cs:892, :899) are ABSENT from
+ * the document — MapHealthChecks emits no endpoint metadata. So this guard covers 135 domain
+ * OPERATIONS, never "every routable path".
+ */
+
+const ROOT = join(__dirname, '..', '..');
+const OPENAPI = join(ROOT, 'contracts/openapi/Tims.Api.json');
+
+const HTTP_VERBS = ['get', 'post', 'patch', 'put', 'delete'] as const;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * VERB + path, per-SEGMENT tokenisation. Applied IDENTICALLY to all three sides (deployed, registry,
+ * allowlist), because a normalisation applied to only one side is a silent false match. Each rule has
+ * a reason:
+ *
+ *  1. Truncate at the first `?`. Eight of the 24 read registry entries carry a query string
+ *     (`/monitoring/alerts?page=1&limit=20`, the three access-review `?organizationId=…` routes, …);
+ *     no OpenAPI path and no .cs route template ever does.
+ *  2. Split on '/', and replace a WHOLE segment with `{*}` when it is a `{…}` placeholder or a bare
+ *     UUID. Both sides need it: param NAMES differ (the registry writes `/compensation/employee/{id}`
+ *     where the deployed template says `{userId}`), and the write builders interpolate REAL module
+ *     constants (e.g. `e0000361-…`) plus the resolver stub's sentinel, so a concrete UUID appears
+ *     where the deployed side has a template.
+ *  3. Compare the joined string with EXACT equality — never a `.+` regex.
+ *     `GET /platform/organizations/kpis` (a literal, registered) and
+ *     `GET /platform/organizations/{id}` (a template) are BOTH live routes; a loose wildcard would
+ *     let the registered literal satisfy the unregistered by-id route. `kpis !== {*}` keeps them apart.
+ *  4. Key on VERB + path, NEVER path alone. Seven OpenAPI paths carry two verbs, so a verb-blind key
+ *     would falsely mark FIVE currently-unregistered routes covered: POST /platform/organizations,
+ *     GET /evaluation360/cycles, GET /succession/critical-roles, GET /ninebox/calibrations and
+ *     GET /engagement/action-plans. It was SIX until 2026-08-11: GET /platform/organizations/{id} was
+ *     unregistered while PATCH on that same path was registered (the organization write surface's
+ *     `update`), so a verb-blind key excused a read that had never been probed with the write that
+ *     had — the exact shape of failure this rule exists to prevent.
+ *  5. Upper-case the verb and strip a trailing '/'. Neither varies today; normalise anyway so a future
+ *     `.MapGet("/billing/plan/")` cannot slip past as a "new" route.
+ */
+function routeKey(verb: string, path: string): string {
+  let p = path.split('?')[0];
+  if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+  const segments = p
+    .split('/')
+    .map((s) => (/^\{[^}]*\}$/.test(s) || UUID_RE.test(s) ? '{*}' : s))
+    .join('/');
+  return `${verb.toUpperCase()} ${segments}`;
+}
+
+// ── The deployed side ────────────────────────────────────────────────────────────────────────────
+interface OpenApiDoc {
+  paths: Record<string, Record<string, unknown>>;
+}
+const doc = JSON.parse(readFileSync(OPENAPI, 'utf8')) as OpenApiDoc;
+const deployed = new Set<string>();
+/** Raw operations PARSED, counted before the Set dedupes anything. `deployed.size` alone cannot
+ *  distinguish "no new route" from "a new route collapsed onto an existing key": `routeKey` maps a
+ *  bare UUID segment to `{*}`, so a future literal-id diagnostic (say
+ *  `GET /platform/organizations/00000000-…`) would normalise onto the already-registered
+ *  `GET /platform/organizations/{*}`, be counted as covered, and leave the 135 pin unmoved. Asserting
+ *  these two are EQUAL proves the normaliser is injective over the deployed set, which is the
+ *  property every count below silently assumes. */
+let deployedOperations = 0;
+/** The document's own spelling of each key, so a failure message names the real route. */
+const deployedRaw = new Map<string, string>();
+for (const [path, item] of Object.entries(doc.paths ?? {})) {
+  for (const method of Object.keys(item)) {
+    if (!(HTTP_VERBS as readonly string[]).includes(method.toLowerCase())) continue;
+    deployedOperations++;
+    const key = routeKey(method, path);
+    deployed.add(key);
+    deployedRaw.set(key, `${method.toUpperCase()} ${path}`);
+  }
+}
+
+// ── The registry side ────────────────────────────────────────────────────────────────────────────
+// Read endpoints carry a static `csharpPath` and are all GET (checks/parity.ts + checks/rls.ts issue
+// a plain GET; SURFACES has no method field precisely because a read surface is GET-only).
+const registry = new Set<string>();
+let registryEndpointCount = 0;
+for (const surface of Object.values(SURFACES)) {
+  for (const ep of surface.endpoints) {
+    registryEndpointCount++;
+    registry.add(routeKey('GET', ep.csharpPath));
+  }
+}
+
+/**
+ * 52% of the registry (26 of the 50 endpoints — the write side) has NO static path: `buildParity` is a function of the
+ * resolved seeded ids. Rather than add a hand-written `routeTemplate` field — 26 strings that can
+ * drift from the builder they duplicate — call every builder with a recursive Proxy stub that answers
+ * any property access with another stub and coerces to a fixed UUID sentinel. write-surfaces.test.ts
+ * already stubs these builders with a plain literal bag, so this is the registry's own idiom, just
+ * total instead of per-surface. Measured: 26 of 26 resolve, zero throws, zero degenerate paths.
+ */
+const PROXY_UUID = '00000000-0000-0000-0000-0000000000ff';
+function resolverStub(): WriteResolvedBase {
+  const target = function stubTarget() {} as unknown as object;
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === Symbol.toPrimitive) return () => PROXY_UUID;
+      if (prop === 'toString' || prop === 'valueOf' || prop === 'toJSON') return () => PROXY_UUID;
+      if (prop === Symbol.toStringTag) return 'writeResolverStub';
+      // A Proxy that answers `then` with a stub makes itself thenable and would hang an `await`.
+      if (prop === 'then') return undefined;
+      return resolverStub();
+    },
+    apply() {
+      return resolverStub();
+    },
+  };
+  return new Proxy(target, handler) as unknown as WriteResolvedBase;
+}
+
+const writePaths: string[] = [];
+const degenerateWritePaths: string[] = [];
+for (const [surfaceKey, surface] of Object.entries(WRITE_SURFACES)) {
+  for (const ep of surface.endpoints) {
+    registryEndpointCount++;
+    let path: string;
+    try {
+      path = ep.buildParity(resolverStub()).path;
+    } catch (err) {
+      degenerateWritePaths.push(`${surfaceKey}/${ep.name}: buildParity THREW (${String(err)})`);
+      continue;
+    }
+    if (typeof path !== 'string' || !path.startsWith('/') || /undefined|\[object|NaN|\/\//.test(path)) {
+      degenerateWritePaths.push(`${surfaceKey}/${ep.name}: buildParity produced a degenerate path "${String(path)}"`);
+      continue;
+    }
+    writePaths.push(path);
+    registry.add(routeKey(ep.method, path));
+  }
+}
+
+// ── The allowlist ────────────────────────────────────────────────────────────────────────────────
+interface AllowGroup {
+  reason: string;
+  routes: string[];
+}
+
+/**
+ * Groups, each with ONE reason covering every route in it, and EXACT literal VERB+path entries using
+ * the OpenAPI document's own param names. Deliberately not prefixes: a `/engagement/*` prefix group
+ * would let a brand-new engagement route land silently, which is the exact drift this file exists to
+ * stop.
+ */
+const UNREGISTERED_ALLOWLIST: AllowGroup[] = [
+  {
+    reason:
+      'INFRA / DIAGNOSTIC, not a domain surface. `/` and the two whoami routes are liveness and identity echoes; ' +
+      '/require-permission and /require-org-scope (Program.cs:1225, :1265) are the permission-kernel probes the C# ' +
+      'auth integration tests drive. None reads tenant data, so none carries a parity, RLS or RBAC obligation.',
+    routes: [
+      'GET /',
+      'GET /whoami',
+      'GET /external-whoami',
+      'GET /require-permission/{module}/{action}',
+      'GET /require-org-scope/{module}/{action}',
+    ],
+  },
+  {
+    reason:
+      'SURFACE WAS REGISTERED AND THEN DELETED, on the reasoning "the TS procedures are gone, so there is nothing ' +
+      'left to diff" — obsolete since `tsProcedure` became OPTIONAL on 2026-08-06 (efb7553f). These are exactly the ' +
+      'six `parity_command=NONE` rows in scripts/deploy/cutover.sh. Re-registering them C#-only (the audit-log / ' +
+      'access-review precedent, 2026-08-11) is the fix and is tracked separately: unlike those two platform-owner ' +
+      'surfaces, each of these is org-scoped RBAC and needs its OWN seeded grant fixture first — a missing grant ' +
+      "reproduces #166's false 12/43 FAIL, which is worse than a documented gap.",
+    routes: [
+      'GET /succession/comp-gap-alerts',
+      'GET /succession/competency-coverage',
+      'GET /succession/critical-roles',
+      'GET /succession/critical-roles/{criticalRoleId}',
+      'GET /succession/critical-roles/{criticalRoleId}/simulate-exit',
+      'GET /succession/critical-roles/{criticalRoleId}/suggested-successors',
+      'GET /succession/dashboard-kpis',
+      'GET /succession/flight-risk',
+      'GET /succession/roles-without-successor',
+      'GET /team-intel/compare',
+      'GET /team-intel/dashboard-kpis',
+      'GET /team-intel/teams/{teamId}/balance-alerts',
+      'GET /team-intel/teams/{teamId}/balance-score',
+      'GET /team-intel/teams/{teamId}/members',
+      'GET /team-intel/teams/{teamId}/profile',
+      'GET /team-intel/teams/{teamId}/recommended-hires',
+      'GET /reporting/funnel',
+      'GET /reporting/kpis',
+      'GET /reporting/lost-by-delay',
+      'GET /reporting/recruiter-sla',
+      'GET /reporting/source-breakdown',
+      'GET /reporting/trend',
+      'GET /evaluation360/cycles',
+      'GET /evaluation360/cycles/{cycleId}/progress',
+      'GET /evaluation360/my/rater-tasks',
+      'GET /evaluation360/my/report-cycles',
+      'GET /evaluation360/my/reports/{cycleId}',
+      'GET /billing/usage',
+      'GET /billing/plan',
+      'GET /billing/config',
+      'GET /billing/invoices',
+      'GET /billing/invoices/{id}',
+    ],
+  },
+  {
+    reason:
+      'THE SURFACE IS REGISTERED, BUT ONLY A SUBSET OF ITS DEPLOYED READS IS. Adding the rest is NOT a registry ' +
+      'edit: each needs a seeded grant fixture and a PROBED cross-org status before an expectation can be written ' +
+      'down rather than guessed. Measured coverage of DEPLOYED GETs, 2026-08-11 — engagement 2 of 14, dei 2 of 11, ' +
+      'compensation 2 of 12, ninebox 4 of 11. Do not read "the surface is registered" as "the domain is covered". ' +
+      'The platform-organizations WRITE surface is the same shape in the other direction: it registers 2 of the 3 ' +
+      'deployed writes (PATCH /{id}, POST /{id}/suspend), and the third is the POST below.',
+    routes: [
+      'GET /engagement/action-plans',
+      'GET /engagement/alerts',
+      'GET /engagement/climate-heatmap',
+      'GET /engagement/dashboard-kpis',
+      'GET /engagement/enps',
+      'GET /engagement/leader-commitments',
+      'GET /engagement/my/pending-surveys',
+      'GET /engagement/surveys/{surveyId}/results',
+      'GET /engagement/surveys/{surveyId}/results-by-area',
+      'GET /engagement/surveys/{surveyId}/sentiment',
+      'GET /engagement/surveys/{surveyId}/take',
+      'GET /engagement/surveys/{surveyId}/word-cloud',
+      'GET /dei/age-distribution',
+      'GET /dei/dashboard-kpis',
+      'GET /dei/gender-representation',
+      'GET /dei/hiring-funnel',
+      'GET /dei/inclusion-index',
+      'GET /dei/leadership-diversity',
+      'GET /dei/nationality-diversity',
+      'GET /dei/promotion-equity',
+      'GET /compensation/benefits-utilization',
+      'GET /compensation/compa-ratio-distribution',
+      'GET /compensation/my-compensation',
+      'GET /compensation/pending-adjustments',
+      'GET /compensation/salary-bands',
+      'GET /ninebox/bench-strength',
+      'GET /ninebox/calibrations',
+      'GET /ninebox/calibrations/{id}',
+      'GET /ninebox/dashboard-kpis',
+      'GET /ninebox/employee/{userId}',
+      'GET /ninebox/grid',
+      'GET /ninebox/my-calibrations',
+      // POST /platform/organizations (createOrganization) shipped DARK in 87a02ef1 — Phase-5 slice 21,
+      // PR #209 — and was never registered. It is the newest instance of exactly the drift this file
+      // stops, kept here as the worked example rather than quietly excused.
+      'POST /platform/organizations',
+    ],
+  },
+  {
+    reason:
+      'DEPLOYED BEHIND `Platform__FxReadsEnabled`, NOT the flag of the surface whose path prefix they share ' +
+      '(Program.cs:1188-1192 maps MapDeiPayEquityEndpoint() + MapCompensationFxReadEndpoints() under that one flag). ' +
+      'A guard that grouped by path prefix would mis-attribute these to `dei`/`compensation`, and registering them ' +
+      'under those surfaces would assert against a flag that does not gate them — a green that means nothing.',
+    routes: [
+      'GET /dei/pay-equity',
+      'GET /compensation/band-distribution',
+      'GET /compensation/pay-equity',
+      'GET /compensation/total-comp-breakdown',
+      'GET /compensation/dashboard-kpis',
+      'GET /compensation/simulate-adjustment',
+    ],
+  },
+  {
+    reason:
+      'THE DOMAIN HAS NEVER HAD A PARITY SURFACE AT ALL — no SURFACES or WRITE_SURFACES entry has ever existed for ' +
+      'it, so there is no deletion to reverse and no partial coverage to extend. Each needs a surface designed from ' +
+      'scratch: probe role, seeded grants, cross-org probe semantics. POST /billing/webhooks/stripe additionally ' +
+      'does not fit this harness at all — it is ANONYMOUS and authenticated by the Stripe SIGNATURE ' +
+      '(BillingWebhookEndpoints.cs:8, :27), not by a Bearer token, so there is no probe identity to mint. ' +
+      'GET /internal/alert-metrics is the #172 privileged cross-org cron read (AlertMetricsEndpoints.cs:43, :47).',
+    routes: [
+      'GET /external/assessment-results',
+      'GET /external/assessment-results/{assignmentId}',
+      'POST /external/validations/{validationId}/result',
+      'POST /billing/checkout-session',
+      'POST /billing/portal-session',
+      'POST /billing/cancel-subscription',
+      'POST /billing/webhooks/stripe',
+      'GET /internal/alert-metrics',
+      'PATCH /validations/{validationId}',
+    ],
+  },
+];
+
+const allowlistNormalised = UNREGISTERED_ALLOWLIST.flatMap((g) =>
+  g.routes.map((r) => {
+    const [verb, ...rest] = r.split(' ');
+    return routeKey(verb, rest.join(' '));
+  }),
+);
+const allowed = new Set(allowlistNormalised);
+
+describe('parity registry covers every deployed route (or documents why not)', () => {
+  it('parses the deployed contract and the registry — a broken parser must not silently pass', () => {
+    // NON-VACUITY FLOOR (the idiom is tests/governance/cutover-table-matches-script.test.ts:64-70).
+    // If the OpenAPI shape changes, the verb filter breaks, or the write-builder Proxy stub starts
+    // returning garbage, THIS fails loudly — instead of the coverage assertions below filtering an
+    // empty set, producing `[]`, and reporting green while checking nothing.
+    expect(
+      deployedOperations,
+      'zero operations parsed from the OpenAPI document — the parser is broken',
+    ).toBeGreaterThan(0);
+    expect(deployed.size, 'zero deployed route keys built — routeKey() is broken').toBeGreaterThan(0);
+    // INJECTIVITY. Two OpenAPI operations that normalise to the same key would collapse into one Set
+    // entry, be silently counted as covered, and leave the 135 pin below unmoved. See
+    // `deployedOperations`.
+    expect(
+      deployed.size,
+      'two deployed operations normalise to the same VERB+path key — one of them is invisible to the ' +
+        'coverage assertion below, and the deployed.size pin cannot see it',
+    ).toBe(deployedOperations);
+    expect(registry.size, 'zero registry entries parsed — the SURFACES/WRITE_SURFACES walk is broken').toBeGreaterThan(
+      0,
+    );
+    expect(degenerateWritePaths, 'a write buildParity threw or produced a degenerate path').toEqual([]);
+
+    // COUNT PINS. Each carries its reason, because a pin without one is unmaintainable — the next
+    // person cannot tell a deliberate change from a regression.
+    //
+    //   135 = every GET/POST/PATCH/PUT/DELETE operation in contracts/openapi/Tims.Api.json across 128
+    //         paths (GET 102, POST 26, PATCH 5, DELETE 2), measured 2026-08-11 at 87a02ef1.
+    //         /health + /ready are NOT in the document (MapHealthChecks emits no endpoint metadata),
+    //         so this counts domain operations, not "every routable path". A new route bumps this,
+    //         deliberately — that is the point.
+    expect(deployed.size).toBe(135);
+    //   50 = 24 read endpoints (surfaces.ts, 8 surfaces) + 26 write (write-surfaces.ts, 7 surfaces:
+    //        23 written literally + 3 produced by the shared `transitionEndpoint` helper).
+    expect(registryEndpointCount).toBe(50);
+    //   ...resolving to 50 DISTINCT VERB+path keys. A drop here means two registry entries normalise
+    //   to the same route, which would make one of them invisible to the coverage assertion below.
+    expect(registry.size, 'two registry entries normalise to the same VERB+path key').toBe(50);
+    //   26 write paths resolved through the Proxy stub, none degenerate.
+    expect(writePaths.length).toBe(26);
+  });
+
+  it('every registry entry points at a route that is actually deployed', () => {
+    // The INVERSE direction, which nothing in this repo checked before. A typo'd `csharpPath` is
+    // caught by no test and no compiler — it would simply 404 during a live cutover, in Federico's
+    // hands, and read as a C# failure rather than a registry one. (surfaces.test.ts pins the three
+    // access-review paths exactly; this generalises that to all 50.)
+    expect([...registry].filter((k) => !deployed.has(k))).toEqual([]);
+  });
+
+  it('every deployed route is registered, or on the documented allowlist with a reason', () => {
+    const unaccounted = [...deployed].filter((k) => !registry.has(k) && !allowed.has(k)).map((k) => deployedRaw.get(k));
+    expect(
+      unaccounted,
+      'a NEWLY deployed route has neither a parity registry entry nor an allowlist reason. Register it ' +
+        "(scripts/parity/surfaces.ts or write-surfaces.ts — SEED ITS GRANT FIXTURE FIRST, or you get #166's " +
+        'false 12/43 FAIL) or add it to UNREGISTERED_ALLOWLIST under a group whose reason genuinely applies to it.',
+    ).toEqual([]);
+  });
+
+  it('the allowlist has no stale, duplicate, or contradictory entries', () => {
+    expect(allowlistNormalised.length, 'duplicate allowlist entry').toBe(allowed.size);
+    expect(
+      [...allowed].filter((k) => !deployed.has(k)),
+      'allowlisted route is no longer deployed — delete the line rather than leaving a stale excuse',
+    ).toEqual([]);
+    expect(
+      [...allowed].filter((k) => registry.has(k)),
+      'route is BOTH registered and allowlisted — remove the allowlist line, it now excuses nothing',
+    ).toEqual([]);
+    //   85 = the measured gap at 87a02ef1 (86) minus GET /platform/organizations/{id}, registered the
+    //   same day as `organization/detail` under `noTenantBoundaryForCaller` (#195). Pinned so SHRINKING
+    //   the gap is visible as progress and GROWING it is visible as drift; neither can happen silently.
+    expect(allowlistNormalised.length).toBe(85);
+    // Every group must actually carry a reason and actually cover something — an empty group, or one
+    // whose "reason" is a word, is a rubber stamp.
+    for (const g of UNREGISTERED_ALLOWLIST) {
+      expect(g.routes.length, `an allowlist group is empty: "${g.reason.slice(0, 40)}…"`).toBeGreaterThan(0);
+      expect(g.reason.length, `allowlist group reason is too short to be a reason: "${g.reason}"`).toBeGreaterThan(40);
+    }
+    expect(UNREGISTERED_ALLOWLIST.length, 'the five documented gap categories').toBe(5);
+  });
+});


### PR DESCRIPTION
Three tooling deliverables. **No C# changes** — `git diff --name-only 87a02ef1 | grep -c '\.cs$'` is 0,
so the C# anchors below are the base's and are not restated as this branch's work.

## A — #206: a live probe-viability preflight

#205 added an invariant asserting `expectedByRole[probeRole] === 200` for every surface. That checks the
**registry against itself** and cannot see a registry that is internally consistent and *wrong about the
product* — a role marked 200 that the live gate actually 403s. Same symptom as the #203 defect, same blast
radius: the C# leg fails closed, the TS leg **throws** inside `stripTrpcJson`, and the run crashes instead
of reporting.

`scripts/parity/checks/preflight.ts` calls one endpoint with the probe token before the three checks and
returns an actionable diagnosis. Placed **after** `orgAEndpoint` is bound, not at the top: the "endpoint 0
is always Tier-1" shortcut was true right up until this same commit added a by-id endpoint, and baking in
a positional convention is how the next defect ships.

Exit code is **1, not 2**, deliberately — the parity CLI's contract is binary today and every other
could-not-run path already collapses to 1. Half-adopting the 0/1/2 contract on one branch produces a
partial contract that misleads more than none. Filed rather than smuggled in.

## B — #195: a deployed-route coverage guard with a real non-vacuity floor

`tests/governance/parity-registry-covers-deployed-routes.test.ts` matches the registry against
`contracts/openapi/Tims.Api.json` — **not** the `.cs` files, because a source parser cannot resolve 8 of
133 `.Map*(` call sites (6 put the literal on the next line, 1 uses a `const`, 1 interpolates).

Re-derived at this commit: **135 deployed operations across 128 paths** (GET 102, POST 26, PATCH 5,
DELETE 2) against **50 registered endpoints**. **85 routes are unregistered**, on an explicit allowlist
grouped by reason, so a newly deployed route must be added deliberately.

Registering those 85 is **not attempted and must not be** — each org-scoped surface needs its own seeded
grant fixture first, and a missing one reproduces #166's false 12/43 FAIL.

The floor is the point: three assertions fail loudly if the parser breaks — parsed-operations > 0,
built-keys > 0, and `deployed.size === deployedOperations` (proving the normaliser is injective, so two
routes cannot silently collapse onto one key).

## C — #195: `getOrganization` registered under a NEW marker

It needed a real org id **and** no Mode-A probe, and the only way to express the second was `globalScope` —
which `surfaces.test.ts` forbids combining with `idScopeKey`. Correctly: `globalScope` claims the *payload*
is org-independent, and `getOrganization`'s payload is org-**specific**. That guard caught me once before
and I reverted rather than weakened it.

So: a new `noTenantBoundaryForCaller` field with its own `checks/rls.ts` branch and its own **distinct**
reason string. The distinction is load-bearing — a reader must not conflate *"there is no per-org data
here"* with *"there is per-org data here and this caller may see all of it."* The guard is untouched and
provably worked **with**: setting `globalScope` on `detail` instead would push the count pin to 10 **and**
trip the by-id assertion.

`detail` keeps its `tsProcedure` even though it is **predicted to FAIL** — C# serialises `counts` where TS
returns Prisma `_count`. Dropping it to dodge a known red is how a gate is made unable to fail. Filed as
**#211** (4 divergences: 1 on `detail`, 3 on `list`), which #205's own fix could not surface because
nobody could run `verify organization`.

## What the panel caught

23 findings, 3 HIGH. Two HIGH were confirmed **by mutation against the new tests themselves**: stripping
the remediation clause out of three preflight branches left the suite **green**. Both directions are
asserted now.

It also caught **three of my own errors from #205, merged yesterday**:

- *"None of the seven is by-id"* — never re-derived when access-review's three routes were re-added. It's
  **nine**, and the enumeration directly above it already said 2+2+2+3. Superlative-as-quantifier, again.
- `checks/parity.ts:47-55` → `:49-56` (`:47-48` are comments).
- `surfaces.test.ts:46` cited for the globalScope guard — **off by ~70**; the assertion is at `:124`. Both
  call sites now cite the test **by title**, so the citation cannot rot again.

Plus a claim that an issue had been filed for the serialisation divergence when none existed — checked
against all 132 issues, found nothing, then actually filed #211.

## Verification

Re-run by me on the final tree, not taken from the agents.

| Check | Result |
| --- | --- |
| vitest | **3124 / 313 files** (main: 3084 / 311) |
| `tsc` @tims/api · apps/web | exit 0 · exit 0 |
| C# unit / integration | 987 / 1239 — **unchanged by construction**, 0 `.cs` files differ |
| `contracts/openapi` | no change (no C# route touched) |

**Independent mutation proofs**, run separately from the workflow's own:

| Mutation | Result |
| --- | --- |
| route parser yields zero operations | **RED** — the non-vacuity floor fires |
| route parser adds nothing to the set | **RED** |
| drop `noTenantBoundaryForCaller` from `getOrganization` | **RED** |
| neuter the Mode-C short-circuit in `rls.ts` | **RED** |

Counts re-derived independently: 50 registered endpoints; 135 operations / 128 paths.

**Cross-model verification: NOT RUN.** Check 15 exited **2** for the 23rd time — Codex quota, refusal now
reads **"try again at Sep 9th, 2026"**. Tier 2 correctly refuses with `OMNIROUTE_MODEL` unset. **Tier 3 ran
instead** — a 3-lens same-model adversarial panel as the review phase of the build workflow. Per the rule,
same-model review is weaker and shares the author's blind spots. **Nothing here is cross-model verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
