### PR TITLE
fix(security): route the last six CSV builders through the shared helper

### DIFF
--- a/apps/web/app/(admin)/platform/organizations/org-bulk-bar.tsx
+++ b/apps/web/app/(admin)/platform/organizations/org-bulk-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { csvRow } from '@tims/shared';
 import { trpc } from '../../../../lib/trpc';
 import { useI18n } from '../../../../lib/i18n';
 import { toast } from '../../../../lib/toast';
@@ -45,17 +46,21 @@ export function OrgBulkBar({ selectedIds, organizations, onDeselectAll }: OrgBul
 
   const handleExportSelected = () => {
     const selected = organizations.filter((o) => selectedIds.includes(o.id));
-    const header = 'Nombre,Slug,Plan,Estado,Usuarios,Facturas,MRR,Creada';
+    // Every cell through csvRow — same defect and same fix as organizations/page.tsx. NOTE the column
+    // order differs from that file (MRR before Creada here, after it there); that inconsistency is
+    // pre-existing and deliberately left alone, since changing it would alter a second thing under cover
+    // of a security fix. Tracked as GHSA-w6h5-g5gv-7g95.
+    const header = csvRow(['Nombre', 'Slug', 'Plan', 'Estado', 'Usuarios', 'Facturas', 'MRR', 'Creada']);
     const rows = selected.map((org) => {
       const plan = org.plan || org.subscription?.plan || 'trial';
-      return [
-        `"${org.name}"`, org.slug, plan,
+      return csvRow([
+        org.name, org.slug, plan,
         org.isActive ? 'active' : 'suspended',
         org._count?.users ?? 0,
         org._count?.invoices ?? 0,
         PLAN_MRR[plan] || 0,
         new Date(org.createdAt).toISOString().slice(0, 10),
-      ].join(',');
+      ]);
     });
     const csv = [header, ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });

--- a/apps/web/app/(admin)/platform/organizations/page.tsx
+++ b/apps/web/app/(admin)/platform/organizations/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { csvRow } from '@tims/shared';
 import { trpc } from '../../../../lib/trpc';
 import { useI18n } from '../../../../lib/i18n';
 import { toast } from '../../../../lib/toast';
@@ -56,17 +57,22 @@ export default function OrganizationsPage() {
   };
 
   const handleExport = () => {
-    const header = 'Nombre,Slug,Plan,Estado,Usuarios,Facturas,Creada,MRR';
+    // Every cell through csvRow (packages/shared/src/csv.ts) — the same helper the server-side platform
+    // exports use. This builder previously wrapped `org.name` in quotes WITHOUT escaping embedded ones, so
+    // an organization named `Acme "The" Corp` broke the row outright, and no field had formula-injection
+    // defence (CWE-1236). Client-side construction is why this one was missed when the server exports were
+    // audited. Tracked as GHSA-w6h5-g5gv-7g95.
+    const header = csvRow(['Nombre', 'Slug', 'Plan', 'Estado', 'Usuarios', 'Facturas', 'Creada', 'MRR']);
     const rows = organizations.map((org) => {
       const plan = org.plan || org.subscription?.plan || 'trial';
-      return [
-        `"${org.name}"`, org.slug, plan,
+      return csvRow([
+        org.name, org.slug, plan,
         org.isActive ? 'active' : 'suspended',
         org._count?.users ?? 0,
         (org._count as Record<string, number>)?.invoices ?? 0,
         new Date(org.createdAt).toISOString().slice(0, 10),
         PLAN_MRR[plan] || 0,
-      ].join(',');
+      ]);
     });
     const csv = [header, ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });

--- a/packages/api/src/routers/platform/ai-agents.ts
+++ b/packages/api/src/routers/platform/ai-agents.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { csvRow } from '@tims/shared';
 import { router } from '../../trpc';
 import { db, db as systemDb, Prisma } from '@tims/db';
 import { TRPCError } from '@trpc/server';
@@ -274,9 +275,14 @@ export const aiAgentsRouter = router({
         _count: { select: { orgConfigs: true, usageLogs: true } },
       },
     });
