### PR TITLE
fix(security): cap the invitations export at 10,000 rows (GHSA-6759-h69h-m739)

### DIFF
--- a/packages/api/src/routers/platform/invitations.ts
+++ b/packages/api/src/routers/platform/invitations.ts
@@ -13,6 +13,11 @@ import { provisionOrgDefaults, provisionOrgEntitlements } from '../../services/o
 const INVITATION_TYPE = z.enum(['org_admin', 'user']);
 const INVITATION_STATUS = z.enum(['pending', 'sent', 'accepted', 'expired', 'revoked']);
 
+// The CSV export row cap, matching audit.service.ts:13 so the two platform exports bound egress the
+// same way. exportInvitationsCsv was unbounded until 2026-08-13 (GHSA-6759-h69h-m739): one call
+// returned every invitation across every tenant, and the whole set was materialised into a string.
+const EXPORT_LIMIT = 10_000;
+
 const invitationListSelect = {
   id: true,
   email: true,
@@ -290,9 +295,15 @@ export const invitationsRouter = router({
       if (input.type) where.type = input.type as InvitationType;
       if (input.status) where.status = input.status as InvitationStatus;
 
-      const invitations = await db.platformInvitation.findMany({
+      // Capped, mirroring audit.service.ts (EXPORT_LIMIT / take LIMIT+1 / truncated). Before this, the
+      // export was unbounded: one platform-owner call returned EVERY invitation across EVERY tenant in a
+      // single response (GHSA-6759-h69h-m739). Fetch one MORE than the cap so `truncated` can be reported
+      // without a second count query, then trim to the cap. The C# port applies the identical cap in the
+      // same change — a one-sided cap would fail `verify invitation`.
+      const rawInvitations = await db.platformInvitation.findMany({
         where,
         orderBy: { createdAt: 'desc' },
+        take: EXPORT_LIMIT + 1,
         select: {
           email: true,
           type: true,
@@ -304,6 +315,8 @@ export const invitationsRouter = router({
           acceptedAt: true,
         },
       });
+      const truncated = rawInvitations.length > EXPORT_LIMIT;
+      const invitations = truncated ? rawInvitations.slice(0, EXPORT_LIMIT) : rawInvitations;
 
       // Every cell goes through csvRow (packages/shared/src/csv.ts), matching audit.service.ts.
       // This export previously hand-rolled its CSV and quoted ONLY organizationName, so it had no
@@ -327,8 +340,8 @@ export const invitationsRouter = router({
         ]),
       );
 
-      logPlatformExport(ctx, { resource: 'invitations', count: invitations.length, format: 'csv' });
-      return { csv: [header, ...rows].join('\n'), count: invitations.length };
+      logPlatformExport(ctx, { resource: 'invitations', count: invitations.length, format: 'csv', truncated });
+      return { csv: [header, ...rows].join('\n'), count: invitations.length, truncated };
     }),
 
   // ============ PUBLIC INVITATION ENDPOINTS ============

--- a/services/Tims.Platform/src/Tims.Application/PlatformInvitations/PlatformInvitationsReadModels.cs
+++ b/services/Tims.Platform/src/Tims.Application/PlatformInvitations/PlatformInvitationsReadModels.cs
@@ -95,7 +95,7 @@ public sealed record PlatformInvitationListResult(
 /// <c>exportInvitationsCsv</c> has no format param and returns <c>csv</c>. Copying the audit envelope here
 /// would be the natural mistake and a guaranteed parity FAIL on all three keys.</para>
 /// </summary>
-public sealed record PlatformInvitationExportResult(string Csv, int Count);
+public sealed record PlatformInvitationExportResult(string Csv, int Count, bool Truncated);
 
 /// <summary>
 /// One export row — the <c>exportInvitationsCsv</c> <c>select</c>, which is a DIFFERENT and narrower set

--- a/services/Tims.Platform/src/Tims.Application/PlatformInvitations/PlatformInvitationsReadUseCase.cs
+++ b/services/Tims.Platform/src/Tims.Application/PlatformInvitations/PlatformInvitationsReadUseCase.cs
@@ -151,12 +151,23 @@ public sealed class PlatformInvitationsReadUseCase(IPlatformInvitationsReadRepos
         CancellationToken cancellationToken) =>
         repository.ListAsync(query, cancellationToken);
 
+    /// <summary>
+    /// The CSV export row cap, matching the TS <c>EXPORT_LIMIT</c> in <c>invitations.ts</c> (itself copied
+    /// from <c>audit.service.ts</c>). The export was UNBOUNDED until 2026-08-13
+    /// (<c>GHSA-6759-h69h-m739</c>): one platform-owner call returned every invitation across every tenant,
+    /// materialised into a single string. The repository fetches <c>ExportLimit + 1</c> so truncation can be
+    /// reported without a second COUNT query.
+    /// </summary>
+    public const int ExportLimit = 10_000;
+
     public async Task<PlatformInvitationExportResult> ExportAsync(
         PlatformInvitationExportQuery query,
         CancellationToken cancellationToken)
     {
         var rows = await repository.ExportAsync(query, cancellationToken).ConfigureAwait(false);
-        return new PlatformInvitationExportResult(BuildCsv(rows), rows.Count);
+        var truncated = rows.Count > ExportLimit;
+        var page = truncated ? rows.Take(ExportLimit).ToList() : rows;
+        return new PlatformInvitationExportResult(BuildCsv(page), page.Count, truncated);
     }
 
     /// <summary>

--- a/services/Tims.Platform/src/Tims.Infrastructure/PlatformInvitations/PlatformInvitationsReadRepository.cs
+++ b/services/Tims.Platform/src/Tims.Infrastructure/PlatformInvitations/PlatformInvitationsReadRepository.cs
@@ -138,9 +138,12 @@ public sealed class PlatformInvitationsReadRepository(PlatformInvitationsReadDbC
     {
         return await ApplyFilters(db.Invitations.AsNoTracking(), query.Type, query.Status, null)
             .OrderByDescending(i => i.CreatedAt)
+            // Bounded at ExportLimit + 1 (the +1 lets the use case report `truncated` without a second
+            // COUNT). Before 2026-08-13 this query had NO limit — GHSA-6759-h69h-m739. Matches the TS
+            // `take: EXPORT_LIMIT + 1`.
+            .Take(PlatformInvitationsReadUseCase.ExportLimit + 1)
             // The projection is the TS export `select`, which is NARROWER than the list's: no id, no
-            // organizationId, no createdAt, no joins. Projecting in SQL keeps the unbounded read as small as
-            // it can be, since this query has no LIMIT at all.
+            // organizationId, no createdAt, no joins. Projecting in SQL keeps the read small.
             .Select(i => new PlatformInvitationExportRow(
                 i.Email,
                 i.Type,

--- a/services/Tims.Platform/tests/Tims.UnitTests/PlatformInvitations/PlatformInvitationsReadUseCaseTests.cs
+++ b/services/Tims.Platform/tests/Tims.UnitTests/PlatformInvitations/PlatformInvitationsReadUseCaseTests.cs
@@ -247,6 +247,42 @@ public sealed class PlatformInvitationsReadUseCaseTests
         Assert.False(csv.EndsWith('\n'));
     }
 
+    // ── the export cap (GHSA-6759-h69h-m739) ─────────────────────────────────────────────────────────
+    /// <summary>
+    /// The export is capped at <see cref="PlatformInvitationsReadUseCase.ExportLimit"/>. The repository
+    /// fetches <c>ExportLimit + 1</c> rows so the use case can report <c>Truncated</c> without a second
+    /// COUNT; when more than the cap exist it returns EXACTLY the cap with <c>Truncated == true</c>, and the
+    /// CSV has the header plus that many rows and no more. Boundary: exactly <c>ExportLimit</c> is NOT
+    /// truncated (<c>&gt;</c>, not <c>&gt;=</c>), matching the TS <c>rows.length &gt; EXPORT_LIMIT</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(0, false, 0)]
+    [InlineData(9_999, false, 9_999)]
+    [InlineData(10_000, false, 10_000)]        // the repo returned exactly the cap ⇒ not truncated
+    [InlineData(10_001, true, 10_000)]         // the repo's LIMIT+1 fetch hit ⇒ truncated, trimmed to cap
+    public async Task ExportAsync_capsAtExportLimit_andReportsTruncated(int rowsFromRepo, bool expectedTruncated, int expectedCount)
+    {
+        var useCase = new PlatformInvitationsReadUseCase(new StubRepo(rowsFromRepo));
+
+        var result = await useCase.ExportAsync(new PlatformInvitationExportQuery(null, null), CancellationToken.None);
+
+        Assert.Equal(expectedTruncated, result.Truncated);
+        Assert.Equal(expectedCount, result.Count);
+        // header + expectedCount data rows (no trailing newline), so the CSV line count is the proof the
+        // slice actually happened rather than just the reported Count.
+        Assert.Equal(expectedCount + 1, result.Csv.Split('\n').Length);
+    }
+
+    private sealed class StubRepo(int rows) : IPlatformInvitationsReadRepository
+    {
+        public Task<IReadOnlyList<PlatformInvitationExportRow>> ExportAsync(PlatformInvitationExportQuery query, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<PlatformInvitationExportRow>>(
+                Enumerable.Range(0, rows).Select(i => Row(email: $"u{i}@b.test")).ToList());
+
+        public Task<PlatformInvitationKpis> GetKpisAsync(CancellationToken ct) => throw new NotSupportedException();
+        public Task<PlatformInvitationListResult> ListAsync(PlatformInvitationListQuery query, CancellationToken ct) => throw new NotSupportedException();
+    }
+
     private static PlatformInvitationExportRow Row(
         string email = "a@b.test",
         string type = "user",

--- a/tests/platform/invitations-export-cap.test.ts
+++ b/tests/platform/invitations-export-cap.test.ts
@@ -1,0 +1,106 @@
+/**
+ * invitations-export-cap.test.ts — GHSA-6759-h69h-m739.
+ *
+ * WHY THIS FILE EXISTS: exportInvitationsCsv was UNBOUNDED — one platform-owner call returned every
+ * platform_invitations row across every tenant (each carrying an invitee email) in a single response,
+ * materialised whole into a string. This pins the cap in the RUNNING layer: it asserts the Prisma query
+ * the procedure actually builds (`take: EXPORT_LIMIT + 1`) and the `truncated` flag it computes. The C#
+ * half is pinned separately by ExportAsync_capsAtExportLimit_andReportsTruncated (a unit test with a stub
+ * repository) — both sides changed in one commit, so both are pinned in one commit.
+ *
+ * Mock strategy mirrors tests/platform/list-organizations-query-shape.test.ts: mock `../../trpc` so the
+ * procedure builders are pass-throughs while the REAL platformProcedure owner gate (from ./_common) still
+ * runs, and mock `@tims/db` to capture the findMany arguments.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { initTRPC } from '@trpc/server';
+
+const EXPORT_LIMIT = 10_000;
+const invitationFindMany = vi.fn();
+
+vi.mock('@tims/db', () => ({
+  db: { platformInvitation: { findMany: (...a: unknown[]) => invitationFindMany(...a) } },
+  InvitationType: { org_admin: 'org_admin', user: 'user' },
+  InvitationStatus: { pending: 'pending', sent: 'sent', accepted: 'accepted', expired: 'expired', revoked: 'revoked' },
+}));
+
+vi.mock('../../packages/api/src/trpc', () => {
+  const t = initTRPC
+    .context<{ user: { id: string; organizationId: string; isPlatformOwner: boolean }; headers: Headers }>()
+    .create();
+  return { router: t.router, publicProcedure: t.procedure, protectedProcedure: t.procedure };
+});
+
+import { invitationsRouter } from '../../packages/api/src/routers/platform/invitations';
+
+const t = initTRPC
+  .context<{ user: { id: string; organizationId: string; isPlatformOwner: boolean }; headers: Headers }>()
+  .create();
+const createCaller = t.createCallerFactory(invitationsRouter as unknown as Parameters<typeof t.createCallerFactory>[0]);
+
+interface ExportCaller {
+  exportInvitationsCsv(input: Record<string, unknown>): Promise<{ csv: string; count: number; truncated: boolean }>;
+}
+
+const caller = () =>
+  createCaller({
+    user: { id: 'owner-1', organizationId: '99999999-9999-4999-8999-999999999999', isPlatformOwner: true },
+    headers: new Headers(),
+  }) as unknown as ExportCaller;
+
+/** A minimal export row; only the 8 selected fields matter to the CSV. */
+const row = (i: number) => ({
+  email: `u${i}@b.test`,
+  type: 'user',
+  organizationName: 'Acme',
+  roleSlug: 'hr_admin',
+  status: 'sent',
+  sentAt: null,
+  expiresAt: new Date('2026-08-01T00:00:00.000Z'),
+  acceptedAt: null,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('platform.exportInvitationsCsv is capped (GHSA-6759-h69h-m739)', () => {
+  it('fetches EXPORT_LIMIT + 1 rows — the +1 is how truncation is detected without a second query', async () => {
+    invitationFindMany.mockResolvedValue([]);
+
+    await caller().exportInvitationsCsv({});
+
+    expect(invitationFindMany, 'export no longer calls platformInvitation.findMany').toHaveBeenCalledTimes(1);
+    const args = invitationFindMany.mock.calls[0][0] as { take: number };
+    expect(args.take).toBe(EXPORT_LIMIT + 1);
+  });
+
+  it('reports truncated=true and returns exactly EXPORT_LIMIT rows when more exist', async () => {
+    // The DB (via take: LIMIT+1) hands back LIMIT+1 rows — the signal that more exist.
+    invitationFindMany.mockResolvedValue(Array.from({ length: EXPORT_LIMIT + 1 }, (_, i) => row(i)));
+
+    const res = await caller().exportInvitationsCsv({});
+
+    expect(res.truncated).toBe(true);
+    expect(res.count).toBe(EXPORT_LIMIT);
+    // header + EXPORT_LIMIT data rows, and no more — proves the slice happened, not just the count.
+    expect(res.csv.split('\n').length).toBe(EXPORT_LIMIT + 1);
+  });
+
+  it('reports truncated=false at exactly EXPORT_LIMIT (boundary is >, not >=)', async () => {
+    invitationFindMany.mockResolvedValue(Array.from({ length: EXPORT_LIMIT }, (_, i) => row(i)));
+
+    const res = await caller().exportInvitationsCsv({});
+
+    expect(res.truncated).toBe(false);
+    expect(res.count).toBe(EXPORT_LIMIT);
+  });
+
+  it('reports truncated=false for a small export', async () => {
+    invitationFindMany.mockResolvedValue([row(0), row(1), row(2)]);
+
+    const res = await caller().exportInvitationsCsv({});
+
+    expect(res.truncated).toBe(false);
+    expect(res.count).toBe(3);
+    expect(res.csv.split('\n').length).toBe(4); // header + 3
+  });
+});


### PR DESCRIPTION
`exportInvitationsCsv` was **unbounded**: one platform-owner call returned every `platform_invitations` row across every tenant — each carrying an invitee email — in a single response, and both stacks materialised the whole set into a string (a memory-exhaustion vector as the table grows, on top of the mass PII egress). Closes draft advisory **GHSA-6759-h69h-m739**.

## The fix is copied, not invented

The sibling audit export already solved this — `audit.service.ts:13,52-54`: `EXPORT_LIMIT = 10_000`, fetch `LIMIT+1` (so truncation is detectable without a second COUNT), slice to `LIMIT`, report `truncated`. This reproduces that pattern verbatim rather than inventing a new one.

## Both stacks in one commit

The invitations export is parity-registered, so the two sides must stay byte-identical:

| Stack | Change |
| --- | --- |
| TS `invitations.ts` | `take: EXPORT_LIMIT + 1`; `truncated = len > LIMIT`; slice; return `{ csv, count, truncated }` |
| C# `PlatformInvitationsReadUseCase.ExportAsync` + repository | `.Take(LIMIT+1)`; `PlatformInvitationExportResult` gains `Truncated` |

- The CSV **string bytes are unchanged** (`truncated` is a sibling field), so the byte-for-byte parity tests still pass.
- The JSON envelope gains a field **additively** — existing `count` assertions are untouched.
- The invitations endpoints use untyped `.Produces()`, so **`contracts/openapi/Tims.Api.json` does not change** (confirmed: `-c Release` build, zero diff).

## Pinned in both stacks, at the running layer

- **TS** — `tests/platform/invitations-export-cap.test.ts`: mocks `@tims/db`, asserts the procedure passes `take: 10001`, returns `truncated=true` + exactly 10,000 rows when more exist, and `truncated=false` at the boundary (`>`, not `>=`).
- **C#** — `ExportAsync_capsAtExportLimit_andReportsTruncated`: a stub-repo unit test over the same four cases (a 10,001-row integration test would be wasteful).

**Mutation-proved:** un-capping the C# side fails 1 unit case; removing the TS `take` fails the take assertion.

## Scope

The sibling advisory **GHSA-h5cw-pc57-hh95** — this same export can leave **no audit row** for an org-less owner — is **not** addressed here. It needs a different fix (a sentinel org id or an org-independent audit sink) and stays open.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @tims/api exec tsc --noEmit` | exit 0 |
| `cd apps/web && npx tsc --noEmit` | exit 0 |
| `npx vitest run` | 3172 → **3176 / 318 files** |
| `dotnet test tests/Tims.UnitTests` | 1054 → **1058** |
| `dotnet test ~PlatformInvitations` (integration) | 71 (unchanged — envelope is additive) |
| OpenAPI contract | unchanged |
| gitleaks | no leaks |

**Cross-model verification: NOT RUN** (`codex-review.sh` exit 2, Codex quota-blocked until Sep 9 2026). No tier-3 panel — this is a verbatim copy of an established, already-reviewed pattern, pinned and mutation-proved in both stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)