-    const header = 'Name,Slug,Category,Model,Status,Batch,Cache TTL,Cost/Call,Org Configs,Usage Logs';
+    const header = csvRow([
+      'Name', 'Slug', 'Category', 'Model', 'Status', 'Batch', 'Cache TTL', 'Cost/Call', 'Org Configs', 'Usage Logs',
+    ]);
+    // Every cell through csvRow — previously a bare `.join(',')` with no quoting and no
+    // formula-injection defence on any field, including the tenant-visible `name`.
+    // Tracked as GHSA-w6h5-g5gv-7g95.
     const rows = agents.map((a) =>
-      [
+      csvRow([
         a.name,
         a.slug,
         a.category,
@@ -287,7 +293,7 @@ export const aiAgentsRouter = router({
         `$${a.costPerCall.toFixed(3)}`,
         a._count.orgConfigs,
         a._count.usageLogs,
-      ].join(','),
+      ]),
     );
     logPlatformExport(ctx, { resource: 'ai_agents', count: agents.length, format: 'csv' });
     return { csv: [header, ...rows].join('\n'), count: agents.length };

--- a/packages/api/src/routers/platform/invoices.ts
+++ b/packages/api/src/routers/platform/invoices.ts
@@ -23,7 +23,7 @@ import {
   upsertBillingProfileInput,
 } from './invoices.schemas';
 import { sumMoney } from '../../lib/currency';
-import { PLATFORM_BILLING_CURRENCY } from '@tims/shared';
+import { csvRow, PLATFORM_BILLING_CURRENCY } from '@tims/shared';
 
 export const invoicesRouter = router({
   getInvoiceKpis: platformProcedure.query(async () => {
@@ -297,20 +297,25 @@ export const invoicesRouter = router({
 
       logPlatformExport(ctx, { resource: 'invoices', count: invoices.length, format: 'csv', targetOrgId: input.organizationId });
 
-      const header = 'Numero,Organizacion,Monto,Moneda,Estado,Descripcion,Emision,Vencimiento,Pagada';
+      // Every cell through csvRow. Previously only `organization.name` and `description` were quoted
+      // (2 of 9), so a comma in any other field shifted that row's later columns, and no field had
+      // formula-injection defence (CWE-1236). Tracked as GHSA-w6h5-g5gv-7g95.
+      const header = csvRow([
+        'Numero', 'Organizacion', 'Monto', 'Moneda', 'Estado', 'Descripcion', 'Emision', 'Vencimiento', 'Pagada',
+      ]);
       const rows = invoices.map((inv) => {
         const fmt = (d: Date | null | undefined) => d ? new Intl.DateTimeFormat('es', { day: '2-digit', month: '2-digit', year: 'numeric' }).format(d) : '';
-        return [
+        return csvRow([
           `INV-${inv.invoiceNumber}`,
-          `"${inv.organization.name.replace(/"/g, '""')}"`,
-          inv.amount,
+          inv.organization.name,
+          String(inv.amount),
           inv.currency,
           inv.status,
-          `"${(inv.description || '').replace(/"/g, '""')}"`,
+          inv.description || '',
           fmt(inv.createdAt),
           fmt(inv.dueDate),
           fmt(inv.paidAt),
-        ].join(',');
+        ]);
       });
 
       return [header, ...rows].join('\n');

--- a/packages/api/src/routers/platform/subscriptions.ts
+++ b/packages/api/src/routers/platform/subscriptions.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { csvRow } from '@tims/shared';
 import { router } from '../../trpc';
 import { db, OrgPlan, SubscriptionStatus } from '@tims/db';
 import { TRPCError } from '@trpc/server';
@@ -252,14 +253,16 @@ export const subscriptionsRouter = router({
         select: subscriptionSelect,
       });
 
-      const header = 'Organizacion,Plan,Estado,MRR,Periodo,Trial Vence,Creada';
+      // Every cell through csvRow. Previously nothing was quoted and the org name had its commas
+      // REPLACED with spaces — data mutation standing in for escaping, so "Acme, Inc" exported as
+      // "Acme  Inc". No formula-injection defence either. Tracked as GHSA-w6h5-g5gv-7g95.
+      const header = csvRow(['Organizacion', 'Plan', 'Estado', 'MRR', 'Periodo', 'Trial Vence', 'Creada']);
       const rows = subs.map((sub) => {
         const mrr = sub.status === SubscriptionStatus.active ? (PLAN_PRICES[sub.plan] || 0) : 0;
         const period = computeBillingPeriod(sub.currentPeriodStart, sub.currentPeriodEnd) || '—';
         const trialEnd = sub.trialEndsAt ? sub.trialEndsAt.toISOString().split('T')[0] : '—';
         const created = sub.createdAt.toISOString().split('T')[0];
-        const orgName = sub.organization.name.replace(/,/g, ' ');
-        return `${orgName},${sub.plan},${sub.status},$${mrr},${period},${trialEnd},${created}`;
+        return csvRow([sub.organization.name, sub.plan, sub.status, `$${mrr}`, period, trialEnd, created]);
       });
 
       logPlatformExport(ctx, { resource: 'subscriptions', count: subs.length, format: 'csv' });

--- a/packages/api/src/routers/platform/users.ts
+++ b/packages/api/src/routers/platform/users.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
-import { getAppUrl, ASSIGNABLE_STAFF_ROLES } from '@tims/shared';
+import { csvRow, getAppUrl, ASSIGNABLE_STAFF_ROLES } from '@tims/shared';
 import { router } from '../../trpc';
 import { db } from '@tims/db';
 import type { Prisma } from '@tims/db';
@@ -367,13 +367,29 @@ export const usersRouter = router({
 
       logPlatformExport(ctx, { resource: 'users', count: users.length, format: 'csv', targetOrgId: input.organizationId });
 
-      const header = 'Nombre,Email,Organizacion,Rol,Estado,Ultimo Login,Creado';
+      // Every cell through csvRow (packages/shared/src/csv.ts). This export previously emitted EVERY
+      // field raw — no quoting anywhere, not even on `email` or `role` — with a comma-stripping regex
+      // replace on name and org as the only concession to delimiters. That is data MUTATION, not
+      // escaping: a user
+      // named "Doe, Jane" was silently exported as "Doe  Jane". Quoting handles the comma correctly, so
+      // the strip is removed rather than kept alongside it. It also had no formula-injection defence
+      // (CWE-1236) on any field. Tracked as GHSA-w6h5-g5gv-7g95.
+      const header = csvRow(['Nombre', 'Email', 'Organizacion', 'Rol', 'Estado', 'Ultimo Login', 'Creado']);
       const rows = users.map((u) => {
-        const name = `${u.firstName || ''} ${u.lastName || ''}`.trim().replace(/,/g, ' ');
-        const org = u.isPlatformOwner ? 'Plataforma' : u.organization?.name?.replace(/,/g, ' ') || '-';
+        const name = `${u.firstName || ''} ${u.lastName || ''}`.trim();
+        // `|| '-'` stays FALSY, not `??`: an empty-string organization name must still become "-".
+        const org = u.isPlatformOwner ? 'Plataforma' : u.organization?.name || '-';
         const role = u.isPlatformOwner ? 'platform_owner' : u.userRoles[0]?.role?.slug || 'employee';
         const fmt = (d: Date | null | undefined) => d ? d.toISOString().split('T')[0] : '-';
-        return `${name},${u.email},${org},${role},${u.isActive ? 'active' : 'inactive'},${fmt(u.lastLoginAt)},${fmt(u.createdAt)}`;
+        return csvRow([
+          name,
+          u.email,
+          org,
+          role,
+          u.isActive ? 'active' : 'inactive',
+          fmt(u.lastLoginAt),
+          fmt(u.createdAt),
+        ]);
       });
 
       return { csv: [header, ...rows].join('\n'), count: users.length };

--- a/packages/shared/src/csv.ts
+++ b/packages/shared/src/csv.ts
@@ -4,13 +4,18 @@
  * Use for ANY CSV export field sourced from tenant-editable data (names, org names)
  * that may be opened in a spreadsheet — csv exports are a standing formula-injection
  * vector (CWE-1236).
+ *
+ * Accepts `number` as well as `string` because several platform exports emit counts, amounts and
+ * MRR figures. The implementation already did `String(value)`; only the SIGNATURE was narrow, which
+ * pushed call sites into hand-stringifying and was one more reason to hand-roll a row instead of
+ * using this helper.
  */
-export function csvCell(value: string | null | undefined): string {
+export function csvCell(value: string | number | null | undefined): string {
   const raw = value == null ? '' : String(value);
   const neutralized = /^[=+\-@\t\r]/.test(raw) ? `'${raw}` : raw;
   return `"${neutralized.replace(/"/g, '""')}"`;
 }
 
-export function csvRow(values: Array<string | null | undefined>): string {
+export function csvRow(values: Array<string | number | null | undefined>): string {
   return values.map(csvCell).join(',');
 }

--- a/tests/security/csv-builders-use-the-shared-helper.test.ts
+++ b/tests/security/csv-builders-use-the-shared-helper.test.ts
@@ -1,0 +1,96 @@
+/**
+ * csv-builders-use-the-shared-helper.test.ts
+ *
+ * A repo-wide guard that every CSV builder routes through `csvCell`/`csvRow`
+ * (`packages/shared/src/csv.ts`), which quote RFC-4180 and neutralize a leading `=`/`+`/`-`/`@`/TAB/CR
+ * (CWE-1236 formula injection).
+ *
+ * WHY A GUARD RATHER THAN SIX INDIVIDUAL TESTS. The helper has existed since the audit-log export was
+ * hardened, and six builders were still hand-rolling their own rows — four platform routers and two
+ * frontend components. Each was invisible to the others: `tests/security/csv-export-hardening.test.ts`
+ * unit-tests the HELPER, so it passes no matter how many callers ignore it, and its header even asserted
+ * (falsely) that "there is no TS platform CSV export left to wire-test". A per-file test would have the
+ * same blind spot as the thing it replaces — a NEW hand-rolled builder added tomorrow would be caught by
+ * nothing. This test is written to fail on that.
+ *
+ * Tracked as GHSA-w6h5-g5gv-7g95. The invitations export was fixed first, in PR #220.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+
+const ROOT = join(__dirname, '..', '..');
+const read = (p: string) => readFileSync(join(ROOT, p), 'utf8');
+
+/** Every file in the repo that builds a CSV. Adding a builder means adding it here. */
+const CSV_BUILDERS = [
+  'packages/api/src/routers/platform/invitations.ts',
+  'packages/api/src/routers/platform/users.ts',
+  'packages/api/src/routers/platform/invoices.ts',
+  'packages/api/src/routers/platform/subscriptions.ts',
+  'packages/api/src/routers/platform/ai-agents.ts',
+  'apps/web/app/(admin)/platform/organizations/page.tsx',
+  'apps/web/app/(admin)/platform/organizations/org-bulk-bar.tsx',
+  'packages/api/src/services/audit.service.ts',
+  'packages/api/src/services/candidate-pool.service.ts',
+];
+
+describe.each(CSV_BUILDERS)('%s', (path) => {
+  const src = read(path);
+
+  it('imports csvCell/csvRow from @tims/shared', () => {
+    expect(src).toMatch(/import\s*\{[^}]*\bcsv(Cell|Row)\b[^}]*\}\s*from\s*'@tims\/shared'/);
+  });
+
+});
+
+describe('repo-wide: the hand-rolled shapes exist nowhere', () => {
+  // This is the half that survives a stale list. The per-file block above only checks files someone
+  // remembered to add; these three assertions are what catch a NEW hand-rolled builder added tomorrow,
+  // anywhere in the repo. All three were verified to match nothing at the time this landed, so none of
+  // them is vacuously green.
+  // execFileSync with an ARGS ARRAY, never a shell string. Building the command with JSON.stringify
+  // wrapped the pattern in DOUBLE quotes, so /bin/sh read the backtick in `"${x}"` as command
+  // substitution — the grep then matched nearly the whole repo and died with ENOBUFS. No shell, no
+  // quoting to get wrong.
+  const grep = (pattern: string): string[] => {
+    let out = '';
+    try {
+      out = execFileSync(
+        'git',
+        ['grep', '-nE', pattern, '--', 'packages/', 'apps/web/', 'workers/'],
+        { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+      );
+    } catch (e) {
+      // git grep exits 1 when there are no matches, which is the passing case.
+      const err = e as { status?: number; stdout?: string };
+      if (err.status !== 1) throw e;
+      out = err.stdout ?? '';
+    }
+    return out
+      .split('\n')
+      .filter(Boolean)
+      // csv.ts IS the escaping implementation — it necessarily contains the shape it exists to provide.
+      .filter((l) => !l.startsWith('packages/shared/src/csv.ts:'));
+  };
+
+  it("no row is built with [...].join(',')", () => {
+    expect(grep("\\]\\s*\\.join\\(','\\)")).toEqual([]);
+  });
+
+  it('no CSV header is a bare comma-joined string literal', () => {
+    expect(grep("const header = '[^']*,[^']*'")).toEqual([]);
+  });
+
+  it('no value is quoted by template interpolation without escaping', () => {
+    // `` `"${x}"` `` looks like quoting but does not double an embedded quote — it breaks the row
+    // outright for a value containing `"`. Both frontend builders did exactly this.
+    expect(grep('`"\\$\\{[^}]+\\}"`')).toEqual([]);
+  });
+
+  it('no comma-stripping stands in for escaping', () => {
+    // Mutates the data instead of escaping it: users.ts exported "Doe, Jane" as "Doe  Jane".
+    expect(grep("replace\\(/,/g")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes the CWE-1236 formula-injection gap and the column-shift bug in every remaining hand-rolled CSV builder. The invitations export was fixed in #220; these are the other six. Tracked as private advisory `GHSA-w6h5-g5gv-7g95`.

## TS-only — checked first, not assumed

Only three C# export endpoints exist (`/audit/logs/export`, `/access-review/export`, `/platform/invitations/export`) and **all three already use `CsvCell`**. None of these six has a C# counterpart, and no parity fixture pins their output. So unlike the invitations fix, this needs no both-stacks coordination — nothing has to stay byte-identical, which makes it a plain improvement rather than a negotiated one.

## What each was doing

| File | Defect |
| --- | --- |
| `platform/users.ts` | **The worst.** No quoting on *any* field — not even `email` or `role` — with a comma-stripping regex on name/org as the only nod to delimiters. That is data **mutation**, not escaping: `Doe, Jane` exported as `Doe  Jane`. Strip removed; quoting handles it correctly. |
| `platform/invoices.ts` | Quoted 2 of 9 fields (org name, description). |
| `platform/subscriptions.ts` | No quoting; comma-strip on org name — same mutation bug. |
| `platform/ai-agents.ts` | A bare `[...].join(',')` with nothing quoted. |
| `organizations/page.tsx` | Wrapped `org.name` in quotes **without escaping embedded ones**, so an org named `Acme "The" Corp` breaks the row outright. |
| `organizations/org-bulk-bar.tsx` | Same as above. |

Both frontend builders are worse than the server-side ones, which at least doubled inner quotes. Client-side construction is why they were missed when the server exports were audited.

`csvCell`/`csvRow` now accept `number` as well as `string`. The implementation already did `String(value)`; only the **signature** was narrow, which pushed callers into hand-stringifying counts and MRR figures — one more small reason to hand-roll a row instead of using the helper.

## The guard is the point, not the six fixes

`tests/security/csv-export-hardening.test.ts` unit-tests the **helper**, so it passed no matter how many callers ignored it — and its header even asserted *"there is no TS platform CSV export left to wire-test."* That sentence is precisely why six builders drifted. A per-file test inherits the same blind spot: it can only check files someone remembered to add.

So the new guard is **repo-wide and shape-based**. It asserts four hand-rolled shapes appear nowhere under `packages/`, `apps/web/` or `workers/`:

```
[...].join(',')          the row-building shape
const header = 'a,b,c'   a bare comma-joined header literal
`"${x}"`                 quoting that does not escape
replace(/,/g …)          stripping standing in for escaping
```

Each was verified to match nothing at the time this landed — the only hit is `csv.ts` itself, which *is* the implementation — so none is vacuously green.

## Mutation-proved, and the second one is the one that matters

| Mutation | Result |
| --- | --- |
| Revert `subscriptions.ts` to the hand-rolled shape | **2 assertions FAIL** |
| Add a **new** hand-rolled builder to a file **not on the list** (`platform/users/page.tsx`) | **3 assertions FAIL** |

The second is the design goal: the guard catches a builder added tomorrow by someone who never reads this PR.

## Two implementation notes worth keeping

The grep helper uses `execFileSync` with an **args array**. Building the command with `JSON.stringify` wrapped the pattern in double quotes, so `/bin/sh` read the backtick in `` `"${x}"` `` as command substitution — the grep then matched most of the repo and died with `ENOBUFS`. No shell, no quoting to get wrong.

The `users.ts` comment had to be reworded: it **quoted the forbidden literal** while describing what was removed, and the repo-wide guard caught its own documentation. Prose about a banned shape is still the banned shape.

## Deliberately not changed

The two frontend builders emit their columns in different orders (`MRR` before/after `Creada`). Pre-existing, and left alone — changing it would alter a second thing under cover of a security fix.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| vitest | `npx vitest run` | **3172 / 317 files** (3159 / 316 at main) |
| `@tims/api` types | `pnpm --filter @tims/api exec tsc --noEmit` | exit 0 |
| `apps/web` types | `cd apps/web && npx tsc --noEmit` | exit 0 |
| gitleaks | `gitleaks detect` | no leaks |

No C# suites are affected — this branch touches no C# and no contract.

**Cross-model verification: NOT RUN.** `scripts/verification/codex-review.sh` exits **2** (Codex quota, now reading "Sep 9th, 2026" — `.claude/rules/verification.md` still says `2026-08-15` and is stale). Per the rule, exit 2 is not a pass. No tier-3 panel was run on this diff either: it is a mechanical, single-pattern change whose correctness is carried by the repo-wide guard and the two mutations above, not by review judgement. Say the word if you want a panel before merge.

## Follow-up

`GHSA-w6h5-g5gv-7g95` can be closed once this merges. The DSAR/data-requests export is excluded from the guard's scope — it uses its own format and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)