### PR TITLE
feat(web): dashboard FE wrapper — #81 step 4's missing half, dark behind NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,16 @@ NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP=false
 # string 'true' (including unset) keeps the tRPC path. Default off.
 NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP=false
 
+# Per-surface flag: route ALL SIX FE-consumed monitoring reads (executive-kpis / module-health /
+# alerts / action-plan-alerts / cross-module-trend / alert-rules) to the C# service. Mirrors the
+# backend `Platform:MonitoringReadEnabled` flag that gates all six routes. Added 2026-08-17: the
+# second-pass audit found this flag undocumented here while being the dual-path comparator the
+# dashboard stanza above is modeled on — 8 more FE-read flags remain undocumented, recorded in
+# the PR that added these two rather than silently backfilled.
+# Requires NEXT_PUBLIC_TIMS_PLATFORM_API_URL to also be set. Anything other than the exact
+# string 'true' (including unset) keeps the tRPC path. Default off.
+NEXT_PUBLIC_MONITORING_READ_VIA_CSHARP=false
+
 # RETIRED 2026-07-29 — DEAD FLAG, no code reads it. It used to route the FIVE FE-consumed FX-FREE
 # compensation reads (getSalaryBands / getBenefitsUtilization / getCompaRatioDistribution /
 # listPendingAdjustments / myCompensation) to the C# service. The flag was confirmed live in prod on

--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,16 @@ NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP=false
 # 'true' (including unset) keeps the tRPC path. Default off.
 NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP=false
 
+# Per-surface flag: route ALL TWELVE FE-consumed platform-dashboard reads (kpis /
+# attention-items / revenue-by-customer / customer-health / recent-activity /
+# plan-distribution / search / mrr-trend / churn-risk / mrr-forecast /
+# upsell-opportunities / ai-cost-anomalies) to the C# service. getUserGrowth is the
+# thirteenth backend read and has NO FE consumer, so no hook and no effect here. Mirrors
+# the backend `Platform:PlatformDashboardReadEnabled` flag that gates all thirteen routes.
+# Requires NEXT_PUBLIC_TIMS_PLATFORM_API_URL to also be set. Anything other than the exact
+# string 'true' (including unset) keeps the tRPC path. Default off.
+NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP=false
+
 # RETIRED 2026-07-29 — DEAD FLAG, no code reads it. It used to route the FIVE FE-consumed FX-FREE
 # compensation reads (getSalaryBands / getBenefitsUtilization / getCompaRatioDistribution /
 # listPendingAdjustments / myCompensation) to the C# service. The flag was confirmed live in prod on

--- a/apps/web/app/(admin)/dashboard/activity-feed.tsx
+++ b/apps/web/app/(admin)/dashboard/activity-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { trpc } from '../../../lib/trpc';
+import { useDashboardRecentActivity } from '../../../lib/platform-api/dashboard';
 import { timeAgo, Skeleton } from './dashboard-utils';
 import { useI18n } from '../../../lib/i18n';
 import { ErrorState } from '../../../components';
@@ -39,8 +40,18 @@ function ServiceDot({ status, label, latency }: { status: string; label: string;
 
 export function ActivityFeed() {
   const { t } = useI18n();
-  const { data: activity, isLoading: actLoading, isError: actError, refetch: refetchActivity } = trpc.platform.getRecentActivity.useQuery();
-  const { data: health, isLoading: healthLoading, isError: healthError, refetch: refetchHealth } = trpc.platform.getSystemHealth.useQuery();
+  const {
+    data: activity,
+    isLoading: actLoading,
+    isError: actError,
+    refetch: refetchActivity,
+  } = useDashboardRecentActivity();
+  const {
+    data: health,
+    isLoading: healthLoading,
+    isError: healthError,
+    refetch: refetchHealth,
+  } = trpc.platform.getSystemHealth.useQuery();
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -73,9 +84,7 @@ export function ActivityFeed() {
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-medium text-primary truncate">{item.title}</p>
                   <div className="flex items-center gap-2 mt-0.5">
-                    {item.meta && (
-                      <span className="text-[10px] text-muted truncate max-w-[120px]">{item.meta}</span>
-                    )}
+                    {item.meta && <span className="text-[10px] text-muted truncate max-w-[120px]">{item.meta}</span>}
                     <span className="text-[10px] text-muted">{timeAgo(item.timestamp)}</span>
                   </div>
                 </div>
@@ -98,9 +107,7 @@ export function ActivityFeed() {
           {health && (
             <span
               className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${
-                health.overall === 'operational'
-                  ? 'bg-emerald-100 text-emerald-700'
-                  : 'bg-amber-100 text-amber-700'
+                health.overall === 'operational' ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
               }`}
             >
               {health.overall === 'operational' ? 'All Systems Go' : 'Degraded'}
@@ -120,16 +127,9 @@ export function ActivityFeed() {
           <div className="space-y-0 overflow-y-auto max-h-[260px]">
             {(health?.services ?? []).slice(0, 8).map((svc) => {
               const latencyMetric = svc.metrics?.find(
-                (m) => m.label.toLowerCase().includes('latencia') || m.label.toLowerCase().includes('query')
+                (m) => m.label.toLowerCase().includes('latencia') || m.label.toLowerCase().includes('query'),
               );
-              return (
-                <ServiceDot
-                  key={svc.name}
-                  status={svc.status}
-                  label={svc.name}
-                  latency={latencyMetric?.value}
-                />
-              );
+              return <ServiceDot key={svc.name} status={svc.status} label={svc.name} latency={latencyMetric?.value} />;
             })}
             {health?.services.length === 0 && (
               <p className="text-xs text-muted py-6 text-center">{t.dashboard.noServicesFound}</p>

--- a/apps/web/app/(admin)/dashboard/attention-bar.tsx
+++ b/apps/web/app/(admin)/dashboard/attention-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../lib/trpc';
+import { useDashboardAttentionItems } from '../../../lib/platform-api/dashboard';
 import { toast } from '../../../lib/toast';
 import { SEVERITY_CONFIG, Skeleton } from './dashboard-utils';
 import { useI18n } from '../../../lib/i18n';
@@ -11,7 +11,7 @@ import { ErrorState } from '../../../components';
 export function AttentionBar() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getAttentionItems.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardAttentionItems();
   const [collapsed, setCollapsed] = useState(false);
 
   if (isLoading) {
@@ -43,9 +43,7 @@ export function AttentionBar() {
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3">
         <div className="flex items-center gap-2">
-          <span className="text-base">
-            {hasCritical ? '\u26A0' : '\u26A0'}
-          </span>
+          <span className="text-base">{hasCritical ? '\u26A0' : '\u26A0'}</span>
           <span className="text-sm font-semibold text-primary">
             {data.length} item{data.length !== 1 ? 's' : ''} need attention
           </span>
@@ -76,9 +74,7 @@ export function AttentionBar() {
                 <div className="flex items-center gap-3 min-w-0">
                   <span className={`h-2 w-2 rounded-full shrink-0 ${config.dot}`} />
                   <div className="min-w-0">
-                    <span className="text-sm font-medium text-primary truncate block">
-                      {item.title}
-                    </span>
+                    <span className="text-sm font-medium text-primary truncate block">{item.title}</span>
                     <span className="text-xs text-muted">{item.description}</span>
                   </div>
                 </div>
@@ -96,11 +92,7 @@ export function AttentionBar() {
               </div>
             );
           })}
-          {data.length > 8 && (
-            <p className="text-xs text-muted text-center pt-1">
-              +{data.length - 8} more items
-            </p>
-          )}
+          {data.length > 8 && <p className="text-xs text-muted text-center pt-1">+{data.length - 8} more items</p>}
         </div>
       )}
     </div>

--- a/apps/web/app/(admin)/dashboard/charts/ai-cost-anomaly-panel.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/ai-cost-anomaly-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../../lib/trpc';
+import { useDashboardAiCostAnomalies } from '../../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../../lib/i18n';
 import { formatCurrency, Skeleton } from '../dashboard-utils';
 import { ErrorState } from '../../../../components';
@@ -15,7 +15,7 @@ const TYPE_CONFIG = {
 export function AiCostAnomalyPanel() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getAiCostAnomalies.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardAiCostAnomalies();
 
   if (isLoading) {
     return (
@@ -23,7 +23,9 @@ export function AiCostAnomalyPanel() {
         <Skeleton className="h-4 w-44 mb-2" />
         <Skeleton className="h-3 w-56 mb-4" />
         <div className="space-y-2">
-          {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-12 w-full rounded-lg" />)}
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
         </div>
       </div>
     );
@@ -42,9 +44,19 @@ export function AiCostAnomalyPanel() {
       <div className="rounded-xl border border-[#EDEDED] bg-white p-5">
         <h3 className="text-sm font-semibold text-[#1F114C] mb-1">{t.dashboard.aiCostTitle ?? 'AI Cost Anomalies'}</h3>
         <div className="py-6 text-center">
-          <svg className="w-8 h-8 text-emerald-300 mx-auto mb-2" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+          <svg
+            className="w-8 h-8 text-emerald-300 mx-auto mb-2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+          >
+            <path d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
           <p className="text-sm text-[#8B8B8B]">{t.dashboard.noAnomalies ?? 'No cost anomalies detected'}</p>
-          <p className="text-xs text-[#8B8B8B] mt-0.5">{t.dashboard.allOptimized ?? 'All AI agents optimally configured'}</p>
+          <p className="text-xs text-[#8B8B8B] mt-0.5">
+            {t.dashboard.allOptimized ?? 'All AI agents optimally configured'}
+          </p>
         </div>
       </div>
     );
@@ -55,7 +67,9 @@ export function AiCostAnomalyPanel() {
       <div className="flex items-center justify-between mb-1">
         <div>
           <h3 className="text-sm font-semibold text-[#1F114C]">{t.dashboard.aiCostTitle ?? 'AI Cost Anomalies'}</h3>
-          <p className="text-xs text-[#8B8B8B]">{t.dashboard.aiCostSubtitle ?? 'Agents with unusual spending patterns'}</p>
+          <p className="text-xs text-[#8B8B8B]">
+            {t.dashboard.aiCostSubtitle ?? 'Agents with unusual spending patterns'}
+          </p>
         </div>
         {data.totalPotentialSavings > 0 && (
           <div className="text-right">

--- a/apps/web/app/(admin)/dashboard/charts/churn-risk-panel.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/churn-risk-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../../lib/trpc';
+import { useDashboardChurnRisk } from '../../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../../lib/i18n';
 import { formatCurrency, PLAN_BG_CLASSES, PLAN_LABELS, Skeleton } from '../dashboard-utils';
 import { ErrorState } from '../../../../components';
@@ -27,7 +27,7 @@ function getActionLabel(action: string, t: ReturnType<typeof useI18n>['t']): str
 export function ChurnRiskPanel() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getChurnRisk.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardChurnRisk();
 
   if (isLoading) {
     return (
@@ -35,7 +35,9 @@ export function ChurnRiskPanel() {
         <Skeleton className="h-4 w-32 mb-2" />
         <Skeleton className="h-3 w-48 mb-4" />
         <div className="space-y-2">
-          {Array.from({ length: 5 }).map((_, i) => <Skeleton key={i} className="h-12 w-full rounded-lg" />)}
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
         </div>
       </div>
     );
@@ -93,7 +95,15 @@ export function ChurnRiskPanel() {
       {/* Table */}
       {atRiskOrgs.length === 0 ? (
         <div className="py-8 text-center">
-          <svg className="w-8 h-8 text-emerald-300 mx-auto mb-2" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+          <svg
+            className="w-8 h-8 text-emerald-300 mx-auto mb-2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+          >
+            <path d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
           <p className="text-sm text-[#8B8B8B]">{t.dashboard.noOrgsAtRisk}</p>
           <p className="text-xs text-[#8B8B8B] mt-0.5">{t.dashboard.noOrgsAtRiskDesc}</p>
         </div>
@@ -117,10 +127,7 @@ export function ChurnRiskPanel() {
                       <span className={`text-sm font-bold ${tierCfg.text}`}>{org.healthScore}</span>
                     </div>
                     <div className="w-full bg-[#EDEDED] rounded-full h-1.5 mt-0.5">
-                      <div
-                        className={`h-1.5 rounded-full ${tierCfg.bg}`}
-                        style={{ width: `${org.healthScore}%` }}
-                      />
+                      <div className={`h-1.5 rounded-full ${tierCfg.bg}`} style={{ width: `${org.healthScore}%` }} />
                     </div>
                   </div>
 
@@ -131,9 +138,7 @@ export function ChurnRiskPanel() {
                       <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded ${planClass}`}>
                         {PLAN_LABELS[org.plan] ?? org.plan}
                       </span>
-                      {org.mrr > 0 && (
-                        <span className="text-[10px] text-[#8B8B8B]">{formatCurrency(org.mrr)}/mo</span>
-                      )}
+                      {org.mrr > 0 && <span className="text-[10px] text-[#8B8B8B]">{formatCurrency(org.mrr)}/mo</span>}
                     </div>
                     <p className="text-[11px] text-[#585858] truncate">{org.primaryRisk}</p>
                   </div>
@@ -147,7 +152,9 @@ export function ChurnRiskPanel() {
                       <p className="text-[9px] text-[#8B8B8B]">{t.dashboard.loginRate}</p>
                     </div>
                     <div className="text-center">
-                      <p className={`text-[12px] font-medium ${org.overdueInvoices > 0 ? 'text-[#DD0C15]' : 'text-[#333]'}`}>
+                      <p
+                        className={`text-[12px] font-medium ${org.overdueInvoices > 0 ? 'text-[#DD0C15]' : 'text-[#333]'}`}
+                      >
                         {org.overdueInvoices}
                       </p>
                       <p className="text-[9px] text-[#8B8B8B]">{t.dashboard.overdue}</p>

--- a/apps/web/app/(admin)/dashboard/charts/customer-health.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/customer-health.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../../lib/trpc';
+import { useDashboardCustomerHealth } from '../../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../../lib/i18n';
 import { HEALTH_CONFIG, PLAN_BG_CLASSES, PLAN_LABELS, Skeleton } from '../dashboard-utils';
 import { ErrorState } from '../../../../components';
@@ -9,7 +9,7 @@ import { ErrorState } from '../../../../components';
 export function CustomerHealthGrid() {
   const router = useRouter();
   const { t } = useI18n();
-  const { data, isLoading, isError, refetch } = trpc.platform.getCustomerHealth.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardCustomerHealth();
 
   return (
     <div className="rounded-xl border border-border bg-white p-5 flex flex-col">
@@ -46,9 +46,7 @@ export function CustomerHealthGrid() {
           <ErrorState onRetry={() => refetch()} />
         </div>
       ) : !data || data.length === 0 ? (
-        <div className="h-[200px] flex items-center justify-center text-sm text-muted">
-          No customer data
-        </div>
+        <div className="h-[200px] flex items-center justify-center text-sm text-muted">No customer data</div>
       ) : (
         <div className="grid grid-cols-3 gap-2 max-h-[240px] overflow-y-auto">
           {data.map((org) => {
@@ -72,9 +70,7 @@ export function CustomerHealthGrid() {
                 className={`text-left rounded-lg border p-3 transition-all hover:shadow-sm ${healthCfg.bg}`}
               >
                 <div className="flex items-start justify-between mb-1.5">
-                  <span className="text-xs font-semibold text-primary truncate max-w-[100px]">
-                    {org.orgName}
-                  </span>
+                  <span className="text-xs font-semibold text-primary truncate max-w-[100px]">{org.orgName}</span>
                   <span className={`h-2.5 w-2.5 rounded-full shrink-0 mt-0.5 ${healthCfg.dot}`} />
                 </div>
                 <span className={`inline-block text-[10px] font-medium px-1.5 py-0.5 rounded ${planClass} mb-1`}>

--- a/apps/web/app/(admin)/dashboard/charts/mrr-forecast-chart.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/mrr-forecast-chart.tsx
@@ -1,16 +1,7 @@
 'use client';
 
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  ReferenceLine,
-} from 'recharts';
-import { trpc } from '../../../../lib/trpc';
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, ReferenceLine } from 'recharts';
+import { useDashboardMrrForecast } from '../../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../../lib/i18n';
 import { formatCurrency, BRAND_NAVY, Skeleton } from '../dashboard-utils';
 import { ErrorState } from '../../../../components';
@@ -30,10 +21,16 @@ function ForecastTooltip({ active, payload, label }: ForecastTooltipProps) {
     <div className="rounded-lg border border-[#EDEDED] bg-white px-3 py-2 shadow-lg">
       <p className="text-xs text-[#8B8B8B] mb-1">{label}</p>
       {historical && historical.value > 0 && (
-        <p className="text-sm font-bold text-[#1F114C]">{formatCurrency(historical.value)} <span className="text-[10px] font-normal text-[#8B8B8B]">{t.dashboard.historical}</span></p>
+        <p className="text-sm font-bold text-[#1F114C]">
+          {formatCurrency(historical.value)}{' '}
+          <span className="text-[10px] font-normal text-[#8B8B8B]">{t.dashboard.historical}</span>
+        </p>
       )}
       {projected && projected.value > 0 && (
-        <p className="text-sm font-bold text-[#DD0C15]">{formatCurrency(projected.value)} <span className="text-[10px] font-normal text-[#8B8B8B]">{t.dashboard.projected}</span></p>
+        <p className="text-sm font-bold text-[#DD0C15]">
+          {formatCurrency(projected.value)}{' '}
+          <span className="text-[10px] font-normal text-[#8B8B8B]">{t.dashboard.projected}</span>
+        </p>
       )}
     </div>
   );
@@ -41,7 +38,7 @@ function ForecastTooltip({ active, payload, label }: ForecastTooltipProps) {
 
 export function MrrForecastChart() {
   const { t } = useI18n();
-  const { data, isLoading, isError, refetch } = trpc.platform.getMrrForecast.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardMrrForecast();
 
   if (isLoading) {
     return (
@@ -93,7 +90,9 @@ export function MrrForecastChart() {
       <div className="flex items-center justify-between mb-1">
         <div>
           <h3 className="text-sm font-semibold text-[#1F114C]">{t.dashboard.mrrForecast}</h3>
-          <p className="text-xs text-[#8B8B8B]">12m {t.dashboard.historical} + 12m {t.dashboard.projected}</p>
+          <p className="text-xs text-[#8B8B8B]">
+            12m {t.dashboard.historical} + 12m {t.dashboard.projected}
+          </p>
         </div>
         <div className="text-right">
           <p className="text-lg font-bold text-[#1F114C]">{formatCurrency(data.projectedArr)}</p>
@@ -113,7 +112,10 @@ export function MrrForecastChart() {
         </div>
         <div className="flex-1 bg-[#F6F6F6] rounded-lg px-3 py-2">
           <p className="text-[10px] text-[#8B8B8B]">{t.dashboard.monthlyGrowth}</p>
-          <p className={`text-sm font-bold ${growthColor}`}>{growthSign}{data.monthlyGrowthPct}%</p>
+          <p className={`text-sm font-bold ${growthColor}`}>
+            {growthSign}
+            {data.monthlyGrowthPct}%
+          </p>
         </div>
         <div className="flex-1 bg-[#F6F6F6] rounded-lg px-3 py-2">
           <p className="text-[10px] text-[#8B8B8B]">{t.dashboard.pendingTrials}</p>
@@ -188,7 +190,10 @@ export function MrrForecastChart() {
           <span className="text-[10px] text-[#8B8B8B]">{t.dashboard.historical}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div className="w-4 h-0.5 bg-[#DD0C15] rounded" style={{ backgroundImage: 'repeating-linear-gradient(90deg, #DD0C15 0 6px, transparent 6px 9px)' }} />
+          <div
+            className="w-4 h-0.5 bg-[#DD0C15] rounded"
+            style={{ backgroundImage: 'repeating-linear-gradient(90deg, #DD0C15 0 6px, transparent 6px 9px)' }}
+          />
           <span className="text-[10px] text-[#8B8B8B]">{t.dashboard.projected}</span>
         </div>
       </div>

--- a/apps/web/app/(admin)/dashboard/charts/mrr-trend-chart.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/mrr-trend-chart.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-} from 'recharts';
-import { trpc } from '../../../../lib/trpc';
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+import { useDashboardMrrTrend } from '../../../../lib/platform-api/dashboard';
 import { formatCurrency, BRAND_NAVY, Skeleton } from '../dashboard-utils';
 import { useI18n } from '../../../../lib/i18n';
 import { ErrorState } from '../../../../components';
@@ -31,7 +23,7 @@ function MrrTooltip({ active, payload, label }: MrrTooltipProps) {
 }
 
 export function MrrTrendChart() {
-  const { data, isLoading, isError, refetch } = trpc.platform.getMrrTrend.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardMrrTrend();
   const { t } = useI18n();
 
   return (
@@ -42,9 +34,7 @@ export function MrrTrendChart() {
           <p className="text-xs text-muted">{t.dashboard.mrrTrendSubtitle}</p>
         </div>
         {data && data.length > 0 && (
-          <span className="text-lg font-bold text-primary">
-            {formatCurrency(data[data.length - 1].mrr)}
-          </span>
+          <span className="text-lg font-bold text-primary">{formatCurrency(data[data.length - 1].mrr)}</span>
         )}
       </div>
 
@@ -62,12 +52,7 @@ export function MrrTrendChart() {
               </linearGradient>
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="#F0F0F0" vertical={false} />
-            <XAxis
-              dataKey="month"
-              tick={{ fontSize: 11, fill: '#8B8B8B' }}
-              axisLine={false}
-              tickLine={false}
-            />
+            <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#8B8B8B' }} axisLine={false} tickLine={false} />
             <YAxis
               tickFormatter={(v: number) => formatCurrency(v, true)}
               tick={{ fontSize: 11, fill: '#8B8B8B' }}

--- a/apps/web/app/(admin)/dashboard/charts/plan-distribution.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/plan-distribution.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-import {
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from 'recharts';
-import { trpc } from '../../../../lib/trpc';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { useDashboardPlanDistribution } from '../../../../lib/platform-api/dashboard';
 import { PLAN_COLORS, PLAN_LABELS, Skeleton } from '../dashboard-utils';
 import { useI18n } from '../../../../lib/i18n';
 import { ErrorState } from '../../../../components';
@@ -44,10 +37,7 @@ function CustomLegend({ payload }: { payload?: Array<LegendEntryProps> }) {
     <div className="flex flex-col gap-1.5 ml-2">
       {payload.map((entry) => (
         <div key={entry.value} className="flex items-center gap-2">
-          <span
-            className="h-2.5 w-2.5 rounded-full shrink-0"
-            style={{ backgroundColor: entry.color }}
-          />
+          <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: entry.color }} />
           <span className="text-xs text-secondary">{PLAN_LABELS[entry.value] ?? entry.value}</span>
         </div>
       ))}
@@ -76,7 +66,7 @@ function CenterLabel({ cx, cy, total }: CenterLabelProps) {
 
 export function PlanDistributionChart() {
   const { t } = useI18n();
-  const { data, isLoading, isError, refetch } = trpc.platform.getPlanDistribution.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardPlanDistribution();
 
   const total = data?.reduce((s, d) => s + d.count, 0) ?? 0;
 
@@ -94,9 +84,7 @@ export function PlanDistributionChart() {
           <ErrorState onRetry={() => refetch()} />
         </div>
       ) : !data || total === 0 ? (
-        <div className="h-[240px] flex items-center justify-center text-sm text-muted">
-          No subscription data
-        </div>
+        <div className="h-[240px] flex items-center justify-center text-sm text-muted">No subscription data</div>
       ) : (
         <ResponsiveContainer width="100%" height={240}>
           <PieChart>
@@ -117,12 +105,7 @@ export function PlanDistributionChart() {
               <CenterLabel cx={0} cy={0} total={total} />
             </Pie>
             <Tooltip content={<PlanTooltip />} />
-            <Legend
-              content={<CustomLegend />}
-              layout="vertical"
-              align="right"
-              verticalAlign="middle"
-            />
+            <Legend content={<CustomLegend />} layout="vertical" align="right" verticalAlign="middle" />
           </PieChart>
         </ResponsiveContainer>
       )}

--- a/apps/web/app/(admin)/dashboard/charts/revenue-by-customer.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/revenue-by-customer.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from 'recharts';
-import { trpc } from '../../../../lib/trpc';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { useDashboardRevenueByCustomer } from '../../../../lib/platform-api/dashboard';
 import { formatCurrency, PLAN_COLORS, PLAN_LABELS, Skeleton } from '../dashboard-utils';
 import { useI18n } from '../../../../lib/i18n';
 import { ErrorState } from '../../../../components';
@@ -46,7 +38,7 @@ function RevenueTooltip({ active, payload }: RevenueTooltipProps) {
 export function RevenueByCustomerChart() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getRevenueByCustomer.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardRevenueByCustomer();
 
   // Filter to only orgs with MRR > 0 for the chart
   const chartData = (data ?? []).filter((d) => d.mrr > 0).slice(0, 10);
@@ -68,9 +60,7 @@ export function RevenueByCustomerChart() {
           <ErrorState onRetry={() => refetch()} />
         </div>
       ) : chartData.length === 0 ? (
-        <div className="h-[240px] flex items-center justify-center text-sm text-muted">
-          No revenue data yet
-        </div>
+        <div className="h-[240px] flex items-center justify-center text-sm text-muted">No revenue data yet</div>
       ) : (
         <ResponsiveContainer width="100%" height={240}>
           <BarChart

--- a/apps/web/app/(admin)/dashboard/charts/upsell-panel.tsx
+++ b/apps/web/app/(admin)/dashboard/charts/upsell-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../../lib/trpc';
+import { useDashboardUpsellOpportunities } from '../../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../../lib/i18n';
 import { formatCurrency, PLAN_BG_CLASSES, PLAN_LABELS, Skeleton } from '../dashboard-utils';
 import { ErrorState } from '../../../../components';
@@ -15,7 +15,7 @@ const CONFIDENCE_CONFIG = {
 export function UpsellPanel() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getUpsellOpportunities.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardUpsellOpportunities();
 
   if (isLoading) {
     return (
@@ -23,7 +23,9 @@ export function UpsellPanel() {
         <Skeleton className="h-4 w-40 mb-2" />
         <Skeleton className="h-3 w-56 mb-4" />
         <div className="space-y-2">
-          {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-14 w-full rounded-lg" />)}
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
         </div>
       </div>
     );
@@ -40,9 +42,19 @@ export function UpsellPanel() {
   if (!data || data.opportunities.length === 0) {
     return (
       <div className="rounded-xl border border-[#EDEDED] bg-white p-5">
-        <h3 className="text-sm font-semibold text-[#1F114C] mb-1">{t.dashboard.upsellTitle ?? 'Upsell Opportunities'}</h3>
+        <h3 className="text-sm font-semibold text-[#1F114C] mb-1">
+          {t.dashboard.upsellTitle ?? 'Upsell Opportunities'}
+        </h3>
         <div className="py-6 text-center">
-          <svg className="w-8 h-8 text-[#EDEDED] mx-auto mb-2" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" /></svg>
+          <svg
+            className="w-8 h-8 text-[#EDEDED] mx-auto mb-2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+          >
+            <path d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+          </svg>
           <p className="text-sm text-[#8B8B8B]">{t.dashboard.noUpsells ?? 'No upsell opportunities right now'}</p>
         </div>
       </div>
@@ -100,7 +112,15 @@ export function UpsellPanel() {
                     <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded ${planClass}`}>
                       {PLAN_LABELS[opp.currentPlan] ?? opp.currentPlan}
                     </span>
-                    <svg className="w-3 h-3 text-[#8B8B8B] shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
+                    <svg
+                      className="w-3 h-3 text-[#8B8B8B] shrink-0"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                    </svg>
                     <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded ${targetPlanClass}`}>
                       {PLAN_LABELS[opp.targetPlan] ?? opp.targetPlan}
                     </span>
@@ -110,13 +130,13 @@ export function UpsellPanel() {
 
                 <div className="flex items-center gap-3 shrink-0">
                   <div className="text-center">
-                    <p className="text-[12px] font-medium text-[#333]">{opp.signals.activeUsers}/{opp.signals.totalUsers}</p>
+                    <p className="text-[12px] font-medium text-[#333]">
+                      {opp.signals.activeUsers}/{opp.signals.totalUsers}
+                    </p>
                     <p className="text-[9px] text-[#8B8B8B]">{t.dashboard.users ?? 'users'}</p>
                   </div>
                   <span className="text-sm font-bold text-emerald-600">+{formatCurrency(opp.mrrIncrease)}</span>
-                  <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded ${conf.badge}`}>
-                    {opp.confidence}
-                  </span>
+                  <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded ${conf.badge}`}>{opp.confidence}</span>
                 </div>
               </div>
             </button>

--- a/apps/web/app/(admin)/dashboard/customer-table.tsx
+++ b/apps/web/app/(admin)/dashboard/customer-table.tsx
@@ -2,16 +2,9 @@
 
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../lib/trpc';
+import { useDashboardRevenueByCustomer, useDashboardCustomerHealth } from '../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../lib/i18n';
-import {
-  formatCurrency,
-  timeAgo,
-  PLAN_BG_CLASSES,
-  PLAN_LABELS,
-  HEALTH_CONFIG,
-  Skeleton,
-} from './dashboard-utils';
+import { formatCurrency, timeAgo, PLAN_BG_CLASSES, PLAN_LABELS, HEALTH_CONFIG, Skeleton } from './dashboard-utils';
 import { ErrorState } from '../../../components';
 
 type SortKey = 'orgName' | 'plan' | 'mrr' | 'userCount' | 'lastActiveAt';
@@ -28,8 +21,8 @@ const COLUMNS: { key: SortKey; label: string; className: string }[] = [
 export function CustomerTable() {
   const { t } = useI18n();
   const router = useRouter();
-  const { data, isLoading, isError, refetch } = trpc.platform.getRevenueByCustomer.useQuery();
-  const { data: healthData, isError: healthError, refetch: refetchHealth } = trpc.platform.getCustomerHealth.useQuery();
+  const { data, isLoading, isError, refetch } = useDashboardRevenueByCustomer();
+  const { data: healthData, isError: healthError, refetch: refetchHealth } = useDashboardCustomerHealth();
   const [sortKey, setSortKey] = useState<SortKey>('mrr');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
@@ -97,7 +90,12 @@ export function CustomerTable() {
           ))}
         </div>
       ) : isError || healthError ? (
-        <ErrorState onRetry={() => { refetch(); refetchHealth(); }} />
+        <ErrorState
+          onRetry={() => {
+            refetch();
+            refetchHealth();
+          }}
+        />
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-left">
@@ -109,15 +107,12 @@ export function CustomerTable() {
                     className={`px-5 py-2.5 text-xs font-medium text-muted uppercase tracking-wide cursor-pointer hover:text-primary select-none ${col.className}`}
                     onClick={() => handleSort(col.key)}
                   >
-                    {col.label}{sortIndicator(col.key)}
+                    {col.label}
+                    {sortIndicator(col.key)}
                   </th>
                 ))}
-                <th className="px-5 py-2.5 text-xs font-medium text-muted uppercase tracking-wide w-[10%]">
-                  Health
-                </th>
-                <th className="px-5 py-2.5 text-xs font-medium text-muted uppercase tracking-wide w-[8%]">
-                  Action
-                </th>
+                <th className="px-5 py-2.5 text-xs font-medium text-muted uppercase tracking-wide w-[10%]">Health</th>
+                <th className="px-5 py-2.5 text-xs font-medium text-muted uppercase tracking-wide w-[8%]">Action</th>
               </tr>
             </thead>
             <tbody>
@@ -145,9 +140,7 @@ export function CustomerTable() {
                         {PLAN_LABELS[org.plan] ?? org.plan}
                       </span>
                     </td>
-                    <td className="px-5 py-3 text-sm font-medium text-primary">
-                      {formatCurrency(org.mrr)}
-                    </td>
+                    <td className="px-5 py-3 text-sm font-medium text-primary">{formatCurrency(org.mrr)}</td>
                     <td className="px-5 py-3 text-sm text-secondary">{org.userCount}</td>
                     <td className="px-5 py-3 text-xs text-muted">{timeAgo(org.lastActiveAt)}</td>
                     <td className="px-5 py-3">

--- a/apps/web/app/(admin)/dashboard/kpi-strip.tsx
+++ b/apps/web/app/(admin)/dashboard/kpi-strip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { trpc } from '../../../lib/trpc';
+import { useDashboardKpis, useDashboardMrrTrend } from '../../../lib/platform-api/dashboard';
 import { formatCurrency, trendArrow, Skeleton } from './dashboard-utils';
 import { ErrorState } from '../../../components';
 
@@ -68,17 +68,15 @@ function KpiCard({ label, value, trendLabel, trendColor, trendUp, sparkData, spa
             {trendUp ? '\u2191' : '\u2193'} {trendLabel}
           </span>
         </div>
-        {sparkData && sparkData.length > 1 && (
-          <Sparkline data={sparkData} color={sparkColor ?? '#1F114C'} />
-        )}
+        {sparkData && sparkData.length > 1 && <Sparkline data={sparkData} color={sparkColor ?? '#1F114C'} />}
       </div>
     </div>
   );
 }
 
 export function KpiStrip() {
-  const { data: kpis, isLoading, isError, refetch } = trpc.platform.getDashboardKpis.useQuery();
-  const { data: mrrTrend, isError: mrrTrendError, refetch: refetchMrrTrend } = trpc.platform.getMrrTrend.useQuery();
+  const { data: kpis, isLoading, isError, refetch } = useDashboardKpis();
+  const { data: mrrTrend, isError: mrrTrendError, refetch: refetchMrrTrend } = useDashboardMrrTrend();
 
   if (isLoading) {
     return (
@@ -97,7 +95,12 @@ export function KpiStrip() {
   if (isError || mrrTrendError) {
     return (
       <div className="mb-5">
-        <ErrorState onRetry={() => { refetch(); refetchMrrTrend(); }} />
+        <ErrorState
+          onRetry={() => {
+            refetch();
+            refetchMrrTrend();
+          }}
+        />
       </div>
     );
   }
@@ -124,7 +127,12 @@ export function KpiStrip() {
         trendLabel={`+${kpis.totalOrgsChange} this month`}
         trendColor={kpis.totalOrgsChange > 0 ? 'text-emerald-600' : 'text-muted'}
         trendUp={kpis.totalOrgsChange > 0}
-        sparkData={mrrTrend?.map((_, i) => kpis.totalOrgs - kpis.totalOrgsChange + Math.floor(i * (kpis.totalOrgsChange / Math.max(mrrTrend.length - 1, 1))))}
+        sparkData={mrrTrend?.map(
+          (_, i) =>
+            kpis.totalOrgs -
+            kpis.totalOrgsChange +
+            Math.floor(i * (kpis.totalOrgsChange / Math.max(mrrTrend.length - 1, 1))),
+        )}
         sparkColor="#8B5CF6"
       />
       <KpiCard
@@ -135,9 +143,7 @@ export function KpiStrip() {
         trendUp={kpis.totalUsersChange > 0}
         sparkColor="#3B82F6"
         badge={
-          kpis.activeTrials > 0
-            ? { text: `${kpis.activeTrials} trials`, color: 'bg-amber-100 text-amber-700' }
-            : null
+          kpis.activeTrials > 0 ? { text: `${kpis.activeTrials} trials`, color: 'bg-amber-100 text-amber-700' } : null
         }
       />
       <KpiCard

--- a/apps/web/app/(admin)/navbar/search-command.tsx
+++ b/apps/web/app/(admin)/navbar/search-command.tsx
@@ -82,6 +82,7 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         placeholder={t.nav.search}
+        maxLength={100}
         onFocus={() => {
           setSearchFocused(true);
           onFocus?.();

--- a/apps/web/app/(admin)/navbar/search-command.tsx
+++ b/apps/web/app/(admin)/navbar/search-command.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { trpc } from '../../../lib/trpc';
+import { useDashboardSearch } from '../../../lib/platform-api/dashboard';
 import { useI18n } from '../../../lib/i18n';
 import { ErrorState } from '../../../components';
 
@@ -51,22 +51,28 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
     return () => document.removeEventListener('keydown', handler);
   }, []);
 
-  const searchResults = trpc.platform.search.useQuery(
+  const searchResults = useDashboardSearch(
     { query: debouncedQuery },
-    { enabled: debouncedQuery.length >= 1 && searchFocused }
+    { enabled: debouncedQuery.length >= 1 && searchFocused },
   );
 
-  const hasResults = searchResults.data && (
-    searchResults.data.organizations.length > 0 ||
-    searchResults.data.users.length > 0 ||
-    searchResults.data.pages.length > 0
-  );
+  const hasResults =
+    searchResults.data &&
+    (searchResults.data.organizations.length > 0 ||
+      searchResults.data.users.length > 0 ||
+      searchResults.data.pages.length > 0);
 
   const showDropdown = searchFocused && searchQuery.length >= 1;
 
   return (
     <div ref={searchRef} className="relative">
-      <svg className="w-4 h-4 text-[#8B8B8B] absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none z-10" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+      <svg
+        className="w-4 h-4 text-[#8B8B8B] absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none z-10"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
         <circle cx="11" cy="11" r="8" />
         <path d="m21 21-4.35-4.35" />
       </svg>
@@ -76,7 +82,10 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         placeholder={t.nav.search}
-        onFocus={() => { setSearchFocused(true); onFocus?.(); }}
+        onFocus={() => {
+          setSearchFocused(true);
+          onFocus?.();
+        }}
         className={`h-8 pl-9 pr-16 rounded-lg border border-[#EDEDED] bg-[#FAFAFA] text-[12px] text-[#333] placeholder:text-[#8B8B8B] focus:outline-none focus:ring-1 focus:ring-[#1F114C]/20 focus:border-[#1F114C]/30 transition-all ${
           searchFocused ? 'w-[320px]' : 'w-[200px]'
         }`}
@@ -88,10 +97,15 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
       )}
       {searchFocused && searchQuery && (
         <button
-          onMouseDown={(e) => { e.preventDefault(); setSearchQuery(''); }}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            setSearchQuery('');
+          }}
           className="absolute right-3 top-1/2 -translate-y-1/2 text-[#8B8B8B] hover:text-[#585858]"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M18 6L6 18M6 6l12 12" /></svg>
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
         </button>
       )}
 
@@ -106,21 +120,46 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
             <ErrorState onRetry={() => searchResults.refetch()} />
           ) : !hasResults ? (
             <div className="px-4 py-6 text-center">
-              <svg className="w-8 h-8 text-[#EDEDED] mx-auto mb-2" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" /></svg>
-              <p className="text-[12px] text-[#8B8B8B]">{t.nav.noSearchResults} &quot;{searchQuery}&quot;</p>
+              <svg
+                className="w-8 h-8 text-[#EDEDED] mx-auto mb-2"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                viewBox="0 0 24 24"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.35-4.35" />
+              </svg>
+              <p className="text-[12px] text-[#8B8B8B]">
+                {t.nav.noSearchResults} &quot;{searchQuery}&quot;
+              </p>
             </div>
           ) : (
             <>
               {searchResults.data!.pages.length > 0 && (
                 <div>
-                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">{t.nav.pages}</div>
+                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">
+                    {t.nav.pages}
+                  </div>
                   {searchResults.data!.pages.map((page) => (
                     <button
                       key={page.href}
-                      onMouseDown={() => { router.push(page.href); setSearchFocused(false); setSearchQuery(''); }}
+                      onMouseDown={() => {
+                        router.push(page.href);
+                        setSearchFocused(false);
+                        setSearchQuery('');
+                      }}
                       className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F6F6F6] transition-colors"
                     >
-                      <svg className="w-4 h-4 text-[#8B8B8B] shrink-0" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
+                      <svg
+                        className="w-4 h-4 text-[#8B8B8B] shrink-0"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        viewBox="0 0 24 24"
+                      >
+                        <path d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                      </svg>
                       <span className="text-[12px] text-[#333]">{page.name}</span>
                     </button>
                   ))}
@@ -129,22 +168,34 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
 
               {searchResults.data!.organizations.length > 0 && (
                 <div>
-                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">{t.nav.organizations}</div>
+                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">
+                    {t.nav.organizations}
+                  </div>
                   {searchResults.data!.organizations.map((org) => (
                     <button
                       key={org.id}
-                      onMouseDown={() => { router.push('/platform/organizations'); setSearchFocused(false); setSearchQuery(''); }}
+                      onMouseDown={() => {
+                        router.push('/platform/organizations');
+                        setSearchFocused(false);
+                        setSearchQuery('');
+                      }}
                       className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F6F6F6] transition-colors"
                     >
                       <div className="w-7 h-7 rounded-lg bg-[#1F114C]/10 flex items-center justify-center shrink-0">
-                        <span className="text-[10px] font-bold text-[#1F114C]">{org.name.substring(0, 2).toUpperCase()}</span>
+                        <span className="text-[10px] font-bold text-[#1F114C]">
+                          {org.name.substring(0, 2).toUpperCase()}
+                        </span>
                       </div>
                       <div className="min-w-0 flex-1">
                         <p className="text-[12px] text-[#333] font-medium truncate">{org.name}</p>
-                        <p className="text-[10px] text-[#8B8B8B]">{org.slug} · {org.plan}</p>
+                        <p className="text-[10px] text-[#8B8B8B]">
+                          {org.slug} · {org.plan}
+                        </p>
                       </div>
                       {!org.isActive && (
-                        <span className="text-[9px] text-[#DD0C15] bg-red-50 px-1.5 py-0.5 rounded font-medium">{t.nav.suspended}</span>
+                        <span className="text-[9px] text-[#DD0C15] bg-red-50 px-1.5 py-0.5 rounded font-medium">
+                          {t.nav.suspended}
+                        </span>
                       )}
                     </button>
                   ))}
@@ -153,26 +204,42 @@ export function SearchCommand({ onFocus }: { onFocus?: () => void }) {
 
               {searchResults.data!.users.length > 0 && (
                 <div>
-                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">{t.nav.users}</div>
+                  <div className="px-3 py-2 text-[10px] font-semibold text-[#8B8B8B] uppercase tracking-wider bg-[#FAFAFA]">
+                    {t.nav.users}
+                  </div>
                   {searchResults.data!.users.map((user) => (
                     <button
                       key={user.id}
-                      onMouseDown={() => { router.push('/platform/users'); setSearchFocused(false); setSearchQuery(''); }}
+                      onMouseDown={() => {
+                        router.push('/platform/users');
+                        setSearchFocused(false);
+                        setSearchQuery('');
+                      }}
                       className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F6F6F6] transition-colors"
                     >
                       {user.avatar ? (
                         <img src={user.avatar} alt="" className="w-7 h-7 rounded-full shrink-0 object-cover" />
                       ) : (
                         <div className="w-7 h-7 rounded-full bg-blue-100 flex items-center justify-center shrink-0">
-                          <span className="text-[10px] font-bold text-blue-600">{user.firstName[0]}{user.lastName[0]}</span>
+                          <span className="text-[10px] font-bold text-blue-600">
+                            {user.firstName[0]}
+                            {user.lastName[0]}
+                          </span>
                         </div>
                       )}
                       <div className="min-w-0 flex-1">
-                        <p className="text-[12px] text-[#333] font-medium truncate">{user.firstName} {user.lastName}</p>
-                        <p className="text-[10px] text-[#8B8B8B] truncate">{user.email}{user.organization ? ` · ${user.organization.name}` : ''}</p>
+                        <p className="text-[12px] text-[#333] font-medium truncate">
+                          {user.firstName} {user.lastName}
+                        </p>
+                        <p className="text-[10px] text-[#8B8B8B] truncate">
+                          {user.email}
+                          {user.organization ? ` · ${user.organization.name}` : ''}
+                        </p>
                       </div>
                       {user.isPlatformOwner && (
-                        <span className="text-[9px] text-[#1F114C] bg-[#1F114C]/10 px-1.5 py-0.5 rounded font-medium">{t.nav.owner}</span>
+                        <span className="text-[9px] text-[#1F114C] bg-[#1F114C]/10 px-1.5 py-0.5 rounded font-medium">
+                          {t.nav.owner}
+                        </span>
                       )}
                     </button>
                   ))}

--- a/apps/web/app/(admin)/platform/subscriptions/page.tsx
+++ b/apps/web/app/(admin)/platform/subscriptions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { trpc } from '../../../../lib/trpc';
+import { useDashboardMrrTrend } from '../../../../lib/platform-api/dashboard';
 import { toast } from '../../../../lib/toast';
 import { useI18n } from '../../../../lib/i18n';
 import { formatCurrency } from '../../../../lib/format-utils';
@@ -26,7 +27,7 @@ export default function SubscriptionsPage() {
   const [cancelTarget, setCancelTarget] = useState<SubscriptionListItem | null>(null);
 
   const kpis = trpc.platform.getSubscriptionKpis.useQuery();
-  const mrrTrend = trpc.platform.getMrrTrend.useQuery();
+  const mrrTrend = useDashboardMrrTrend();
   const subs = trpc.platform.listSubscriptions.useQuery({
     page,
     limit,
@@ -43,18 +44,32 @@ export default function SubscriptionsPage() {
   };
 
   const updateSub = trpc.platform.updateSubscription.useMutation({
-    onSuccess: () => { invalidateAll(); toast(t.common.save, { type: 'success' }); },
-    onError: (err) => { toast(err.message, { type: 'error' }); },
+    onSuccess: () => {
+      invalidateAll();
+      toast(t.common.save, { type: 'success' });
+    },
+    onError: (err) => {
+      toast(err.message, { type: 'error' });
+    },
   });
 
   const reactivateSub = trpc.platform.reactivateSubscription.useMutation({
-    onSuccess: () => { invalidateAll(); toast(t.subscriptions.reactivate, { type: 'success' }); },
-    onError: (err) => { toast(err.message, { type: 'error' }); },
+    onSuccess: () => {
+      invalidateAll();
+      toast(t.subscriptions.reactivate, { type: 'success' });
+    },
+    onError: (err) => {
+      toast(err.message, { type: 'error' });
+    },
   });
 
   const sendReminder = trpc.platform.sendDunningReminder.useMutation({
-    onSuccess: (data) => { toast(`${t.subscriptions.sendReminder}: ${data.orgName}`, { type: 'success' }); },
-    onError: (err) => { toast(err.message, { type: 'error' }); },
+    onSuccess: (data) => {
+      toast(`${t.subscriptions.sendReminder}: ${data.orgName}`, { type: 'success' });
+    },
+    onError: (err) => {
+      toast(err.message, { type: 'error' });
+    },
   });
 
   const exportCsv = trpc.platform.exportSubscriptionsCsv.useQuery(
@@ -138,21 +153,52 @@ export default function SubscriptionsPage() {
               label={t.subscriptions.kpiMrr}
               value={formatCurrency(kpis.data.mrr)}
               subtitle={`${kpis.data.mrrChangePercent >= 0 ? '+' : ''}${kpis.data.mrrChangePercent}% ${t.subscriptions.vsLastMonth}`}
-              icon={<svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 100 7h5a3.5 3.5 0 110 7H6" /></svg>}
+              icon={
+                <svg
+                  className="w-4 h-4 text-green-500"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 1v22M17 5H9.5a3.5 3.5 0 100 7h5a3.5 3.5 0 110 7H6" />
+                </svg>
+              }
               iconBg="bg-green-50"
             />
             <KpiCard
               label={t.subscriptions.kpiActive}
               value={kpis.data.active}
               subtitle={`${kpis.data.total > 0 ? Math.round((kpis.data.active / kpis.data.total) * 100) : 0}% ${t.subscriptions.ofTotalOrgs}`}
-              icon={<svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14" /><path d="M22 4L12 14.01l-3-3" /></svg>}
+              icon={
+                <svg
+                  className="w-4 h-4 text-blue-500"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M22 11.08V12a10 10 0 11-5.93-9.14" />
+                  <path d="M22 4L12 14.01l-3-3" />
+                </svg>
+              }
               iconBg="bg-blue-50"
             />
             <KpiCard
               label={t.subscriptions.kpiExpiring}
               value={kpis.data.expiringTrials.length}
               subtitle={t.subscriptions.expireIn7Days}
-              icon={<svg className="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" /></svg>}
+              icon={
+                <svg
+                  className="w-4 h-4 text-amber-500"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />
+                </svg>
+              }
               iconBg="bg-amber-50"
               highlight={kpis.data.expiringTrials.length > 0}
             />
@@ -161,7 +207,18 @@ export default function SubscriptionsPage() {
               value={kpis.data.pastDue}
               subtitle={kpis.data.pastDue > 0 ? t.common.requiresAttention : t.common.noIssues}
               valueColor={kpis.data.pastDue > 0 ? 'text-[#DD0C15]' : undefined}
-              icon={<svg className="w-4 h-4 text-[#DD0C15]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M15 9l-6 6M9 9l6 6" /></svg>}
+              icon={
+                <svg
+                  className="w-4 h-4 text-[#DD0C15]"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M15 9l-6 6M9 9l6 6" />
+                </svg>
+              }
               iconBg="bg-red-50"
               highlight={kpis.data.pastDue > 0}
             />
@@ -176,7 +233,9 @@ export default function SubscriptionsPage() {
           <span className="text-xs text-[#8B8B8B]">{t.subscriptions.lastMonths}</span>
         </div>
         {mrrTrend.isLoading ? (
-          <div className="h-[130px] animate-pulse"><div className="h-full w-full bg-gray-100 rounded" /></div>
+          <div className="h-[130px] animate-pulse">
+            <div className="h-full w-full bg-gray-100 rounded" />
+          </div>
         ) : mrrTrend.isError ? (
           <ErrorState onRetry={() => mrrTrend.refetch()} />
         ) : mrrTrend.data ? (
@@ -192,17 +251,22 @@ export default function SubscriptionsPage() {
                   const opacity = m.mrr === 0 ? 0 : 0.2 + (i / 5) * 0.8;
                   return (
                     <div key={i} className="flex-1 flex flex-col items-center justify-end gap-1.5 h-full">
-                      <span className={`text-[10px] font-medium ${isLast ? 'text-green-600 font-bold' : 'text-[#8B8B8B]'}`}>
+                      <span
+                        className={`text-[10px] font-medium ${isLast ? 'text-green-600 font-bold' : 'text-[#8B8B8B]'}`}
+                      >
                         {m.mrr === 0 ? '$0' : `$${m.mrr >= 1000 ? (m.mrr / 1000).toFixed(1) + 'K' : m.mrr}`}
                       </span>
                       <div
                         className="w-full rounded-t-md flex-shrink-0"
                         style={{
                           height: barH,
-                          backgroundColor: m.mrr === 0 ? '#EDEDED' : isLast ? '#22c55e' : `rgba(34, 197, 94, ${opacity})`,
+                          backgroundColor:
+                            m.mrr === 0 ? '#EDEDED' : isLast ? '#22c55e' : `rgba(34, 197, 94, ${opacity})`,
                         }}
                       />
-                      <span className={`text-[10px] flex-shrink-0 ${isLast ? 'text-[#333] font-medium' : 'text-[#8B8B8B]'}`}>
+                      <span
+                        className={`text-[10px] flex-shrink-0 ${isLast ? 'text-[#333] font-medium' : 'text-[#8B8B8B]'}`}
+                      >
                         {m.month.charAt(0).toUpperCase() + m.month.slice(1)}
                       </span>
                     </div>
@@ -217,11 +281,20 @@ export default function SubscriptionsPage() {
       {/* Filter Bar */}
       <FilterBar
         search={search}
-        onSearchChange={(v) => { setSearch(v); setPage(0); }}
+        onSearchChange={(v) => {
+          setSearch(v);
+          setPage(0);
+        }}
         statusFilter={statusFilter}
-        onStatusChange={(v) => { setStatusFilter(v); setPage(0); }}
+        onStatusChange={(v) => {
+          setStatusFilter(v);
+          setPage(0);
+        }}
         planFilter={planFilter}
-        onPlanChange={(v) => { setPlanFilter(v); setPage(0); }}
+        onPlanChange={(v) => {
+          setPlanFilter(v);
+          setPage(0);
+        }}
         onClearFilters={clearFilters}
         onExportCsv={handleExportCsv}
         hasFilters={!!(search || statusFilter || planFilter)}

--- a/apps/web/lib/platform-api/dashboard.ts
+++ b/apps/web/lib/platform-api/dashboard.ts
@@ -12,7 +12,8 @@
 // has today. (NOT billing/dei: an earlier draft cited all three, but those two have since gone
 // C#-only — their TS fallbacks are deleted and dei's flag is dead. The panel counted the set.)
 // The C# side is the thirteen `/platform/dashboard/*` endpoints behind
-// Platform:PlatformDashboardReadEnabled (also dark), so a real cutover needs BOTH flags.
+// Platform:PlatformDashboardReadEnabled (also dark), so a real cutover needs all THREE env
+// conditions: the two NEXT_PUBLIC_* above at Vercel build time plus the server flag.
 //
 // TWELVE hooks for THIRTEEN ported reads, deliberately. `getUserGrowth` has ZERO consumers in
 // apps/web (no user-growth chart exists), so a `useDashboardUserGrowth` hook would ship as an
@@ -29,8 +30,10 @@
 //
 // NO invalidation helper, deliberately. This cluster is read-only: no dashboard write was ported,
 // and no `utils.platform.*.invalidate()` call in apps/web targets any of the thirteen dashboard
-// reads (35 such calls exist — all for OTHER platform procedures) — so there is no mutation whose
-// onSuccess would need to reach the ['platform-api', 'dashboard'] cache family.
+// reads — every such call (36 at last count, and this family of counts has now been wrong three
+// times, so trust the wiring test's scan over this number) is for OTHER platform procedures. So
+// there is no mutation whose onSuccess would need to reach the ['platform-api', 'dashboard']
+// cache family.
 // (Contrast monitoring.ts, which needed one because configureAlertRules stayed a tRPC write.)
 //
 // ⚠️ Null-preserving numerics — `Number(null) === 0`, and for all three of these a fabricated 0

--- a/apps/web/lib/platform-api/dashboard.ts
+++ b/apps/web/lib/platform-api/dashboard.ts
@@ -8,7 +8,9 @@
 //
 // The flag is UNSET everywhere today, so this file changes nothing in production: the flat
 // `trpc.platform.*` dashboard procedures remain the single active reader. It exists so the cutover
-// is a deploy env-var flip rather than a code change — the same shape as monitoring/billing/dei.
+// is a deploy env-var flip rather than a code change — the same dual-path shape monitoring still
+// has today. (NOT billing/dei: an earlier draft cited all three, but those two have since gone
+// C#-only — their TS fallbacks are deleted and dei's flag is dead. The panel counted the set.)
 // The C# side is the thirteen `/platform/dashboard/*` endpoints behind
 // Platform:PlatformDashboardReadEnabled (also dark), so a real cutover needs BOTH flags.
 //
@@ -26,8 +28,9 @@
 // wiring test cross-checks every path literal against contracts/openapi/Tims.Api.json.
 //
 // NO invalidation helper, deliberately. This cluster is read-only: no dashboard write was ported,
-// and zero `utils.platform.<read>.invalidate()` calls exist in apps/web today — there is no
-// mutation whose onSuccess would need to reach the ['platform-api', 'dashboard'] cache family.
+// and no `utils.platform.*.invalidate()` call in apps/web targets any of the thirteen dashboard
+// reads (35 such calls exist — all for OTHER platform procedures) — so there is no mutation whose
+// onSuccess would need to reach the ['platform-api', 'dashboard'] cache family.
 // (Contrast monitoring.ts, which needed one because configureAlertRules stayed a tRPC write.)
 //
 // ⚠️ Null-preserving numerics — `Number(null) === 0`, and for all three of these a fabricated 0
@@ -73,8 +76,10 @@ export function numberOrUndefined(value: number | string | null | undefined): nu
 /**
  * Date reconstruction. The C# contract emits ISO strings (NodeIsoDateTimeConverter), while the
  * tRPC path returns a real `Date` via superjson. Only TWO of the thirteen dashboard wires carry a
- * datetime — recent-activity `timestamp` and revenue-by-customer `lastActiveAt` — the other
- * eleven serve pre-formatted month labels or day counts. Shape copied from monitoring.ts:49.
+ * Date-typed field — recent-activity `timestamp` and revenue-by-customer `lastActiveAt`. (The one
+ * near-miss: kpis' `outstandingRatesAsOf` is date-VALUED but string-TYPED on both paths —
+ * `sumMoney` returns it as `string | null` — so it is deliberately passed through, never
+ * reconstructed.) Shape copied from monitoring.ts:49.
  */
 export const toDate = (v: unknown): Date => new Date(v as string);
 export const toDateOrNull = (v: unknown): Date | null => (v == null ? null : new Date(v as string));
@@ -83,6 +88,9 @@ export const toDateOrNull = (v: unknown): Date | null => (v == null ? null : new
 // Field-for-field identical to the tRPC outputs. Literal unions match the tRPC inferred types so
 // a consumer seeing the union of both paths' data types can index/narrow exactly as before.
 
+// Matches the tRPC-side Prisma `OrgPlan` enum. The C# records type `plan` as a plain string, so
+// this narrowing is a claim about the DATABASE (the column is the native "OrgPlan" enum, which
+// constrains every value both stacks can read), not about the C# wire's own type.
 type OrgPlanName = 'trial' | 'starter' | 'professional' | 'enterprise';
 
 export interface DashboardKpis {
@@ -511,6 +519,35 @@ export function mapChurnRiskOrg(raw: {
   };
 }
 
+/**
+ * Whole-payload churn mapper, extracted so the SUMMARY coercions are testable. The panel found the
+ * summary block living inline in the hook's queryFn — reachable by neither the coercion test (which
+ * imports mappers) nor tsc (the raw comes off an `as` cast) — so `total: Number(raw.summary.red)`
+ * would have compiled and passed the whole suite. "Unreachable from a unit test" is an argument for
+ * extracting the mapping, not for leaving it inline.
+ */
+export function mapChurnRisk(raw: {
+  organizations: Parameters<typeof mapChurnRiskOrg>[0][];
+  summary: {
+    green: number | string;
+    yellow: number | string;
+    red: number | string;
+    total: number | string;
+    atRiskMrr: number | string;
+  };
+}): ChurnRisk {
+  return {
+    organizations: raw.organizations.map(mapChurnRiskOrg),
+    summary: {
+      green: Number(raw.summary.green),
+      yellow: Number(raw.summary.yellow),
+      red: Number(raw.summary.red),
+      total: Number(raw.summary.total),
+      atRiskMrr: Number(raw.summary.atRiskMrr),
+    },
+  };
+}
+
 export function mapMrrForecast(raw: {
   historical: { month: string; mrr: number | string; type: 'historical' }[];
   projected: { month: string; mrr: number | string; type: 'projected' }[];
@@ -754,28 +791,8 @@ export function useDashboardChurnRisk() {
   const trpcQuery = trpc.platform.getChurnRisk.useQuery(undefined, { enabled: !enabled });
   const csharpQuery = useQuery<ChurnRisk>({
     queryKey: ['platform-api', 'dashboard', 'churn-risk'],
-    queryFn: async () => {
-      const raw = (await platformGetRaw('/platform/dashboard/churn-risk')) as {
-        organizations: Parameters<typeof mapChurnRiskOrg>[0][];
-        summary: {
-          green: number | string;
-          yellow: number | string;
-          red: number | string;
-          total: number | string;
-          atRiskMrr: number | string;
-        };
-      };
-      return {
-        organizations: raw.organizations.map(mapChurnRiskOrg),
-        summary: {
-          green: Number(raw.summary.green),
-          yellow: Number(raw.summary.yellow),
-          red: Number(raw.summary.red),
-          total: Number(raw.summary.total),
-          atRiskMrr: Number(raw.summary.atRiskMrr),
-        },
-      };
-    },
+    queryFn: async () =>
+      mapChurnRisk((await platformGetRaw('/platform/dashboard/churn-risk')) as Parameters<typeof mapChurnRisk>[0]),
     enabled,
   });
   return enabled ? csharpQuery : trpcQuery;

--- a/apps/web/lib/platform-api/dashboard.ts
+++ b/apps/web/lib/platform-api/dashboard.ts
@@ -1,0 +1,829 @@
+'use client';
+
+// Platform dashboard FE data layer — Phase-5 slice 23 step 4 (issue #81), DARK.
+//
+// Every hook below returns the tRPC path UNLESS both of these are true:
+//   1. NEXT_PUBLIC_TIMS_PLATFORM_API_URL is set (`isPlatformApiEnabled()`), and
+//   2. NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP === 'true'.
+//
+// The flag is UNSET everywhere today, so this file changes nothing in production: the flat
+// `trpc.platform.*` dashboard procedures remain the single active reader. It exists so the cutover
+// is a deploy env-var flip rather than a code change — the same shape as monitoring/billing/dei.
+// The C# side is the thirteen `/platform/dashboard/*` endpoints behind
+// Platform:PlatformDashboardReadEnabled (also dark), so a real cutover needs BOTH flags.
+//
+// TWELVE hooks for THIRTEEN ported reads, deliberately. `getUserGrowth` has ZERO consumers in
+// apps/web (no user-growth chart exists), so a `useDashboardUserGrowth` hook would ship as an
+// orphan — the exact defect class tests/platform/dashboard-fe-wiring.test.ts exists to catch
+// ("a hook with no callers still compiles, still type-checks, and still has passing unit tests").
+// The wiring test pins the exception by name; its raw-tRPC scan still covers all thirteen reads,
+// so a future user-growth consumer is forced through a new hook here on the day it is written.
+//
+// `platformGetRaw`, NOT `platformGet`: every dashboard endpoint declares an untyped
+// `.Produces(StatusCodes.Status200OK)` (no `<T>`), so the OpenAPI contract types the 200 with
+// `content?: never` and the typed `GetPaths` union cannot accept these paths. That means the path
+// strings below are NOT compile-checked — a typo'd path would compile and 404 at runtime — so the
+// wiring test cross-checks every path literal against contracts/openapi/Tims.Api.json.
+//
+// NO invalidation helper, deliberately. This cluster is read-only: no dashboard write was ported,
+// and zero `utils.platform.<read>.invalidate()` calls exist in apps/web today — there is no
+// mutation whose onSuccess would need to reach the ['platform-api', 'dashboard'] cache family.
+// (Contrast monitoring.ts, which needed one because configureAlertRules stayed a tRPC write.)
+//
+// ⚠️ Null-preserving numerics — `Number(null) === 0`, and for all three of these a fabricated 0
+// is not just wrong but INVERTED:
+//   - churn-risk `daysSinceLastLogin`: null means "no login EVER" (TS maps its 999 sentinel to
+//     null at the wire); 0 means "logged in today" — the opposite end of the risk scale.
+//   - customer-health `signals.trialDaysLeft`: null means "not on a trial"; 0 means "trial
+//     expires today", which would light the at_risk branch for every non-trial org.
+//   - ai-cost-anomalies `monthlyBudget`: null means "no budget configured"; 0 is a real budget —
+//     and the TS anomaly rule treats them differently (`config.monthlyBudget && cost > budget`),
+//     so collapsing null to 0 misrepresents which orgs CAN go over budget.
+// customer-health `signals.daysSinceLastLogin` is NOT in this list: the TS procedure keeps the
+// raw 999 no-login sentinel there (only churn-risk maps it to null), and this file reproduces
+// each procedure's behavior exactly — reproduce, don't improve.
+
+import { useQuery } from '@tanstack/react-query';
+import { trpc } from '../trpc';
+import { isPlatformApiEnabled, platformGetRaw } from './client';
+
+const DASHBOARD_READ_VIA_CSHARP = process.env.NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP === 'true';
+
+function viaCSharp(): boolean {
+  return isPlatformApiEnabled() && DASHBOARD_READ_VIA_CSHARP;
+}
+
+/**
+ * Null-preserving numeric coercion — see the inversion warning above. Exported so the invariant
+ * "a null wire value never becomes 0" is directly testable rather than only argued in a comment.
+ */
+export function numberOrNull(value: number | string | null | undefined): number | null {
+  return value === null || value === undefined ? null : Number(value);
+}
+
+/**
+ * Optional-key numeric coercion. The tRPC client restores a written-`undefined` back to
+ * `undefined` (superjson meta), while the C# wire emits `null` for it — and omits keys the TS
+ * literal never wrote. Both must land as `undefined` so the two paths are indistinguishable.
+ */
+export function numberOrUndefined(value: number | string | null | undefined): number | undefined {
+  return value === null || value === undefined ? undefined : Number(value);
+}
+
+/**
+ * Date reconstruction. The C# contract emits ISO strings (NodeIsoDateTimeConverter), while the
+ * tRPC path returns a real `Date` via superjson. Only TWO of the thirteen dashboard wires carry a
+ * datetime — recent-activity `timestamp` and revenue-by-customer `lastActiveAt` — the other
+ * eleven serve pre-formatted month labels or day counts. Shape copied from monitoring.ts:49.
+ */
+export const toDate = (v: unknown): Date => new Date(v as string);
+export const toDateOrNull = (v: unknown): Date | null => (v == null ? null : new Date(v as string));
+
+// ── Wire shapes ───────────────────────────────────────────────────────────────────────────────
+// Field-for-field identical to the tRPC outputs. Literal unions match the tRPC inferred types so
+// a consumer seeing the union of both paths' data types can index/narrow exactly as before.
+
+type OrgPlanName = 'trial' | 'starter' | 'professional' | 'enterprise';
+
+export interface DashboardKpis {
+  totalOrgs: number;
+  totalOrgsChange: number;
+  totalUsers: number;
+  totalUsersChange: number;
+  mrr: number;
+  mrrPrevMonth: number;
+  activeTrials: number;
+  trialsExpiringThisWeek: number;
+  overdueInvoices: number;
+  outstandingAmount: number;
+  currency: string;
+  outstandingConverted: boolean;
+  outstandingRatesAsOf: string | null;
+}
+
+export interface AttentionItem {
+  id: string;
+  type: 'overdue_invoice' | 'expiring_trial' | 'failed_payment' | 'pending_invitation' | 'suspended_org';
+  severity: 'critical' | 'warning' | 'info';
+  title: string;
+  description: string;
+  orgId?: string;
+  orgName?: string;
+  actionUrl: string;
+  actionLabel: string;
+  amount?: number;
+  currency?: string;
+  daysUntil?: number;
+}
+
+export interface RevenueByCustomerRow {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  mrr: number;
+  paidLast30d: number;
+  outstandingAmount: number;
+  currency: string;
+  converted: boolean;
+  userCount: number;
+  lastActiveAt: Date | null;
+}
+
+export interface CustomerHealthRow {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  health: 'healthy' | 'at_risk' | 'critical';
+  signals: {
+    loginRate: number;
+    overdueInvoices: number;
+    trialDaysLeft: number | null;
+    daysSinceLastLogin: number;
+  };
+}
+
+export interface RecentActivityItem {
+  id: string;
+  type: string;
+  title: string;
+  timestamp: Date;
+  meta?: string;
+}
+
+export interface PlanDistributionRow {
+  plan: string;
+  count: number;
+  percentage: number;
+}
+
+export interface SearchResults {
+  organizations: { id: string; name: string; slug: string; plan: OrgPlanName; isActive: boolean }[];
+  users: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    isPlatformOwner: boolean;
+    isActive: boolean;
+    avatar: string | null;
+    organization: { name: string } | null;
+  }[];
+  pages: { name: string; href: string; keywords: string }[];
+}
+
+export interface MrrTrendPoint {
+  month: string;
+  mrr: number;
+}
+
+export interface ChurnRiskOrg {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  mrr: number;
+  healthScore: number;
+  tier: 'green' | 'yellow' | 'red';
+  totalUsers: number;
+  loginRate: number;
+  daysSinceLastLogin: number | null;
+  overdueInvoices: number;
+  overdueAmount: number;
+  currency: string;
+  overdueAmountConverted: boolean;
+  featureCount: number;
+  primaryRisk: string;
+  risks: string[];
+  actions: string[];
+  signals: {
+    loginScore: number;
+    invoiceScore: number;
+    recencyScore: number;
+    adoptionScore: number;
+    tenureScore: number;
+  };
+}
+
+export interface ChurnRisk {
+  organizations: ChurnRiskOrg[];
+  summary: { green: number; yellow: number; red: number; total: number; atRiskMrr: number };
+}
+
+export interface MrrForecast {
+  historical: { month: string; mrr: number; type: 'historical' }[];
+  projected: { month: string; mrr: number; type: 'projected' }[];
+  currentMrr: number;
+  projectedMrr12m: number;
+  projectedArr: number;
+  monthlyGrowthPct: number;
+  planBreakdown: Record<string, { count: number; mrr: number }>;
+  pendingTrials: number;
+  potentialMrrFromTrials: number;
+}
+
+export interface UpsellOpportunity {
+  orgId: string;
+  orgName: string;
+  currentPlan: string;
+  targetPlan: string;
+  mrrIncrease: number;
+  reason: string;
+  signals: { activeUsers: number; totalUsers: number; features: number; vacancies: number };
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface UpsellOpportunities {
+  opportunities: UpsellOpportunity[];
+  totalPotentialMrr: number;
+  highConfidence: number;
+  mediumConfidence: number;
+}
+
+export interface AiCostAnomaly {
+  type: 'zero_usage' | 'over_budget' | 'high_cost';
+  agentName: string;
+  agentSlug: string;
+  orgName: string;
+  orgId: string;
+  detail: string;
+  monthlyCost: number;
+  monthlyBudget: number | null;
+  potentialSavings: number;
+}
+
+export interface AiCostAnomalies {
+  anomalies: AiCostAnomaly[];
+  totalPotentialSavings: number;
+  zeroUsageCount: number;
+  overBudgetCount: number;
+}
+
+// ── Row mappers ───────────────────────────────────────────────────────────────────────────────
+// Exported for the same reason monitoring's are: an invariant argued only in a comment is not
+// enforced, and the hooks' inline mapping is unreachable from a unit test. Numeric wire fields
+// are typed `number | string` (the contract convention for the C# minimal API), which also makes
+// tsc reject a hook that skips its mapper — `number | string` does not widen into `number`.
+
+export function mapDashboardKpis(raw: {
+  totalOrgs: number | string;
+  totalOrgsChange: number | string;
+  totalUsers: number | string;
+  totalUsersChange: number | string;
+  mrr: number | string;
+  mrrPrevMonth: number | string;
+  activeTrials: number | string;
+  trialsExpiringThisWeek: number | string;
+  overdueInvoices: number | string;
+  outstandingAmount: number | string;
+  currency: string;
+  outstandingConverted: boolean;
+  outstandingRatesAsOf: string | null;
+}): DashboardKpis {
+  return {
+    totalOrgs: Number(raw.totalOrgs),
+    totalOrgsChange: Number(raw.totalOrgsChange),
+    totalUsers: Number(raw.totalUsers),
+    totalUsersChange: Number(raw.totalUsersChange),
+    mrr: Number(raw.mrr),
+    mrrPrevMonth: Number(raw.mrrPrevMonth),
+    activeTrials: Number(raw.activeTrials),
+    trialsExpiringThisWeek: Number(raw.trialsExpiringThisWeek),
+    overdueInvoices: Number(raw.overdueInvoices),
+    outstandingAmount: Number(raw.outstandingAmount),
+    currency: raw.currency,
+    outstandingConverted: raw.outstandingConverted,
+    // A string | null passthrough, NOT a date reconstruction: the tRPC path also serves a string
+    // here (fx `ratesAsOf`), so turning it into a Date would DIVERGE from the TS shape.
+    outstandingRatesAsOf: raw.outstandingRatesAsOf ?? null,
+  };
+}
+
+export function mapAttentionItem(raw: {
+  id: string;
+  type: AttentionItem['type'];
+  severity: AttentionItem['severity'];
+  title: string;
+  description: string;
+  orgId?: string | null;
+  orgName?: string | null;
+  actionUrl: string;
+  actionLabel: string;
+  amount?: number | string | null;
+  currency?: string | null;
+  daysUntil?: number | string | null;
+}): AttentionItem {
+  return {
+    id: raw.id,
+    type: raw.type,
+    severity: raw.severity,
+    title: raw.title,
+    description: raw.description,
+    // `?? undefined`, not passthrough: C# emits null for a written-undefined key (the TS literal
+    // writes `orgId: inv.organization?.id`), while superjson hands the tRPC consumer `undefined`.
+    orgId: raw.orgId ?? undefined,
+    orgName: raw.orgName ?? undefined,
+    actionUrl: raw.actionUrl,
+    actionLabel: raw.actionLabel,
+    amount: numberOrUndefined(raw.amount),
+    currency: raw.currency ?? undefined,
+    daysUntil: numberOrUndefined(raw.daysUntil),
+  };
+}
+
+export function mapRevenueByCustomerRow(raw: {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  mrr: number | string;
+  paidLast30d: number | string;
+  outstandingAmount: number | string;
+  currency: string;
+  converted: boolean;
+  userCount: number | string;
+  lastActiveAt?: string | null;
+}): RevenueByCustomerRow {
+  return {
+    orgId: raw.orgId,
+    orgName: raw.orgName,
+    plan: raw.plan,
+    mrr: Number(raw.mrr),
+    paidLast30d: Number(raw.paidLast30d),
+    outstandingAmount: Number(raw.outstandingAmount),
+    currency: raw.currency,
+    converted: raw.converted,
+    userCount: Number(raw.userCount),
+    // toDateOrNull, NOT toDate: `new Date(null)` is epoch 1970, which would render every
+    // never-logged-in org as "last active 56 years ago" instead of blank.
+    lastActiveAt: toDateOrNull(raw.lastActiveAt),
+  };
+}
+
+export function mapCustomerHealthRow(raw: {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  health: CustomerHealthRow['health'];
+  signals: {
+    loginRate: number | string;
+    overdueInvoices: number | string;
+    trialDaysLeft: number | string | null;
+    daysSinceLastLogin: number | string;
+  };
+}): CustomerHealthRow {
+  return {
+    orgId: raw.orgId,
+    orgName: raw.orgName,
+    plan: raw.plan,
+    health: raw.health,
+    signals: {
+      loginRate: Number(raw.signals.loginRate),
+      overdueInvoices: Number(raw.signals.overdueInvoices),
+      // numberOrNull, NOT Number: null means "not on a trial"; 0 means "trial expires TODAY".
+      trialDaysLeft: numberOrNull(raw.signals.trialDaysLeft),
+      // Number, faithfully: the TS procedure keeps the 999 no-login sentinel on THIS wire
+      // (only churn-risk maps it to null). Reproduce, don't improve.
+      daysSinceLastLogin: Number(raw.signals.daysSinceLastLogin),
+    },
+  };
+}
+
+export function mapRecentActivityItem(raw: {
+  id: string;
+  type: string;
+  title: string;
+  timestamp: string;
+  meta?: string | null;
+}): RecentActivityItem {
+  return {
+    id: raw.id,
+    type: raw.type,
+    title: raw.title,
+    timestamp: toDate(raw.timestamp),
+    // The one optional key on this wire: absent for org rows' plan-less events is impossible
+    // (org rows always write meta), but user rows write `meta: user.email` and the C# converter
+    // mirrors the TS literal's key set — normalize null and absent both to undefined.
+    meta: raw.meta ?? undefined,
+  };
+}
+
+export function mapPlanDistributionRow(raw: {
+  plan: string;
+  count: number | string;
+  percentage: number | string;
+}): PlanDistributionRow {
+  return { plan: raw.plan, count: Number(raw.count), percentage: Number(raw.percentage) };
+}
+
+export function mapSearchResults(raw: {
+  organizations: { id: string; name: string; slug: string; plan: OrgPlanName; isActive: boolean }[];
+  users: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    isPlatformOwner: boolean;
+    isActive: boolean;
+    avatar?: string | null;
+    organization?: { name: string } | null;
+  }[];
+  pages: { name: string; href: string; keywords: string }[];
+}): SearchResults {
+  return {
+    organizations: raw.organizations.map((o) => ({
+      id: o.id,
+      name: o.name,
+      slug: o.slug,
+      plan: o.plan,
+      isActive: o.isActive,
+    })),
+    users: raw.users.map((u) => ({
+      id: u.id,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      email: u.email,
+      isPlatformOwner: u.isPlatformOwner,
+      isActive: u.isActive,
+      // string | null on the tRPC side (nullable column / org-less platform owner) — keep null,
+      // these are NOT the optional-key case.
+      avatar: u.avatar ?? null,
+      organization: u.organization ? { name: u.organization.name } : null,
+    })),
+    pages: raw.pages.map((p) => ({ name: p.name, href: p.href, keywords: p.keywords })),
+  };
+}
+
+export function mapMrrTrendPoint(raw: { month: string; mrr: number | string }): MrrTrendPoint {
+  return { month: raw.month, mrr: Number(raw.mrr) };
+}
+
+export function mapChurnRiskOrg(raw: {
+  orgId: string;
+  orgName: string;
+  plan: OrgPlanName;
+  mrr: number | string;
+  healthScore: number | string;
+  tier: ChurnRiskOrg['tier'];
+  totalUsers: number | string;
+  loginRate: number | string;
+  daysSinceLastLogin: number | string | null;
+  overdueInvoices: number | string;
+  overdueAmount: number | string;
+  currency: string;
+  overdueAmountConverted: boolean;
+  featureCount: number | string;
+  primaryRisk: string;
+  risks: string[];
+  actions: string[];
+  signals: {
+    loginScore: number | string;
+    invoiceScore: number | string;
+    recencyScore: number | string;
+    adoptionScore: number | string;
+    tenureScore: number | string;
+  };
+}): ChurnRiskOrg {
+  return {
+    orgId: raw.orgId,
+    orgName: raw.orgName,
+    plan: raw.plan,
+    mrr: Number(raw.mrr),
+    healthScore: Number(raw.healthScore),
+    tier: raw.tier,
+    totalUsers: Number(raw.totalUsers),
+    loginRate: Number(raw.loginRate),
+    // numberOrNull, NOT Number: null means "no login EVER"; 0 means "logged in TODAY" — a bare
+    // Number() would move an org from one end of the risk scale to the other.
+    daysSinceLastLogin: numberOrNull(raw.daysSinceLastLogin),
+    overdueInvoices: Number(raw.overdueInvoices),
+    overdueAmount: Number(raw.overdueAmount),
+    currency: raw.currency,
+    overdueAmountConverted: raw.overdueAmountConverted,
+    featureCount: Number(raw.featureCount),
+    primaryRisk: raw.primaryRisk,
+    risks: raw.risks,
+    actions: raw.actions,
+    signals: {
+      loginScore: Number(raw.signals.loginScore),
+      invoiceScore: Number(raw.signals.invoiceScore),
+      recencyScore: Number(raw.signals.recencyScore),
+      adoptionScore: Number(raw.signals.adoptionScore),
+      tenureScore: Number(raw.signals.tenureScore),
+    },
+  };
+}
+
+export function mapMrrForecast(raw: {
+  historical: { month: string; mrr: number | string; type: 'historical' }[];
+  projected: { month: string; mrr: number | string; type: 'projected' }[];
+  currentMrr: number | string;
+  projectedMrr12m: number | string;
+  projectedArr: number | string;
+  monthlyGrowthPct: number | string;
+  planBreakdown: Record<string, { count: number | string; mrr: number | string }>;
+  pendingTrials: number | string;
+  potentialMrrFromTrials: number | string;
+}): MrrForecast {
+  return {
+    historical: raw.historical.map((h) => ({ month: h.month, mrr: Number(h.mrr), type: h.type })),
+    projected: raw.projected.map((p) => ({ month: p.month, mrr: Number(p.mrr), type: p.type })),
+    currentMrr: Number(raw.currentMrr),
+    projectedMrr12m: Number(raw.projectedMrr12m),
+    projectedArr: Number(raw.projectedArr),
+    monthlyGrowthPct: Number(raw.monthlyGrowthPct),
+    planBreakdown: Object.fromEntries(
+      Object.entries(raw.planBreakdown).map(([plan, v]) => [plan, { count: Number(v.count), mrr: Number(v.mrr) }]),
+    ),
+    pendingTrials: Number(raw.pendingTrials),
+    potentialMrrFromTrials: Number(raw.potentialMrrFromTrials),
+  };
+}
+
+export function mapUpsellOpportunities(raw: {
+  opportunities: {
+    orgId: string;
+    orgName: string;
+    currentPlan: string;
+    targetPlan: string;
+    mrrIncrease: number | string;
+    reason: string;
+    signals: {
+      activeUsers: number | string;
+      totalUsers: number | string;
+      features: number | string;
+      vacancies: number | string;
+    };
+    confidence: UpsellOpportunity['confidence'];
+  }[];
+  totalPotentialMrr: number | string;
+  highConfidence: number | string;
+  mediumConfidence: number | string;
+}): UpsellOpportunities {
+  return {
+    opportunities: raw.opportunities.map((o) => ({
+      orgId: o.orgId,
+      orgName: o.orgName,
+      currentPlan: o.currentPlan,
+      targetPlan: o.targetPlan,
+      mrrIncrease: Number(o.mrrIncrease),
+      reason: o.reason,
+      signals: {
+        activeUsers: Number(o.signals.activeUsers),
+        totalUsers: Number(o.signals.totalUsers),
+        features: Number(o.signals.features),
+        vacancies: Number(o.signals.vacancies),
+      },
+      confidence: o.confidence,
+    })),
+    totalPotentialMrr: Number(raw.totalPotentialMrr),
+    highConfidence: Number(raw.highConfidence),
+    mediumConfidence: Number(raw.mediumConfidence),
+  };
+}
+
+export function mapAiCostAnomalies(raw: {
+  anomalies: {
+    type: AiCostAnomaly['type'];
+    agentName: string;
+    agentSlug: string;
+    orgName: string;
+    orgId: string;
+    detail: string;
+    monthlyCost: number | string;
+    monthlyBudget: number | string | null;
+    potentialSavings: number | string;
+  }[];
+  totalPotentialSavings: number | string;
+  zeroUsageCount: number | string;
+  overBudgetCount: number | string;
+}): AiCostAnomalies {
+  return {
+    anomalies: raw.anomalies.map((a) => ({
+      type: a.type,
+      agentName: a.agentName,
+      agentSlug: a.agentSlug,
+      orgName: a.orgName,
+      orgId: a.orgId,
+      detail: a.detail,
+      monthlyCost: Number(a.monthlyCost),
+      // numberOrNull, NOT Number: null means "no budget configured", 0 is a real budget, and the
+      // anomaly rule (`monthlyBudget && cost > monthlyBudget`) treats those differently.
+      monthlyBudget: numberOrNull(a.monthlyBudget),
+      potentialSavings: Number(a.potentialSavings),
+    })),
+    totalPotentialSavings: Number(raw.totalPotentialSavings),
+    zeroUsageCount: Number(raw.zeroUsageCount),
+    overBudgetCount: Number(raw.overBudgetCount),
+  };
+}
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────────────────────
+// Each calls BOTH paths' hooks unconditionally (React rules of hooks) and returns the selected
+// one; the unselected query is `enabled: false` so it never fires a request.
+
+/** KPI tiles. GET /platform/dashboard/kpis. */
+export function useDashboardKpis() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getDashboardKpis.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<DashboardKpis>({
+    queryKey: ['platform-api', 'dashboard', 'kpis'],
+    queryFn: async () =>
+      mapDashboardKpis((await platformGetRaw('/platform/dashboard/kpis')) as Parameters<typeof mapDashboardKpis>[0]),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Needs-attention banner items. GET /platform/dashboard/attention-items. */
+export function useDashboardAttentionItems() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getAttentionItems.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<AttentionItem[]>({
+    queryKey: ['platform-api', 'dashboard', 'attention-items'],
+    queryFn: async () =>
+      ((await platformGetRaw('/platform/dashboard/attention-items')) as Parameters<typeof mapAttentionItem>[0][]).map(
+        mapAttentionItem,
+      ),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Per-org revenue table rows. GET /platform/dashboard/revenue-by-customer. */
+export function useDashboardRevenueByCustomer() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getRevenueByCustomer.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<RevenueByCustomerRow[]>({
+    queryKey: ['platform-api', 'dashboard', 'revenue-by-customer'],
+    queryFn: async () =>
+      (
+        (await platformGetRaw('/platform/dashboard/revenue-by-customer')) as Parameters<
+          typeof mapRevenueByCustomerRow
+        >[0][]
+      ).map(mapRevenueByCustomerRow),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Health grid rows. GET /platform/dashboard/customer-health. */
+export function useDashboardCustomerHealth() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getCustomerHealth.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<CustomerHealthRow[]>({
+    queryKey: ['platform-api', 'dashboard', 'customer-health'],
+    queryFn: async () =>
+      (
+        (await platformGetRaw('/platform/dashboard/customer-health')) as Parameters<typeof mapCustomerHealthRow>[0][]
+      ).map(mapCustomerHealthRow),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Recent orgs + users feed. GET /platform/dashboard/recent-activity. */
+export function useDashboardRecentActivity() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getRecentActivity.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<RecentActivityItem[]>({
+    queryKey: ['platform-api', 'dashboard', 'recent-activity'],
+    queryFn: async () =>
+      (
+        (await platformGetRaw('/platform/dashboard/recent-activity')) as Parameters<typeof mapRecentActivityItem>[0][]
+      ).map(mapRecentActivityItem),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Plan distribution donut. GET /platform/dashboard/plan-distribution. */
+export function useDashboardPlanDistribution() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getPlanDistribution.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<PlanDistributionRow[]>({
+    queryKey: ['platform-api', 'dashboard', 'plan-distribution'],
+    queryFn: async () =>
+      (
+        (await platformGetRaw('/platform/dashboard/plan-distribution')) as Parameters<
+          typeof mapPlanDistributionRow
+        >[0][]
+      ).map(mapPlanDistributionRow),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/**
+ * Global ⌘K search. GET /platform/dashboard/search?query=…
+ * The one input-bearing read; the caller gates firing (debounce + focus), so the hook accepts
+ * `opts.enabled` and BOTH paths AND it with the flag branch.
+ */
+export function useDashboardSearch(input: { query: string }, opts?: { enabled?: boolean }) {
+  const enabled = viaCSharp();
+  const callerEnabled = opts?.enabled ?? true;
+  const trpcQuery = trpc.platform.search.useQuery(input, { enabled: !enabled && callerEnabled });
+  const csharpQuery = useQuery<SearchResults>({
+    queryKey: ['platform-api', 'dashboard', 'search', input.query],
+    queryFn: async () =>
+      mapSearchResults(
+        (await platformGetRaw('/platform/dashboard/search', { query: input.query })) as Parameters<
+          typeof mapSearchResults
+        >[0],
+      ),
+    enabled: enabled && callerEnabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** 12-month MRR series. GET /platform/dashboard/mrr-trend. */
+export function useDashboardMrrTrend() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getMrrTrend.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<MrrTrendPoint[]>({
+    queryKey: ['platform-api', 'dashboard', 'mrr-trend'],
+    queryFn: async () =>
+      ((await platformGetRaw('/platform/dashboard/mrr-trend')) as Parameters<typeof mapMrrTrendPoint>[0][]).map(
+        mapMrrTrendPoint,
+      ),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Churn-risk panel. GET /platform/dashboard/churn-risk. */
+export function useDashboardChurnRisk() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getChurnRisk.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<ChurnRisk>({
+    queryKey: ['platform-api', 'dashboard', 'churn-risk'],
+    queryFn: async () => {
+      const raw = (await platformGetRaw('/platform/dashboard/churn-risk')) as {
+        organizations: Parameters<typeof mapChurnRiskOrg>[0][];
+        summary: {
+          green: number | string;
+          yellow: number | string;
+          red: number | string;
+          total: number | string;
+          atRiskMrr: number | string;
+        };
+      };
+      return {
+        organizations: raw.organizations.map(mapChurnRiskOrg),
+        summary: {
+          green: Number(raw.summary.green),
+          yellow: Number(raw.summary.yellow),
+          red: Number(raw.summary.red),
+          total: Number(raw.summary.total),
+          atRiskMrr: Number(raw.summary.atRiskMrr),
+        },
+      };
+    },
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** MRR forecast chart. GET /platform/dashboard/mrr-forecast. */
+export function useDashboardMrrForecast() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getMrrForecast.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<MrrForecast>({
+    queryKey: ['platform-api', 'dashboard', 'mrr-forecast'],
+    queryFn: async () =>
+      mapMrrForecast(
+        (await platformGetRaw('/platform/dashboard/mrr-forecast')) as Parameters<typeof mapMrrForecast>[0],
+      ),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** Upsell panel. GET /platform/dashboard/upsell-opportunities. */
+export function useDashboardUpsellOpportunities() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getUpsellOpportunities.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<UpsellOpportunities>({
+    queryKey: ['platform-api', 'dashboard', 'upsell-opportunities'],
+    queryFn: async () =>
+      mapUpsellOpportunities(
+        (await platformGetRaw('/platform/dashboard/upsell-opportunities')) as Parameters<
+          typeof mapUpsellOpportunities
+        >[0],
+      ),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}
+
+/** AI cost anomaly panel. GET /platform/dashboard/ai-cost-anomalies. */
+export function useDashboardAiCostAnomalies() {
+  const enabled = viaCSharp();
+  const trpcQuery = trpc.platform.getAiCostAnomalies.useQuery(undefined, { enabled: !enabled });
+  const csharpQuery = useQuery<AiCostAnomalies>({
+    queryKey: ['platform-api', 'dashboard', 'ai-cost-anomalies'],
+    queryFn: async () =>
+      mapAiCostAnomalies(
+        (await platformGetRaw('/platform/dashboard/ai-cost-anomalies')) as Parameters<typeof mapAiCostAnomalies>[0],
+      ),
+    enabled,
+  });
+  return enabled ? csharpQuery : trpcQuery;
+}

--- a/apps/web/lib/platform-api/schema.d.ts
+++ b/apps/web/lib/platform-api/schema.d.ts
@@ -564,6 +564,342 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/platform/organizations/kpis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformOrganizationKpis"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["ListPlatformOrganizations"];
+        put?: never;
+        post: operations["CreatePlatformOrganization"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/organizations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformOrganization"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["UpdatePlatformOrganization"];
+        trace?: never;
+    };
+    "/platform/invitations/kpis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformInvitationKpis"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["ListPlatformInvitations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/invitations/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["ExportPlatformInvitationsCsv"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/plan-distribution": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardPlanDistribution"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/user-growth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardUserGrowth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/recent-activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardRecentActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/attention-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardAttentionItems"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/mrr-trend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardMrrTrend"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/mrr-forecast": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardMrrForecast"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/customer-health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardCustomerHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/upsell-opportunities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardUpsellOpportunities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["SearchPlatformDashboard"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/kpis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardKpis"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/revenue-by-customer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardRevenueByCustomer"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/churn-risk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardChurnRisk"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/dashboard/ai-cost-anomalies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetPlatformDashboardAiCostAnomalies"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/platform/organizations/{id}/suspend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["SuspendPlatformOrganization"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/internal/alert-metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["GetAlertMetric"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/evaluation360/cycles": {
         parameters: {
             query?: never;
@@ -2092,6 +2428,15 @@ export interface components {
             percentage: null | number | string;
             suppressed: boolean;
         };
+        AlertMetricResponse: {
+            metric: string;
+            /** Format: uuid */
+            organizationId: string;
+            status: string;
+            /** Format: int32 */
+            value: null | number | string;
+            reason: null | string;
+        };
         AlertRow: {
             id: string;
             organizationId: string;
@@ -2475,6 +2820,13 @@ export interface components {
             status: string;
             /** Format: date-time */
             createdAt: unknown;
+        };
+        CreateOrganizationBody: {
+            name: string;
+            slug: string;
+            plan: string;
+            adminEmail: string;
+            billingEmail?: string;
         };
         CreateSurveyBody: {
             title: string;
@@ -3155,6 +3507,23 @@ export interface components {
             /** Format: date-time */
             endsAt: unknown;
         };
+        PlatformOrganizationRow: {
+            id: string;
+            name: string;
+            slug: string;
+            domain: null | string;
+            logo: null | string;
+            plan: string;
+            settings: null | components["schemas"]["JsonNode"];
+            billingEmail: null | string;
+            isActive: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: date-time */
+            deletedAt: null | string;
+        };
         PromotionEquityView: {
             /** Format: int32 */
             year: number | string;
@@ -3542,6 +3911,9 @@ export interface components {
             /** Format: date-time */
             updatedAt: unknown;
         };
+        SuspendOrganizationBody: {
+            suspend: boolean;
+        };
         TeamBusinessUnitView: {
             id: string;
             name: string;
@@ -3670,6 +4042,17 @@ export interface components {
         };
         UpdateCriticalRoleBandBody: {
             targetBandLevel: null | string;
+        };
+        UpdateOrganizationBody: {
+            name?: string;
+            plan?: string;
+            isActive?: boolean;
+            settings?: components["schemas"]["UpdateOrganizationSettingsBody"];
+        };
+        UpdateOrganizationSettingsBody: {
+            locale?: string;
+            timezone?: string;
+            currency?: string;
         };
         UpdateSuccessorReadinessBody: {
             readiness: string;
@@ -5120,6 +5503,833 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformOrganizationKpis: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ListPlatformOrganizations: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                page?: number | string;
+                limit?: number | string;
+                search?: string;
+                plan?: string;
+                status?: string;
+                sortBy?: string;
+                sortDir?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CreatePlatformOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOrganizationBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOrganizationRow"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UpdatePlatformOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateOrganizationBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOrganizationRow"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformInvitationKpis: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ListPlatformInvitations: {
+        parameters: {
+            query?: {
+                page?: string;
+                limit?: string;
+                type?: string;
+                status?: string;
+                search?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ExportPlatformInvitationsCsv: {
+        parameters: {
+            query?: {
+                type?: string;
+                status?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardPlanDistribution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardUserGrowth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardRecentActivity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardAttentionItems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardMrrTrend: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardMrrForecast: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardCustomerHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardUpsellOpportunities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    SearchPlatformDashboard: {
+        parameters: {
+            query: {
+                query: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardKpis: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardRevenueByCustomer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardChurnRisk: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetPlatformDashboardAiCostAnomalies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    SuspendPlatformOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SuspendOrganizationBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOrganizationRow"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GetAlertMetric: {
+        parameters: {
+            query?: {
+                organizationId?: string;
+                metric?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertMetricResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -346,14 +346,16 @@ year:'2-digit'` label format — `getMrrForecast`, `getCustomerHealth`, `getUpse
     rounds to EVEN (`(0.125).toFixed(2)` is "0.13" vs "0.12"), pinned in
     `PlatformDashboardAiUseCaseTests` against Node-verified values. **What keeps #81 open, counted
     against the issue's own step definitions** (a tier-3 panel corrected an earlier "code-complete at
-    steps 1–4" here): steps 1–4 are now done in full — step 4's `apps/web/lib/platform-api/
+    steps 1–4" here): steps 1–4 are now done — step 4's `apps/web/lib/platform-api/
 dashboard.ts` wrapper shipped 2026-08-17 behind `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP` (twelve
-    dual-path hooks; `getUserGrowth` deliberately has NO hook because it has zero apps/web consumers —
-    an orphan hook is the defect class the wiring tripwire catches — pinned by name in
-    `tests/platform/dashboard-fe-wiring.test.ts`, whose raw-tRPC scan still covers all thirteen);
-    step 5 (`verify dashboard`) has never run (#211) and the flip is Federico's — note a real cutover
-    now needs BOTH flags (`Platform:PlatformDashboardReadEnabled` server-side and the NEXT_PUBLIC one
-    at Vercel build time); step 7 (delete the TS) is open regardless. Three findings worth carrying forward from PR 2/3: (a) the
+    dual-path hooks covering every read that HAS a consumer; `getUserGrowth` deliberately has NO hook
+    because it has zero apps/web consumers — an orphan hook is the defect class the wiring tripwire
+    catches — pinned by name in `tests/platform/dashboard-fe-wiring.test.ts`, whose raw-tRPC scan
+    still covers all thirteen); step 5 (`verify dashboard`) has never run (#211) and the flip is
+    Federico's — note a real cutover needs the server flag (`Platform:PlatformDashboardReadEnabled`)
+    plus `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP` at Vercel build time, on top of the already-set
+    `NEXT_PUBLIC_TIMS_PLATFORM_API_URL` (three env conditions in total); step 7 (delete the TS) is
+    open regardless. Three findings worth carrying forward from PR 2/3: (a) the
     dashboard has a THIRD ICU/locale dependency, and it is environmental rather than versioned —
     `getAttentionItems` bakes `Number.toLocaleString()` with NO locale argument into an invoice
     description, so the deployed Node's default locale is part of the wire contract; (b) `getMrrTrend`

--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -346,10 +346,14 @@ year:'2-digit'` label format — `getMrrForecast`, `getCustomerHealth`, `getUpse
     rounds to EVEN (`(0.125).toFixed(2)` is "0.13" vs "0.12"), pinned in
     `PlatformDashboardAiUseCaseTests` against Node-verified values. **What keeps #81 open, counted
     against the issue's own step definitions** (a tier-3 panel corrected an earlier "code-complete at
-    steps 1–4" here): the BACKEND of steps 1–4 is done, but step 4's `apps/web/lib/platform-api/
-dashboard.ts` wrapper behind `NEXT_PUBLIC_…_VIA_CSHARP` exists for NONE of the thirteen reads;
-    step 5 (`verify dashboard`) has never run (#211) and the flip is Federico's; step 7 (delete the
-    TS) is open regardless. Three findings worth carrying forward from PR 2/3: (a) the
+    steps 1–4" here): steps 1–4 are now done in full — step 4's `apps/web/lib/platform-api/
+dashboard.ts` wrapper shipped 2026-08-17 behind `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP` (twelve
+    dual-path hooks; `getUserGrowth` deliberately has NO hook because it has zero apps/web consumers —
+    an orphan hook is the defect class the wiring tripwire catches — pinned by name in
+    `tests/platform/dashboard-fe-wiring.test.ts`, whose raw-tRPC scan still covers all thirteen);
+    step 5 (`verify dashboard`) has never run (#211) and the flip is Federico's — note a real cutover
+    now needs BOTH flags (`Platform:PlatformDashboardReadEnabled` server-side and the NEXT_PUBLIC one
+    at Vercel build time); step 7 (delete the TS) is open regardless. Three findings worth carrying forward from PR 2/3: (a) the
     dashboard has a THIRD ICU/locale dependency, and it is environmental rather than versioned —
     `getAttentionItems` bakes `Number.toLocaleString()` with NO locale argument into an invoice
     description, so the deployed Node's default locale is part of the wire contract; (b) `getMrrTrend`

--- a/docs/architecture/csharp-migration/phase-5-slice-23-final-ai-cost-anomalies.md
+++ b/docs/architecture/csharp-migration/phase-5-slice-23-final-ai-cost-anomalies.md
@@ -4,11 +4,13 @@
 > cluster — with it, **all thirteen of #81's reads are ported** and one flag
 > (`Platform:PlatformDashboardReadEnabled`) exposes the complete cluster.
 > **What #81 still needs, counted honestly (the panel corrected an earlier "steps 1–4 done"):**
-> the BACKEND half of steps 1–4 is done, but #81's own step-4 wording also requires an
-> `apps/web/lib/platform-api/dashboard.ts` FE wrapper behind `NEXT_PUBLIC_…_VIA_CSHARP`, which does
-> not exist for ANY of the thirteen reads (no slice-23 doc waived it — this sentence is the closest
-> thing); step 5 (`verify dashboard`) has NEVER run (#211) and the flip is Federico's; and step 7
-> (delete the TS) is open regardless.
+> ~~the step-4 FE wrapper does not exist for ANY of the thirteen reads~~ **RESOLVED 2026-08-17**:
+> `apps/web/lib/platform-api/dashboard.ts` shipped behind `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP` —
+> twelve dual-path hooks; `getUserGrowth` deliberately has no hook (zero apps/web consumers; the
+> exception is pinned by name in `tests/platform/dashboard-fe-wiring.test.ts`). What remains: step 5
+> (`verify dashboard`) has NEVER run (#211) and the flip is Federico's — a real cutover needs the
+> server flag above plus the `NEXT_PUBLIC_` pair at Vercel build time; and step 7 (delete the TS) is
+> open regardless.
 
 ## What shipped
 
@@ -151,8 +153,8 @@ dispositions:
   new deterministic repository test), **one recorded** (JsNow → UtcNow, sub-millisecond only).
 - **3 FALSE/OVERSTATED claims (claim auditor)** — the integration anchor ("1449/+2" vs measured
   1453/+6), "uniquely no datetime in this cluster", and "code-complete at steps 1–4" (the issue's
-  step-4 FE wrapper does not exist; step 7 is open regardless). **All three corrected in this doc
-  and REMAINING-WORK.md.** Every other audited claim — counts, pins, line refs, JS/.NET semantics —
+  step-4 FE wrapper did not exist then; it shipped 2026-08-17 — see the status block above — and
+  step 7 is open regardless). **All three corrected in this doc and REMAINING-WORK.md.** Every other audited claim — counts, pins, line refs, JS/.NET semantics —
   verified true, mostly by execution.
 
 **And a SECOND PASS then audited the fixes themselves** (a review pass creates new unreviewed text),

--- a/scripts/deploy/README-cutover.md
+++ b/scripts/deploy/README-cutover.md
@@ -29,7 +29,7 @@ executed.
 | `--rollback`     | Only with `--yes` | Same recipe, flips the flag back to `false`, plus prints the FE Vercel-revert steps.                         |
 
 Run `./scripts/deploy/cutover.sh --list` for the full surface table (flag name, parity CLI key, FE
-flag, and CONFIRMED LIVE / FLIP-READY / COEXISTENCE / TS DELETED status per
+flag, and CONFIRMED LIVE / FLIP-READY / COEXISTENCE / BLOCKED / TS DELETED status per
 [the runbook's §6 classification](../../docs/architecture/csharp-migration/PROD-DEPLOY-RUNBOOK-gate-g3.md#6-per-surface-cutover-one-flag-at-a-time-ts-stays-until-prod-verified)).
 
 ## Worked example: cutting over `engagement`
@@ -102,8 +102,8 @@ object) only models **9 of the ~24** `Platform:<Surface>Enabled` flags: `externa
 `external_vendor_write`, `billing_read`, `billing_usage`, `billing_webhook_write`,
 `billing_self_serve`, `reporting_read`, `validation_staff_write`, `team_intel_read`. It has **no
 field at all** for evaluation360, succession, compensation, nine-box, engagement, dei, audit-log,
-or access-review (read OR write) — 8 of this script's 12 read surfaces and all 6 of its write
-surfaces. Extending the module (new `optional(bool, false)` fields in `variables.tf` + wiring them
+access-review (read OR write), or the platform dashboard — 9 of this script's 13 read surfaces and
+all 6 of its write surfaces. Extending the module (new `optional(bool, false)` fields in `variables.tf` + wiring them
 into `main.tf`'s `local.base_env`) is real, deliberate infra work outside this script's scope.
 
 Rather than have the script silently behave differently per surface — Terraform for 4, raw AWS CLI
@@ -131,26 +131,27 @@ Cross-checked directly against `services/Tims.Platform/src/Tims.Api/Configuratio
 number) and independently corroborated by the `flag:` field in `scripts/parity/surfaces.ts` /
 `scripts/parity/write-surfaces.ts`.
 
-| Surface (this script) | Kind  | Backend flag                | Parity CLI invocation         | FE flag (`apps/web`)                         | Status                                                                      |
-| --------------------- | ----- | --------------------------- | ----------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
-| `team-intel`          | read  | `TeamIntelReadEnabled`      | `NONE` (TS router deleted)    | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `reporting`           | read  | `ReportingReadEnabled`      | `NONE` (TS router deleted)    | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
-| `billing-read`        | read  | `BillingReadEnabled`        | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
-| `billing-usage`       | read  | `BillingUsageEnabled`       | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
-| `evaluation360`       | read  | `Evaluation360ReadEnabled`  | `NONE` (TS router deleted)    | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
-| `succession`          | read  | `SuccessionReadEnabled`     | `NONE` (surface unregistered) | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | TS DELETED (surface unregistered #58 — verify is a no-op)                   |
-| `compensation`        | read  | `CompensationReadEnabled`   | `verify compensation`         | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
-| `nine-box`            | read  | `NineBoxReadEnabled`        | `verify ninebox`              | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
-| `engagement`          | read  | `EngagementReadEnabled`     | `verify engagement`           | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
-| `dei`                 | read  | `DeiReadEnabled`            | `verify dei`                  | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | TS DELETED (all 11; surface kept C#-only — see cutover.sh)                  |
-| `audit-log`           | read  | `AuditLogReadEnabled`       | `verify audit-log`            | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
-| `access-review`       | read  | `AccessReviewReadEnabled`   | `verify access-review`        | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
-| `evaluation360-write` | write | `Evaluation360WriteEnabled` | `verify-write evaluation360`  | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIPPED_AHEAD_OF_FLAG (ownership flipped while dark — see cutover.sh)       |
-| `succession-write`    | write | `SuccessionWriteEnabled`    | `verify-write succession`     | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
-| `nine-box-write`      | write | `NineBoxWriteEnabled`       | `verify-write ninebox`        | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
-| `compensation-write`  | write | `CompensationWriteEnabled`  | `verify-write compensation`   | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
-| `engagement-write`    | write | `EngagementWriteEnabled`    | `verify-write engagement`     | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
-| `access-review-write` | write | `AccessReviewWriteEnabled`  | `verify-write access-review`  | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | CONFIRMED LIVE (TS deleted; write surface tests C# directly, no TS dep)     |
+| Surface (this script) | Kind  | Backend flag                   | Parity CLI invocation         | FE flag (`apps/web`)                         | Status                                                                      |
+| --------------------- | ----- | ------------------------------ | ----------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
+| `team-intel`          | read  | `TeamIntelReadEnabled`         | `NONE` (TS router deleted)    | `NEXT_PUBLIC_TEAMINTEL_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `reporting`           | read  | `ReportingReadEnabled`         | `NONE` (TS router deleted)    | `NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP`      | TS DELETED                                                                  |
+| `billing-read`        | read  | `BillingReadEnabled`           | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_INVOICES_VIA_CSHARP`    | TS DELETED                                                                  |
+| `billing-usage`       | read  | `BillingUsageEnabled`          | `NONE` (TS router deleted)    | `NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP`       | TS DELETED                                                                  |
+| `evaluation360`       | read  | `Evaluation360ReadEnabled`     | `NONE` (TS router deleted)    | `NEXT_PUBLIC_EVALUATION360_READ_VIA_CSHARP`  | TS DELETED                                                                  |
+| `succession`          | read  | `SuccessionReadEnabled`        | `NONE` (surface unregistered) | `NEXT_PUBLIC_SUCCESSION_READ_VIA_CSHARP`     | TS DELETED (surface unregistered #58 — verify is a no-op)                   |
+| `compensation`        | read  | `CompensationReadEnabled`      | `verify compensation`         | `NEXT_PUBLIC_COMPENSATION_READ_VIA_CSHARP`   | CONFIRMED LIVE (partial TS deletion — 5/7 read procedures, see cutover.sh)  |
+| `nine-box`            | read  | `NineBoxReadEnabled`           | `verify ninebox`              | `NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP`        | TS DELETED (all 11 read procedures; surface kept C#-only — see cutover.sh)  |
+| `engagement`          | read  | `EngagementReadEnabled`        | `verify engagement`           | `NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP`     | CONFIRMED LIVE (partial TS deletion — 8/14 read procedures, see cutover.sh) |
+| `dei`                 | read  | `DeiReadEnabled`               | `verify dei`                  | `NEXT_PUBLIC_DEI_READ_VIA_CSHARP`            | TS DELETED (all 11; surface kept C#-only — see cutover.sh)                  |
+| `audit-log`           | read  | `AuditLogReadEnabled`          | `verify audit-log`            | `NEXT_PUBLIC_AUDIT_LOG_READ_VIA_CSHARP`      | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `access-review`       | read  | `AccessReviewReadEnabled`      | `verify access-review`        | `NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP`  | TS DELETED (surface re-registered C#-only 2026-08-11 — see below)           |
+| `dashboard`           | read  | `PlatformDashboardReadEnabled` | `verify dashboard`            | `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP`      | BLOCKED (step-5 `verify dashboard` never run, #211 — see cutover.sh)        |
+| `evaluation360-write` | write | `Evaluation360WriteEnabled`    | `verify-write evaluation360`  | `NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP` | FLIPPED_AHEAD_OF_FLAG (ownership flipped while dark — see cutover.sh)       |
+| `succession-write`    | write | `SuccessionWriteEnabled`       | `verify-write succession`     | `NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP`    | CONFIRMED LIVE                                                              |
+| `nine-box-write`      | write | `NineBoxWriteEnabled`          | `verify-write ninebox`        | `NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP`       | CONFIRMED LIVE                                                              |
+| `compensation-write`  | write | `CompensationWriteEnabled`     | `verify-write compensation`   | `NEXT_PUBLIC_COMPENSATION_WRITE_VIA_CSHARP`  | COEXISTENCE (flag live; both TS mutations deleted — see cutover.sh)         |
+| `engagement-write`    | write | `EngagementWriteEnabled`       | `verify-write engagement`     | `NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP`    | COEXISTENCE (flag live; 3 of 5 TS mutations deleted — see cutover.sh)       |
+| `access-review-write` | write | `AccessReviewWriteEnabled`     | `verify-write access-review`  | `NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP` | CONFIRMED LIVE (TS deleted; write surface tests C# directly, no TS dep)     |
 
 Run `./scripts/deploy/cutover.sh --list` for the per-surface long-form notes (why each is
 classified the way it is, and every naming quirk below).

--- a/scripts/deploy/cutover.sh
+++ b/scripts/deploy/cutover.sh
@@ -2,12 +2,12 @@
 # scripts/deploy/cutover.sh — per-domain "flip and verify" automation for the C# strangler-fig
 # production cutover (docs/architecture/csharp-migration/PROD-DEPLOY-RUNBOOK-gate-g3.md §6).
 #
-# SCOPE: the ~11 STANDARD domains that use the normal staff-JWT/browser-cookie auth pattern —
+# SCOPE: the STANDARD domains that use the normal staff-JWT/browser-cookie auth pattern —
 # team-intel, reporting, billing-read, billing-usage, evaluation360, succession, compensation,
-# nine-box, engagement, dei, audit-log, access-review, dashboard (13 read surfaces once the
-# read+write flags are counted separately — see --list). external-vendor, billing-webhook, and
-# billing-self-serve are OUT OF SCOPE (different auth mechanisms; separate workstream) and are
-# deliberately absent from the surface table below.
+# nine-box, engagement, dei, audit-log, access-review, dashboard. Counted as SURFACES (read and
+# write flags separately): 13 read + 6 write = 19 — see --list. external-vendor, billing-webhook,
+# and billing-self-serve are OUT OF SCOPE (different auth mechanisms; separate workstream) and
+# are deliberately absent from the surface table below.
 #
 # SAFETY MODEL (mirrors the runbook's "Federico-run" rule — nothing here touches AWS/prod unless
 # a human explicitly opts in):

--- a/scripts/deploy/cutover.sh
+++ b/scripts/deploy/cutover.sh
@@ -2,9 +2,9 @@
 # scripts/deploy/cutover.sh — per-domain "flip and verify" automation for the C# strangler-fig
 # production cutover (docs/architecture/csharp-migration/PROD-DEPLOY-RUNBOOK-gate-g3.md §6).
 #
-# SCOPE: the ~10 STANDARD domains that use the normal staff-JWT/browser-cookie auth pattern —
+# SCOPE: the ~11 STANDARD domains that use the normal staff-JWT/browser-cookie auth pattern —
 # team-intel, reporting, billing-read, billing-usage, evaluation360, succession, compensation,
-# nine-box, engagement, dei, audit-log, access-review (12 read/write-pair domains once the
+# nine-box, engagement, dei, audit-log, access-review, dashboard (13 read surfaces once the
 # read+write flags are counted separately — see --list). external-vendor, billing-webhook, and
 # billing-self-serve are OUT OF SCOPE (different auth mechanisms; separate workstream) and are
 # deliberately absent from the surface table below.
@@ -98,6 +98,9 @@ surface_row() {
     access-review)
       echo "read|AccessReviewReadEnabled|verify|access-review|NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP|TS_DELETED|Phase-5 Slice-18. UPDATE 2026-07-31: flag confirmed live in prod; all 3 registered TS read procedures (getAccessReview/exportAccessReviewCsv/listAccessReviewAttestations) have been deleted — the C# read path is the sole implementation now. UPDATE 2026-08-11: scripts/parity/surfaces.ts's 'access-review' entry was removed on 2026-07-31 and that removal is REVERSED — re-registered C#-only, so --verify-only runs a REAL check again. Same reading as the audit-log row above: [WEAK] parity (no TS side), REAL RBAC platform_owner-200/org_admin-403, RLS a documented N/A (globalScope, unchanged before and after). All 3 routes pin a fixed non-existent org id in organizationId; neither expectation depends on that org existing (the 403 precedes any org lookup, and BuildReportAsync has no org-exists precondition — only AttestAsync does). UPDATE 2026-07-31 (same day, continued): the write flag (access-review-write) was ALSO confirmed live and its TS side deleted the same session — with BOTH sides gone, the whole TS router (packages/api/src/routers/platform/access-review.ts + its schemas/service/repository) was removed outright, matching the team-intel/reporting precedent, unlike this entry's original note. Read side is efcoreReadOnly over Phase-2 identity tables (users/roles/user_roles/role_permissions/permissions/organizations); access_reviews itself stays Prisma-owned (the C# write is a coexistence write, not an ownership flip — see table-ownership.md)."
       ;;
+    dashboard)
+      echo "read|PlatformDashboardReadEnabled|verify|dashboard|NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP|BLOCKED|Phase-5 Slice 23 (issue #81; PRs #225/#233/#234/#237). All THIRTEEN platform-dashboard reads are deployed DARK behind this ONE flag; scripts/parity/surfaces.ts registers 'dashboard' with all 13 endpoints (the three FX reads — kpis/revenue-by-customer/churn-risk — are registered C#-only because the two stacks read DIFFERENT rate providers; the other ten carry real tsProcedures). FE wrapper apps/web/lib/platform-api/dashboard.ts shipped DARK 2026-08-17: twelve dual-path hooks; getUserGrowth has ZERO FE consumers so deliberately no hook (pinned by name in tests/platform/dashboard-fe-wiring.test.ts). BLOCKED on step 5: 'verify dashboard' has NEVER run against prod (#211) — run it fresh and PASS immediately before flipping, and mind the surface-header caveats in surfaces.ts (wall-clock month-boundary re-run situations; the recent-activity per-source take tie; the AI fixture's ~25-day decay). A real cutover needs THREE env conditions: Platform__PlatformDashboardReadEnabled=true on App Runner, NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP=true at Vercel BUILD time (NEXT_PUBLIC_* is inlined — a redeploy without rebuild changes nothing), on top of the already-set NEXT_PUBLIC_TIMS_PLATFORM_API_URL."
+      ;;
     evaluation360-write)
       echo "write|Evaluation360WriteEnabled|verify-write|evaluation360|NEXT_PUBLIC_EVALUATION360_WRITE_VIA_CSHARP|FLIPPED_AHEAD_OF_FLAG|Runbook §6 Phase B #8 — FLIP-READY. UPDATE 2026-07-28: this note used to say 'once verified, drop the TS eval360 router' as a pending future step — that's now DONE (packages/api/src/routers/evaluation360.ts + its FE fallback in apps/web/lib/platform-api/evaluation360.ts were deleted outright), independent of this flag's flip state. verify-write itself is UNAFFECTED by that deletion (scripts/parity/write-surfaces.ts's 'evaluation360' entry hits the C# API directly for RBAC/IDOR checks — it never depended on the TS router). Flipping Platform:Evaluation360WriteEnabled is still the pending step to move review_cycles/rater_assignments/rater_responses to efcore table-ownership. ⚠️ UPDATE 2026-08-06 (#67, runbook §7e): THE OWNERSHIP FLIP HAS BEEN EXECUTED WHILE THIS FLAG IS STILL DARK. review_cycles/rater_assignments/rater_responses are now efcore[] in docs/architecture/table-ownership.md. This DEVIATES from runbook §8 Q8 / precondition P1, which require the write flag confirmed live in prod before the flip PR opens — all three prior flips (access_reviews, critical_roles+successors, calibration_*) had CONFIRMED_LIVE write flags. Federico authorised the deviation explicitly on 2026-08-06 after it was raised. CONSEQUENCE, stated plainly: the TS router was deleted 2026-07-28 and its orphaned repository by #54, so with this flag dark these three tables currently have NO ACTIVE WRITER ON EITHER STACK. The ledger's efcore[] entry means C# is the sole IMPLEMENTATION and sole authority for future schema changes; it does not currently mean C# is writing. Flip this flag to make the ledger operationally true, then change this status to CONFIRMED_LIVE."
       ;;
@@ -122,7 +125,7 @@ surface_row() {
   esac
 }
 
-ALL_SURFACES="team-intel reporting billing-read billing-usage evaluation360 succession compensation nine-box engagement dei audit-log access-review evaluation360-write succession-write nine-box-write compensation-write engagement-write access-review-write"
+ALL_SURFACES="team-intel reporting billing-read billing-usage evaluation360 succession compensation nine-box engagement dei audit-log access-review dashboard evaluation360-write succession-write nine-box-write compensation-write engagement-write access-review-write"
 
 field() {
   # field <pipe-delimited-row> <index 1-based>
@@ -287,9 +290,10 @@ run_verify() {
 # the ~24 Platform:<Surface>Enabled flags — external_vendor_read/write, billing_read,
 # billing_usage, billing_webhook_write, billing_self_serve, reporting_read, validation_staff_write,
 # team_intel_read. It has NO field at all for evaluation360/succession/compensation/nine-box/
-# engagement/dei/audit-log/access-review (read OR write) — 8 of our 12 read surfaces and all 6 of
-# our write surfaces would need the module extended (new optional fields in variables.tf + wiring
-# in main.tf's local.base_env) before `terraform apply -target=aws_apprunner_service.api` could
+# engagement/dei/audit-log/access-review (read OR write) or the platform dashboard — 9 of our 13
+# read surfaces and all 6 of our write surfaces would need the module extended (new optional
+# fields in variables.tf + wiring in main.tf's local.base_env) before
+# `terraform apply -target=aws_apprunner_service.api` could
 # touch them at all. Rather than have this script special-case "4 surfaces via Terraform, 8+6 via
 # AWS CLI" (exactly the kind of inconsistency the task asks to avoid), it always uses the direct
 # `aws apprunner update-service` path — the one mechanism that works uniformly for every surface

--- a/tests/platform/dashboard-fe-coercion.test.ts
+++ b/tests/platform/dashboard-fe-coercion.test.ts
@@ -104,11 +104,13 @@ describe('mapChurnRiskOrg — null daysSinceLastLogin must never become "logged 
     // the coercion test nor tsc (the raw comes off an `as` cast), so a copy-paste like
     // `total: Number(raw.summary.red)` compiled and passed the whole suite. Extracted to
     // mapChurnRisk; DISTINCT values per field so a crossed wire cannot cancel out.
+    // total(17) ≠ green+yellow+red(15) on purpose: with 15 the test could not tell "read the
+    // total field" from "recompute it as the sum" — the second pass caught the coincidence.
     const out = mapChurnRisk({
       organizations: [base],
-      summary: { green: '7', yellow: '5', red: '3', total: '15', atRiskMrr: '998' },
+      summary: { green: '7', yellow: '5', red: '3', total: '17', atRiskMrr: '998' },
     });
-    expect(out.summary).toEqual({ green: 7, yellow: 5, red: 3, total: 15, atRiskMrr: 998 });
+    expect(out.summary).toEqual({ green: 7, yellow: 5, red: 3, total: 17, atRiskMrr: 998 });
     expect(out.organizations).toHaveLength(1);
     expect(out.organizations[0].daysSinceLastLogin).toBeNull();
   });

--- a/tests/platform/dashboard-fe-coercion.test.ts
+++ b/tests/platform/dashboard-fe-coercion.test.ts
@@ -20,6 +20,8 @@ import { describe, it, expect } from 'vitest';
 import {
   numberOrNull,
   numberOrUndefined,
+  toDate,
+  toDateOrNull,
   mapDashboardKpis,
   mapAttentionItem,
   mapRevenueByCustomerRow,
@@ -29,6 +31,7 @@ import {
   mapMrrTrendPoint,
   mapPlanDistributionRow,
   mapChurnRiskOrg,
+  mapChurnRisk,
   mapMrrForecast,
   mapUpsellOpportunities,
   mapAiCostAnomalies,
@@ -94,6 +97,29 @@ describe('mapChurnRiskOrg — null daysSinceLastLogin must never become "logged 
     expect(out.daysSinceLastLogin).toBe(3);
     expect(out.healthScore).toBe(35);
     expect(out.signals.adoptionScore).toBe(4);
+  });
+
+  it('mapChurnRisk coerces each SUMMARY counter off its OWN field', () => {
+    // The panel found the summary block living inline in the hook's queryFn — reachable by neither
+    // the coercion test nor tsc (the raw comes off an `as` cast), so a copy-paste like
+    // `total: Number(raw.summary.red)` compiled and passed the whole suite. Extracted to
+    // mapChurnRisk; DISTINCT values per field so a crossed wire cannot cancel out.
+    const out = mapChurnRisk({
+      organizations: [base],
+      summary: { green: '7', yellow: '5', red: '3', total: '15', atRiskMrr: '998' },
+    });
+    expect(out.summary).toEqual({ green: 7, yellow: 5, red: 3, total: 15, atRiskMrr: 998 });
+    expect(out.organizations).toHaveLength(1);
+    expect(out.organizations[0].daysSinceLastLogin).toBeNull();
+  });
+});
+
+describe('toDate / toDateOrNull — the exported helpers, directly', () => {
+  it('toDate parses an ISO string; toDateOrNull passes null AND undefined through as null', () => {
+    expect(toDate('2026-08-17T00:00:00.000Z').toISOString()).toBe('2026-08-17T00:00:00.000Z');
+    expect(toDateOrNull(null)).toBeNull();
+    expect(toDateOrNull(undefined)).toBeNull();
+    expect((toDateOrNull('2026-08-17T00:00:00.000Z') as Date).getTime()).toBeGreaterThan(0);
   });
 });
 

--- a/tests/platform/dashboard-fe-coercion.test.ts
+++ b/tests/platform/dashboard-fe-coercion.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * dashboard-fe-coercion.test.ts — Phase-5 slice 23 step 4 (issue #81).
+ *
+ * The platform-dashboard endpoints expose untyped 200s (`.Produces(200)` with no `<T>`), so the FE
+ * wrapper hand-types the wire and coerces every numeric back from the contract's
+ * `number | string` convention. Three of those fields are nullable with an INVERTED meaning at 0:
+ *
+ *   - churn-risk `daysSinceLastLogin`: null = "no login EVER", 0 = "logged in today".
+ *   - customer-health `signals.trialDaysLeft`: null = "not on a trial", 0 = "expires today".
+ *   - ai-cost-anomalies `monthlyBudget`: null = "no budget configured", 0 = a real zero budget —
+ *     and the TS anomaly rule (`monthlyBudget && cost > monthlyBudget`) treats them differently.
+ *
+ * `Number(null) === 0`, so a bare `Number()` on any of them fabricates the OPPOSITE reading.
+ * These exercise the REAL row mappers the hooks call (the hooks' inline mapping is unreachable
+ * from a unit test) — testing the helper alone would prove the helper works, not that the wrapper
+ * uses it. Same defect class and same layering as tests/monitoring/monitoring-fe-coercion.test.ts.
+ */
+import {
+  numberOrNull,
+  numberOrUndefined,
+  mapDashboardKpis,
+  mapAttentionItem,
+  mapRevenueByCustomerRow,
+  mapCustomerHealthRow,
+  mapRecentActivityItem,
+  mapSearchResults,
+  mapMrrTrendPoint,
+  mapPlanDistributionRow,
+  mapChurnRiskOrg,
+  mapMrrForecast,
+  mapUpsellOpportunities,
+  mapAiCostAnomalies,
+} from '../../apps/web/lib/platform-api/dashboard';
+
+describe('null-preserving helpers', () => {
+  it('numberOrNull preserves null and undefined as null, never 0 or NaN', () => {
+    expect(numberOrNull(null)).toBeNull();
+    expect(numberOrNull(undefined)).toBeNull();
+    expect(numberOrNull(null)).not.toBe(0);
+  });
+
+  it('numberOrUndefined lands both null (C# wire) and absent (tRPC) as undefined', () => {
+    // superjson hands the tRPC consumer `undefined` for a written-undefined key; the C# wire emits
+    // null for the same key. Both must collapse to undefined so the paths are indistinguishable.
+    expect(numberOrUndefined(null)).toBeUndefined();
+    expect(numberOrUndefined(undefined)).toBeUndefined();
+  });
+
+  it('both coerce the contract string form and pass a genuine 0 through', () => {
+    expect(numberOrNull('7')).toBe(7);
+    expect(numberOrNull(0)).toBe(0);
+    expect(numberOrUndefined('7')).toBe(7);
+    expect(numberOrUndefined(0)).toBe(0);
+  });
+
+  it('is distinguishable from a bare Number() on the null input — the bug, stated', () => {
+    expect(Number(null)).toBe(0);
+    expect(numberOrNull(null)).not.toBe(0);
+  });
+});
+
+describe('mapChurnRiskOrg — null daysSinceLastLogin must never become "logged in today"', () => {
+  const base = {
+    orgId: 'o1',
+    orgName: 'Acme',
+    plan: 'starter' as const,
+    mrr: '499',
+    healthScore: '35',
+    tier: 'red' as const,
+    totalUsers: '4',
+    loginRate: '0',
+    daysSinceLastLogin: null as number | string | null,
+    overdueInvoices: '2',
+    overdueAmount: '1200',
+    currency: 'USD',
+    overdueAmountConverted: false,
+    featureCount: '1',
+    primaryRisk: 'No login in 999 days',
+    risks: ['r'],
+    actions: ['a'],
+    signals: { loginScore: '0', invoiceScore: '0', recencyScore: '0', adoptionScore: '4', tenureScore: '2' },
+  };
+
+  it('null stays null (no login EVER) — a 0 would be the opposite end of the risk scale', () => {
+    const out = mapChurnRiskOrg(base);
+    expect(out.daysSinceLastLogin).toBeNull();
+    expect(out.daysSinceLastLogin).not.toBe(0);
+  });
+
+  it('a real recency coerces off the string form, and the score signals coerce too', () => {
+    const out = mapChurnRiskOrg({ ...base, daysSinceLastLogin: '3' });
+    expect(out.daysSinceLastLogin).toBe(3);
+    expect(out.healthScore).toBe(35);
+    expect(out.signals.adoptionScore).toBe(4);
+  });
+});
+
+describe('mapCustomerHealthRow — trialDaysLeft null must not read as "expires today"', () => {
+  const base = {
+    orgId: 'o1',
+    orgName: 'Acme',
+    plan: 'professional' as const,
+    health: 'healthy' as const,
+    signals: {
+      loginRate: '80',
+      overdueInvoices: '0',
+      trialDaysLeft: null as number | string | null,
+      daysSinceLastLogin: '999',
+    },
+  };
+
+  it('a non-trial org keeps trialDaysLeft null — 0 would light at_risk for every non-trial org', () => {
+    const out = mapCustomerHealthRow(base);
+    expect(out.signals.trialDaysLeft).toBeNull();
+    expect(out.signals.trialDaysLeft).not.toBe(0);
+  });
+
+  it('daysSinceLastLogin keeps the 999 no-login sentinel — the TS procedure keeps it on THIS wire', () => {
+    // Only churn-risk maps 999 → null; customer-health does not. Reproduce, don't improve.
+    expect(mapCustomerHealthRow(base).signals.daysSinceLastLogin).toBe(999);
+  });
+
+  it('a real trial coerces the string form', () => {
+    const out = mapCustomerHealthRow({ ...base, signals: { ...base.signals, trialDaysLeft: '4' } });
+    expect(out.signals.trialDaysLeft).toBe(4);
+  });
+});
+
+describe('mapAiCostAnomalies — a null budget is not a zero budget', () => {
+  const anomaly = {
+    type: 'zero_usage' as const,
+    agentName: 'CV Parser',
+    agentSlug: 'cv-parser',
+    orgName: 'Acme',
+    orgId: 'o1',
+    detail: 'Enabled but 0 calls in 30 days',
+    monthlyCost: '0',
+    monthlyBudget: null as number | string | null,
+    potentialSavings: '1.5',
+  };
+  const base = {
+    anomalies: [anomaly],
+    totalPotentialSavings: '1.5',
+    zeroUsageCount: '1',
+    overBudgetCount: '0',
+  };
+
+  it('null monthlyBudget stays null — the TS rule `monthlyBudget && cost > budget` treats 0 and null differently', () => {
+    const out = mapAiCostAnomalies(base);
+    expect(out.anomalies[0].monthlyBudget).toBeNull();
+    expect(out.anomalies[0].monthlyBudget).not.toBe(0);
+  });
+
+  it('a genuine zero budget stays 0, distinguishable from unconfigured', () => {
+    const out = mapAiCostAnomalies({ ...base, anomalies: [{ ...anomaly, monthlyBudget: 0 }] });
+    expect(out.anomalies[0].monthlyBudget).toBe(0);
+  });
+
+  it('the aggregate counters coerce off the string form', () => {
+    const out = mapAiCostAnomalies(base);
+    expect(out.totalPotentialSavings).toBe(1.5);
+    expect(out.zeroUsageCount).toBe(1);
+    expect(out.overBudgetCount).toBe(0);
+  });
+});
+
+describe('date reconstruction — the two datetime wires of the thirteen', () => {
+  it('mapRecentActivityItem reconstructs timestamp as a Date', () => {
+    const out = mapRecentActivityItem({
+      id: 'a1',
+      type: 'org_created',
+      title: 'Nueva organizacion: Acme',
+      timestamp: '2026-08-17T01:23:45.000Z',
+      meta: 'starter',
+    });
+    expect(out.timestamp).toBeInstanceOf(Date);
+    expect(out.timestamp.toISOString()).toBe('2026-08-17T01:23:45.000Z');
+  });
+
+  it('mapRevenueByCustomerRow reconstructs lastActiveAt as a Date', () => {
+    const out = mapRevenueByCustomerRow({
+      orgId: 'o1',
+      orgName: 'Acme',
+      plan: 'starter',
+      mrr: '499',
+      paidLast30d: '0',
+      outstandingAmount: '0',
+      currency: 'USD',
+      converted: false,
+      userCount: '3',
+      lastActiveAt: '2026-08-16T12:00:00.000Z',
+    });
+    expect(out.lastActiveAt).toBeInstanceOf(Date);
+    expect((out.lastActiveAt as Date).toISOString()).toBe('2026-08-16T12:00:00.000Z');
+  });
+
+  it('a NULL lastActiveAt stays null — never epoch 1970', () => {
+    // `new Date(null)` is 1970-01-01: a bare toDate() would render every never-logged-in org as
+    // "last active 56 years ago" instead of blank. Same failure shape as Number(null) === 0.
+    const out = mapRevenueByCustomerRow({
+      orgId: 'o1',
+      orgName: 'Acme',
+      plan: 'trial',
+      mrr: '0',
+      paidLast30d: '0',
+      outstandingAmount: '0',
+      currency: 'USD',
+      converted: false,
+      userCount: '0',
+      lastActiveAt: null,
+    });
+    expect(out.lastActiveAt).toBeNull();
+    expect(new Date(null as unknown as string).getTime()).toBe(0); // the bug, stated
+  });
+});
+
+describe('mapAttentionItem — optional-key normalization (C# null ≡ tRPC undefined)', () => {
+  const base = {
+    id: 'i1',
+    type: 'pending_invitation' as const,
+    severity: 'info' as const,
+    title: 'Invitacion sin aceptar - a@b.co',
+    description: 'Enviada hace 6 dias',
+    actionUrl: '/platform/invitations',
+    actionLabel: 'Reenviar',
+  };
+
+  it('a null orgId (org-less invitation on the C# wire) lands as undefined, like the tRPC path', () => {
+    const out = mapAttentionItem({ ...base, orgId: null, orgName: null });
+    expect(out.orgId).toBeUndefined();
+    expect(out.orgName).toBeUndefined();
+  });
+
+  it('absent amount/daysUntil stay undefined, never NaN or 0', () => {
+    const out = mapAttentionItem(base);
+    expect(out.amount).toBeUndefined();
+    expect(out.daysUntil).toBeUndefined();
+  });
+
+  it('a present amount coerces the string form, and a NEGATIVE daysUntil survives (overdue)', () => {
+    const out = mapAttentionItem({
+      ...base,
+      type: 'overdue_invoice',
+      severity: 'critical',
+      amount: '1200',
+      daysUntil: '-3',
+    });
+    expect(out.amount).toBe(1200);
+    expect(out.daysUntil).toBe(-3);
+  });
+});
+
+describe('remaining wires — spot coercions', () => {
+  it('mapDashboardKpis coerces numerics and passes outstandingRatesAsOf through as string | null', () => {
+    const out = mapDashboardKpis({
+      totalOrgs: '12',
+      totalOrgsChange: '2',
+      totalUsers: '300',
+      totalUsersChange: '25',
+      mrr: '4990',
+      mrrPrevMonth: '4491',
+      activeTrials: '3',
+      trialsExpiringThisWeek: '1',
+      overdueInvoices: '2',
+      outstandingAmount: '1200.5',
+      currency: 'USD',
+      outstandingConverted: true,
+      outstandingRatesAsOf: '2026-07-31',
+    });
+    expect(out.totalOrgs).toBe(12);
+    expect(out.outstandingAmount).toBe(1200.5);
+    // A string passthrough, NOT a Date: the tRPC path serves a string here too.
+    expect(out.outstandingRatesAsOf).toBe('2026-07-31');
+    expect(mapDashboardKpis({ ...out, outstandingRatesAsOf: null }).outstandingRatesAsOf).toBeNull();
+  });
+
+  it('mapSearchResults preserves avatar null and organization null (nullable, NOT optional-key)', () => {
+    const out = mapSearchResults({
+      organizations: [{ id: 'o1', name: 'Acme', slug: 'acme', plan: 'starter', isActive: true }],
+      users: [
+        {
+          id: 'u1',
+          firstName: 'Ana',
+          lastName: 'Diaz',
+          email: 'ana@acme.co',
+          isPlatformOwner: true,
+          isActive: true,
+          avatar: null,
+          organization: null,
+        },
+      ],
+      pages: [{ name: 'Dashboard', href: '/dashboard', keywords: 'inicio home panel' }],
+    });
+    expect(out.users[0].avatar).toBeNull();
+    expect(out.users[0].organization).toBeNull();
+    expect(out.organizations[0].plan).toBe('starter');
+    expect(out.pages[0].href).toBe('/dashboard');
+  });
+
+  it('mapMrrTrendPoint and mapPlanDistributionRow coerce the string form', () => {
+    expect(mapMrrTrendPoint({ month: 'ago 26', mrr: '4990' }).mrr).toBe(4990);
+    const row = mapPlanDistributionRow({ plan: 'starter', count: '4', percentage: '33' });
+    expect(row.count).toBe(4);
+    expect(row.percentage).toBe(33);
+  });
+
+  it('mapMrrForecast coerces planBreakdown values and keeps the historical/projected type literals', () => {
+    const out = mapMrrForecast({
+      historical: [{ month: 'sep 25', mrr: '3000', type: 'historical' }],
+      projected: [{ month: 'sep 26', mrr: '5500', type: 'projected' }],
+      currentMrr: '4990',
+      projectedMrr12m: '5500',
+      projectedArr: '66000',
+      monthlyGrowthPct: '1.2',
+      planBreakdown: { starter: { count: '4', mrr: '1996' } },
+      pendingTrials: '3',
+      potentialMrrFromTrials: '1497',
+    });
+    expect(out.historical[0]).toEqual({ month: 'sep 25', mrr: 3000, type: 'historical' });
+    expect(out.projected[0].type).toBe('projected');
+    expect(out.planBreakdown.starter).toEqual({ count: 4, mrr: 1996 });
+    expect(out.monthlyGrowthPct).toBe(1.2);
+  });
+
+  it('mapUpsellOpportunities coerces nested signals and the aggregate counters', () => {
+    const out = mapUpsellOpportunities({
+      opportunities: [
+        {
+          orgId: 'o1',
+          orgName: 'Acme',
+          currentPlan: 'starter',
+          targetPlan: 'professional',
+          mrrIncrease: '500',
+          reason: '8 users (threshold: 8)',
+          signals: { activeUsers: '6', totalUsers: '8', features: '5', vacancies: '3' },
+          confidence: 'high',
+        },
+      ],
+      totalPotentialMrr: '500',
+      highConfidence: '1',
+      mediumConfidence: '0',
+    });
+    expect(out.opportunities[0].mrrIncrease).toBe(500);
+    expect(out.opportunities[0].signals.activeUsers).toBe(6);
+    expect(out.totalPotentialMrr).toBe(500);
+  });
+});

--- a/tests/platform/dashboard-fe-hook-path-off.test.tsx
+++ b/tests/platform/dashboard-fe-hook-path-off.test.tsx
@@ -66,7 +66,10 @@ describe('flag OFF — every hook must return the tRPC branch and fire zero plat
     // And the tRPC branch is the ENABLED one (the complement of the C# branch).
     expect(trpcUseQuery).toHaveBeenCalledWith(undefined, { enabled: true });
     // The C# branch must not have fired a single request: `enabled: false` on the useQuery AND
-    // the platformGetRaw disabled-throw both sit between us and the network.
+    // the platformGetRaw disabled-throw both sit between us and the network. Flushed first —
+    // a fired queryFn awaits the token before fetch, so the synchronous form is vacuous (see the
+    // ON file's gate-CLOSED test for the mutation that proved it).
+    await new Promise((r) => setTimeout(r, 50));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -79,6 +82,7 @@ describe('flag OFF — every hook must return the tRPC branch and fire zero plat
     renderHook(() => useDashboardSearch({ query: 'ana' }, { enabled: true }), { wrapper: makeWrapper() });
     expect(trpcUseQuery).toHaveBeenLastCalledWith({ query: 'ana' }, { enabled: true });
 
+    await new Promise((r) => setTimeout(r, 50));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/platform/dashboard-fe-hook-path-off.test.tsx
+++ b/tests/platform/dashboard-fe-hook-path-off.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * dashboard-fe-hook-path-off.test.tsx — the FLAG-OFF half of the runtime hook-path pair.
+ *
+ * The tier-3 panel found that no test EXECUTED any wrapper hook: the coercion test imports
+ * mappers, the wiring test is a source-text scan, and every queryFn/`enabled` composition was
+ * covered by neither test nor compiler. This pair closes that at runtime for a representative
+ * hook plus the one input-bearing hook.
+ *
+ * TWO FILES, not one with vi.resetModules(): the flag is a module-level const, so switching it
+ * requires re-evaluating the wrapper module — but resetModules would also hand the wrapper a
+ * FRESH react/@tanstack/react-query instance while @testing-library keeps the old one, and two
+ * React instances break hooks outright. Instead each file sets the env BEFORE its dynamic
+ * import of the wrapper and vitest's per-file isolation keeps the two states apart.
+ */
+
+// Env must be decided before the wrapper module is first evaluated (both consts are read at
+// module scope). Base URL SET but flag UNSET: the base URL alone must not route to C#.
+process.env.NEXT_PUBLIC_TIMS_PLATFORM_API_URL = 'https://csharp.invalid';
+delete process.env.NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP;
+
+const trpcSentinel = { __branch: 'trpc' };
+const trpcUseQuery = vi.fn(() => trpcSentinel);
+vi.mock('../../apps/web/lib/trpc', () => ({
+  trpc: {
+    platform: new Proxy(
+      {},
+      {
+        get: () => ({ useQuery: trpcUseQuery }),
+      },
+    ),
+  },
+}));
+vi.mock('@tims/auth/client', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { getSession: async () => ({ data: { session: { access_token: 'test-token' } } }) },
+  }),
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  trpcUseQuery.mockClear();
+  fetchMock.mockClear();
+});
+
+describe('flag OFF — every hook must return the tRPC branch and fire zero platform-api requests', () => {
+  it('useDashboardKpis returns the tRPC query object and enables it', async () => {
+    const { useDashboardKpis } = await import('../../apps/web/lib/platform-api/dashboard');
+    const { result } = renderHook(() => useDashboardKpis(), { wrapper: makeWrapper() });
+
+    // The returned object IS the tRPC branch — not a react-query result wrapping it.
+    expect(result.current).toBe(trpcSentinel);
+    // And the tRPC branch is the ENABLED one (the complement of the C# branch).
+    expect(trpcUseQuery).toHaveBeenCalledWith(undefined, { enabled: true });
+    // The C# branch must not have fired a single request: `enabled: false` on the useQuery AND
+    // the platformGetRaw disabled-throw both sit between us and the network.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("useDashboardSearch forwards the caller's enabled gate to the tRPC branch", async () => {
+    const { useDashboardSearch } = await import('../../apps/web/lib/platform-api/dashboard');
+
+    renderHook(() => useDashboardSearch({ query: 'ana' }, { enabled: false }), { wrapper: makeWrapper() });
+    expect(trpcUseQuery).toHaveBeenLastCalledWith({ query: 'ana' }, { enabled: false });
+
+    renderHook(() => useDashboardSearch({ query: 'ana' }, { enabled: true }), { wrapper: makeWrapper() });
+    expect(trpcUseQuery).toHaveBeenLastCalledWith({ query: 'ana' }, { enabled: true });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/platform/dashboard-fe-hook-path-on.test.tsx
+++ b/tests/platform/dashboard-fe-hook-path-on.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * dashboard-fe-hook-path-on.test.tsx — the FLAG-ON half of the runtime hook-path pair.
+ * See dashboard-fe-hook-path-off.test.tsx's header for why this is a separate file.
+ *
+ * What only THIS file can prove (source-text pins cannot): with the flag on, a hook actually
+ * requests the expected C# URL with the session bearer token, routes the payload through its
+ * mapper (string-form numerics arrive as numbers), and the search hook's `callerEnabled` gate
+ * still suppresses the request — the panel's concrete post-cutover failure scenario was an
+ * empty-query search firing on every navbar render if `&& callerEnabled` were dropped from the
+ * C# branch, a mutation every other test in the suite survives.
+ */
+
+process.env.NEXT_PUBLIC_TIMS_PLATFORM_API_URL = 'https://csharp.test';
+process.env.NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP = 'true';
+
+const trpcSentinel = { __branch: 'trpc' };
+const trpcUseQuery = vi.fn(() => trpcSentinel);
+vi.mock('../../apps/web/lib/trpc', () => ({
+  trpc: {
+    platform: new Proxy(
+      {},
+      {
+        get: () => ({ useQuery: trpcUseQuery }),
+      },
+    ),
+  },
+}));
+vi.mock('@tims/auth/client', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { getSession: async () => ({ data: { session: { access_token: 'test-token' } } }) },
+  }),
+}));
+
+// String-form numerics on purpose: data arriving as numbers on the other side proves the hook
+// routed the payload through mapDashboardKpis at RUNTIME, not merely that the mapper is exported.
+const kpisPayload = {
+  totalOrgs: '12',
+  totalOrgsChange: '2',
+  totalUsers: '300',
+  totalUsersChange: '25',
+  mrr: '4990',
+  mrrPrevMonth: '4491',
+  activeTrials: '3',
+  trialsExpiringThisWeek: '1',
+  overdueInvoices: '2',
+  outstandingAmount: '1200.5',
+  currency: 'USD',
+  outstandingConverted: true,
+  outstandingRatesAsOf: null,
+};
+
+const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+  async () =>
+    new Response(JSON.stringify(kpisPayload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+);
+vi.stubGlobal('fetch', fetchMock);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  trpcUseQuery.mockClear();
+  fetchMock.mockClear();
+});
+
+describe('flag ON — the C# branch is the live one', () => {
+  it('useDashboardKpis requests the C# route with the bearer token and returns MAPPED data', async () => {
+    const { useDashboardKpis } = await import('../../apps/web/lib/platform-api/dashboard');
+    const { result } = renderHook(() => useDashboardKpis(), { wrapper: makeWrapper() });
+
+    // The tRPC branch is the disabled one now.
+    expect(trpcUseQuery).toHaveBeenCalledWith(undefined, { enabled: false });
+    expect(result.current).not.toBe(trpcSentinel);
+
+    await waitFor(() => expect((result.current as { data?: unknown }).data).toBeDefined());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://csharp.test/platform/dashboard/kpis');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
+
+    const data = (result.current as { data: Record<string, unknown> }).data;
+    // Coerced by the mapper: the wire sent '12' (string), the consumer must see 12 (number).
+    expect(data.totalOrgs).toBe(12);
+    expect(data.outstandingAmount).toBe(1200.5);
+    expect(data.outstandingRatesAsOf).toBeNull();
+  });
+
+  it("useDashboardSearch with the caller's gate CLOSED fires nothing, even with the flag on", async () => {
+    const { useDashboardSearch } = await import('../../apps/web/lib/platform-api/dashboard');
+    renderHook(() => useDashboardSearch({ query: '' }, { enabled: false }), { wrapper: makeWrapper() });
+
+    // The panel's scenario: drop `&& callerEnabled` from the C# branch and the navbar fires an
+    // empty-query search on every render of every admin page. This is the runtime kill for it.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(trpcUseQuery).toHaveBeenLastCalledWith({ query: '' }, { enabled: false });
+  });
+
+  it("useDashboardSearch with the caller's gate OPEN requests the search route with the term", async () => {
+    const { useDashboardSearch } = await import('../../apps/web/lib/platform-api/dashboard');
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ organizations: [], users: [], pages: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const { result } = renderHook(() => useDashboardSearch({ query: 'ana' }, { enabled: true }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect((result.current as { data?: unknown }).data).toBeDefined());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://csharp.test/platform/dashboard/search?query=ana');
+  });
+});

--- a/tests/platform/dashboard-fe-hook-path-on.test.tsx
+++ b/tests/platform/dashboard-fe-hook-path-on.test.tsx
@@ -101,6 +101,12 @@ describe('flag ON — the C# branch is the live one', () => {
 
     // The panel's scenario: drop `&& callerEnabled` from the C# branch and the navbar fires an
     // empty-query search on every render of every admin page. This is the runtime kill for it.
+    //
+    // The flush is LOAD-BEARING: a fired queryFn awaits getAccessToken() before fetch, so a
+    // synchronous not-called assertion passes even against the mutation — proven by running that
+    // exact mutation and watching only the text pin go red. The gate-OPEN test below is this
+    // file's positive control that fetch observation works at all.
+    await new Promise((r) => setTimeout(r, 50));
     expect(fetchMock).not.toHaveBeenCalled();
     expect(trpcUseQuery).toHaveBeenLastCalledWith({ query: '' }, { enabled: false });
   });

--- a/tests/platform/dashboard-fe-wiring.test.ts
+++ b/tests/platform/dashboard-fe-wiring.test.ts
@@ -207,6 +207,25 @@ describe('dashboard FE wiring — the C# surface must be REACHABLE', () => {
     expect(wrapperSrc).not.toMatch(/daysUntil: Number\(/);
   });
 
+  it("useDashboardSearch composes the caller's gate into BOTH branches", () => {
+    // The panel's post-cutover failure scenario: drop `&& callerEnabled` from the C# branch and
+    // the navbar fires an empty-query cross-tenant search on every render of every admin page —
+    // and with the flag OFF that mutation is inert, which is exactly why it would survive review.
+    // The runtime kill lives in dashboard-fe-hook-path-on.test.tsx; these are the wide text pins.
+    expect(wrapperSrc).toMatch(/enabled: !enabled && callerEnabled/);
+    expect(wrapperSrc).toMatch(/enabled: enabled && callerEnabled/);
+  });
+
+  it('the 12 react-query keys are unique — a copy-pasted key cross-contaminates the cache', () => {
+    // react-query serves whichever payload is cached under the key, so two hooks sharing one key
+    // would silently hand one endpoint's data to the other's consumer. Uniqueness of PORTED_READS
+    // and of path literals is already pinned; the key set was the unpinned third leg.
+    const keys = [...wrapperSrc.matchAll(/queryKey: (\[[^\]]*\])/g)].map((m) => m[1]);
+    expect(keys).toHaveLength(12);
+    expect(new Set(keys).size).toBe(keys.length);
+    keys.forEach((k) => expect(k).toMatch(/^\['platform-api', 'dashboard', '/));
+  });
+
   it('every wrapper hook has at least one real consumer', () => {
     // The direct anti-"zero consumers" assertion. A hook nobody calls means that slice of the C#
     // surface is unreachable no matter what the env flag says.

--- a/tests/platform/dashboard-fe-wiring.test.ts
+++ b/tests/platform/dashboard-fe-wiring.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+// #81 step 4 — the platform-dashboard FE consumer tripwire, adapted from
+// tests/monitoring/monitoring-fe-wiring.test.ts (#100 / PR #140).
+//
+// WHY THIS EXISTS. The monitoring C# surface once shipped six wrapper hooks with ZERO consumers:
+// every live call site still went straight to tRPC, so the cutover flag was INERT and nothing in
+// the suite noticed — a hook with no callers still compiles, still type-checks, and still has
+// passing unit tests. This file pins the same invariants for the dashboard cluster: not "does the
+// wrapper work" but "is the wrapper WIRED".
+//
+// TWO dashboard-specific differences from the monitoring original:
+//
+//   1. The read set spans FOUR router files (dashboard.ts + its churn/forecast/upsell siblings),
+//      all merged FLAT into `platformRouter` — consumers call `trpc.platform.<proc>`, with no
+//      `.dashboard.` segment. The derivation walks all four, and is from the ROUTERS, not the
+//      wrapper: a wrapper-derived set can only see already-ported reads (the tier-3 finding on the
+//      first monitoring version).
+//
+//   2. THIRTEEN router reads, TWELVE hooks, deliberately. `getUserGrowth` has zero consumers
+//      anywhere in apps/web (no user-growth chart exists), so a hook for it would itself be the
+//      orphan this file exists to catch. The exception is pinned BY NAME below; the raw-tRPC scan
+//      still quantifies over all thirteen, so the day a user-growth consumer appears it must come
+//      through a new wrapper hook — adding it then is the wired path, not an exemption.
+//
+// EXTRA PIN this surface needs and monitoring did not: the wrapper calls `platformGetRaw`, whose
+// path argument is UNTYPED (every dashboard endpoint declares `.Produces(200)` without `<T>`, so
+// the OpenAPI 200 carries no body type and the typed `platformGet` cannot accept these paths).
+// A typo'd path compiles clean and 404s at runtime — so every path literal in the wrapper is
+// cross-checked against contracts/openapi/Tims.Api.json, the same contract CI keeps in sync with
+// the C# routes.
+
+const ROOT = join(__dirname, '..', '..');
+const WEB = 'apps/web';
+const WRAPPER = `${WEB}/lib/platform-api/dashboard.ts`;
+const ROUTER_FILES = [
+  'packages/api/src/routers/platform/dashboard.ts',
+  'packages/api/src/routers/platform/dashboard-churn.ts',
+  'packages/api/src/routers/platform/dashboard-forecast.ts',
+  'packages/api/src/routers/platform/dashboard-upsell.ts',
+];
+const CONTRACT = 'contracts/openapi/Tims.Api.json';
+/** The one router read with no apps/web consumer and therefore, deliberately, no hook. */
+const UNPORTED = ['getUserGrowth'];
+/** A file that must exist under the walk root — a sentinel floor guard, not a bare count. */
+const SENTINEL = `${WEB}/app/(admin)/dashboard/platform-dashboard.tsx`;
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.claude',
+  '.next',
+  '.turbo',
+  '.vercel',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+]);
+
+function walk(rel: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(join(ROOT, rel));
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (SKIP_DIRS.has(name)) continue;
+    const childRel = `${rel}/${name}`;
+    let st;
+    try {
+      st = statSync(join(ROOT, childRel));
+    } catch {
+      continue; // broken symlink
+    }
+    if (st.isDirectory()) walk(childRel, out);
+    else if (/\.(ts|tsx)$/.test(name)) out.push(childRel);
+  }
+}
+
+const FILES: string[] = [];
+walk(WEB, FILES);
+const SOURCES = FILES.map((file) => ({ file, text: readFileSync(join(ROOT, file), 'utf8') }));
+const wrapperSrc = readFileSync(join(ROOT, WRAPPER), 'utf8');
+
+/**
+ * Every READ across the four dashboard routers — a `platformProcedure` whose builder chain ends in
+ * `.query(`. Split on the procedure-name boundary rather than brace-matching, for the same reason
+ * the monitoring original does: `search` has an `.input(...)` link so the procedures do not share
+ * a closing indent, and a brace-matching regex silently swallowed the next procedure there.
+ */
+const ROUTER_READS = ROUTER_FILES.flatMap((rel) => {
+  const src = readFileSync(join(ROOT, rel), 'utf8');
+  const starts = [...src.matchAll(/^ {2}(\w+): platformProcedure/gm)];
+  return starts
+    .filter((m, i) => /\.query\(/.test(src.slice(m.index!, starts[i + 1]?.index ?? src.length)))
+    .map((m) => m[1]);
+});
+
+/** The reads the wrapper offers a C# path for — off its own tRPC-fallback branch. */
+const PORTED_READS = [...wrapperSrc.matchAll(/trpc\.platform\.(\w+)\.useQuery/g)].map((m) => m[1]);
+
+/** The hooks the wrapper exposes. */
+const HOOKS = [...wrapperSrc.matchAll(/export function (useDashboard\w+)/g)].map((m) => m[1]);
+
+/** The C# routes for this cluster, straight from the committed OpenAPI contract. */
+const CONTRACT_PATHS = Object.keys(
+  (JSON.parse(readFileSync(join(ROOT, CONTRACT), 'utf8')) as { paths: Record<string, unknown> }).paths,
+).filter((p) => p.startsWith('/platform/dashboard/'));
+
+describe('dashboard FE wiring — the C# surface must be REACHABLE', () => {
+  // Floor guards. Every assertion below quantifies over these sets; a derivation that silently
+  // returned nothing would make the whole file pass vacuously. Counts are pinned EXACTLY as a
+  // change-detector: porting a fourteenth read (or wiring getUserGrowth) must bring a human here.
+  it('the walker and every derivation found what they should have', () => {
+    expect(FILES).toContain(SENTINEL);
+    expect(FILES.length).toBeGreaterThan(100);
+    expect(ROUTER_READS).toHaveLength(13);
+    expect(PORTED_READS).toHaveLength(12);
+    expect(HOOKS).toHaveLength(12);
+    expect(CONTRACT_PATHS).toHaveLength(13);
+    // No duplicates: two hooks falling back to the same read would keep the length at 12 while
+    // leaving one real read uncovered by the offenders scan below.
+    expect(new Set(PORTED_READS).size).toBe(PORTED_READS.length);
+    expect(new Set(ROUTER_READS).size).toBe(ROUTER_READS.length);
+  });
+
+  it('the wrapper covers every router read EXCEPT the pinned no-consumer exception', () => {
+    const uncovered = ROUTER_READS.filter((r) => !PORTED_READS.includes(r)).sort();
+    // getUserGrowth: zero consumers in apps/web, so a hook would be an orphan (the defect class
+    // this file catches). The C# endpoint exists and stays parity-covered; only the FE hook is
+    // deliberately absent. If this assertion fails with an EMPTY array, someone wired user-growth
+    // — delete the exception. If it fails with MORE names, reads were added without hooks.
+    expect(uncovered).toEqual([...UNPORTED].sort());
+    expect(PORTED_READS.filter((r) => UNPORTED.includes(r))).toEqual([]);
+  });
+
+  it('every router read is consumed ONLY through the wrapper, never raw tRPC', () => {
+    // Quantified over ALL THIRTEEN router reads, not the twelve ported ones: an unported read
+    // consumed raw (the future user-growth chart) is precisely the regression this must catch.
+    const offenders: string[] = [];
+    for (const { file, text } of SOURCES) {
+      if (file === WRAPPER) continue;
+      for (const read of ROUTER_READS) {
+        // Both spellings — the direct hook call and the `trpc.useUtils()` cache methods
+        // (`.fetch()` / `.ensureData()` / `.prefetch()` re-orphan the wrapper just as effectively).
+        // `.invalidate()` alone is exempt, on the METHOD not the file, matching the monitoring
+        // precedent: a future write's onSuccess may legitimately invalidate the tRPC family.
+        if (new RegExp(`trpc\\.platform\\.${read}\\b`).test(text)) offenders.push(`${file} → trpc.${read}`);
+        const utilsMisuse = new RegExp(`utils\\.platform\\.${read}\\.(?!invalidate\\b)(\\w+)`).exec(text);
+        if (utilsMisuse) offenders.push(`${file} → utils.${read}.${utilsMisuse[1]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every platformGetRaw path literal exists in the OpenAPI contract', () => {
+    // THE pin for the untyped-path hazard: platformGetRaw paths are not compile-checked, so a
+    // typo'd literal compiles clean and 404s at runtime. The contract is regenerated from the C#
+    // routes by CI ("OpenAPI contract is up to date"), so agreement here means agreement with the
+    // deployed route table.
+    const used = [...wrapperSrc.matchAll(/platformGetRaw\(\s*'([^']+)'/g)].map((m) => m[1]);
+    expect(used).toHaveLength(12);
+    expect(new Set(used).size).toBe(used.length);
+    const unknown = used.filter((p) => !CONTRACT_PATHS.includes(p));
+    expect(unknown).toEqual([]);
+    // And the inverse: the only contract route the wrapper does not call is the pinned exception.
+    const uncalled = CONTRACT_PATHS.filter((p) => !used.includes(p));
+    expect(uncalled).toEqual(['/platform/dashboard/user-growth']);
+  });
+
+  it('the C# branch is reachable at all — the flag must keep its NEXT_PUBLIC_ prefix', () => {
+    // Proven by mutation on the monitoring twin (2026-08-09): dropping the prefix makes Next.js
+    // stop inlining the value into the client bundle, `viaCSharp()` is permanently false, and the
+    // cutover flag flip changes nothing — while every other assertion here stays green.
+    expect(wrapperSrc).toMatch(/process\.env\.NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP === 'true'/);
+    // The gate is BOTH conditions: a base URL and the per-surface flag.
+    expect(wrapperSrc).toMatch(/isPlatformApiEnabled\(\)\s*&&\s*DASHBOARD_READ_VIA_CSHARP/);
+    // Any client-read env var here must carry the prefix, or it silently reads `undefined` in the
+    // browser. Derived over every `process.env.X` in the file rather than pinning the one name.
+    const envReads = [...wrapperSrc.matchAll(/process\.env\.(\w+)/g)].map((m) => m[1]);
+    expect(envReads.length).toBeGreaterThan(0);
+    expect(envReads.filter((v) => !v.startsWith('NEXT_PUBLIC_'))).toEqual([]);
+  });
+
+  it('the three inverted-at-zero fields route through the null-preserving mappers', () => {
+    // `number` widens silently into `number | null`, so tsc does NOT catch a bare Number() on
+    // these — unlike the two Date fields, where Date vs string makes the compiler the enforcer.
+    // (Mutation-proved on the monitoring twin, 2026-08-09; same widening, same silence.)
+    expect(wrapperSrc).toMatch(/monthlyBudget: numberOrNull\(/);
+    expect(wrapperSrc).not.toMatch(/monthlyBudget: Number\(/);
+    expect(wrapperSrc).toMatch(/trialDaysLeft: numberOrNull\(/);
+    expect(wrapperSrc).not.toMatch(/trialDaysLeft: Number\(/);
+    // daysSinceLastLogin appears on TWO wires with DIFFERENT rules, so neither a bare positive
+    // nor a bare negative assertion can pin it. churn-risk null-preserves (null = no login ever);
+    // customer-health keeps the raw 999 sentinel (the TS procedure does). Exactly one of each —
+    // a count of one apiece means neither mapper absorbed the other's rule.
+    expect(wrapperSrc.match(/daysSinceLastLogin: numberOrNull\(/g)).toHaveLength(1);
+    expect(wrapperSrc.match(/daysSinceLastLogin: Number\(/g)).toHaveLength(1);
+    // The optional-key numerics must not collapse null/absent to NaN-vs-0 asymmetry either.
+    expect(wrapperSrc).toMatch(/amount: numberOrUndefined\(/);
+    expect(wrapperSrc).toMatch(/daysUntil: numberOrUndefined\(/);
+    expect(wrapperSrc).not.toMatch(/amount: Number\(/);
+    expect(wrapperSrc).not.toMatch(/daysUntil: Number\(/);
+  });
+
+  it('every wrapper hook has at least one real consumer', () => {
+    // The direct anti-"zero consumers" assertion. A hook nobody calls means that slice of the C#
+    // surface is unreachable no matter what the env flag says.
+    const unconsumed = HOOKS.filter(
+      (hook) => !SOURCES.some(({ file, text }) => file !== WRAPPER && new RegExp(`\\b${hook}\\s*\\(`).test(text)),
+    );
+    expect(unconsumed).toEqual([]);
+  });
+
+  it('every hook is still dual-path — the flag must remain a reversible switch', () => {
+    // The cutover contract: each hook calls BOTH paths and returns the selected one, so the flag
+    // can be flipped back without a code change. A hook rewritten to call only the C# path would
+    // make NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP one-way.
+    expect(PORTED_READS).toHaveLength(HOOKS.length);
+    const returns = wrapperSrc.match(/return enabled \? csharpQuery : trpcQuery;/g) ?? [];
+    expect(returns).toHaveLength(HOOKS.length);
+  });
+
+  it('no invalidation helper, deliberately — and nothing needs one', () => {
+    // The dashboard cluster is read-only: no write was ported and no tRPC mutation's onSuccess
+    // touches these reads. If either side of that changes, this pin forces the monitoring
+    // treatment (dual-family invalidation) instead of a silent stale-cache-after-cutover.
+    expect(wrapperSrc).not.toMatch(/invalidateQueries/);
+    const invalidators: string[] = [];
+    for (const { file, text } of SOURCES) {
+      for (const read of ROUTER_READS) {
+        if (new RegExp(`utils\\.platform\\.${read}\\.invalidate\\(`).test(text)) {
+          invalidators.push(`${file} → utils.${read}.invalidate`);
+        }
+      }
+    }
+    expect(invalidators).toEqual([]);
+  });
+});

--- a/tests/security/i18n-no-hardcoded-strings.test.ts
+++ b/tests/security/i18n-no-hardcoded-strings.test.ts
@@ -49,11 +49,14 @@ const EXCLUDE_PATHS = ['apps/web/app/(admin)/platform/email-preview/'];
 // now anchored to each branch's own line, but a jsx-text and a ternary vector
 // could still coincide), so the vector disambiguates them.
 const KNOWN_DEBT = new Set<string>([
-  'apps/web/app/(admin)/dashboard/activity-feed.tsx:106:ternary',
-  'apps/web/app/(admin)/dashboard/charts/customer-health.tsx:50:jsx-text',
-  'apps/web/app/(admin)/dashboard/charts/plan-distribution.tsx:98:jsx-text',
-  'apps/web/app/(admin)/dashboard/charts/revenue-by-customer.tsx:72:jsx-text',
-  'apps/web/app/(admin)/dashboard/customer-table.tsx:168:jsx-text',
+  // The five dashboard entries below were re-anchored 2026-08-17: the #81 step-4 FE-wrapper
+  // rewiring ran prettier over these files and shifted the (unchanged, still-grandfathered)
+  // strings to new lines. Same debt, same text, new anchors.
+  'apps/web/app/(admin)/dashboard/activity-feed.tsx:113:ternary',
+  'apps/web/app/(admin)/dashboard/charts/customer-health.tsx:49:jsx-text',
+  'apps/web/app/(admin)/dashboard/charts/plan-distribution.tsx:87:jsx-text',
+  'apps/web/app/(admin)/dashboard/charts/revenue-by-customer.tsx:63:jsx-text',
+  'apps/web/app/(admin)/dashboard/customer-table.tsx:161:jsx-text',
   'apps/web/app/(admin)/people/onboarding/onboarding-panels.tsx:106:ternary',
   'apps/web/app/(admin)/people/onboarding/onboarding-panels.tsx:167:jsx-text',
   'apps/web/app/(admin)/people/onboarding/onboarding-panels.tsx:185:jsx-text',
@@ -160,7 +163,9 @@ function looksLikeClassName(t: string): boolean {
   const allClassShaped = tokens.every((tok) => /^[a-zA-Z0-9:/#.\-[\]]+$/.test(tok));
   if (!allClassShaped) return false;
   return tokens.some((tok) =>
-    /^(bg-|text-|border|w-|h-|p[xytlbr]?-|m[xytlbr]?-|rounded|flex|grid|hover:|focus:|active:|disabled:|shadow|gap-|space-|items-|justify-|transition|opacity-|cursor-|absolute|relative|inline|block|font-|leading-|tracking-|z-|overflow-|max-w|min-w)/.test(tok),
+    /^(bg-|text-|border|w-|h-|p[xytlbr]?-|m[xytlbr]?-|rounded|flex|grid|hover:|focus:|active:|disabled:|shadow|gap-|space-|items-|justify-|transition|opacity-|cursor-|absolute|relative|inline|block|font-|leading-|tracking-|z-|overflow-|max-w|min-w)/.test(
+      tok,
+    ),
   );
 }
 
@@ -209,7 +214,12 @@ function looksLikeProse(s: string): boolean {
   return /\s/.test(t) || /[áéíóúñ¿¡ÁÉÍÓÚÑ]/.test(t);
 }
 
-interface Violation { file: string; line: number; vector: string; text: string }
+interface Violation {
+  file: string;
+  line: number;
+  vector: string;
+  text: string;
+}
 
 function scanFile(rel: string): Violation[] {
   const src = readFileSync(resolve(ROOT, rel), 'utf8');
@@ -254,7 +264,7 @@ function scanFile(rel: string): Violation[] {
   // per-line scan (the prior implementation) can never see. Uses `d` (indices)
   // so the reported line is where the TEXT itself starts (after skipping the
   // tag's `>` and any leading whitespace/newlines), not the tag's own line.
-  const textRe = />\s*([^<>{}][^<>{}]*?)\s*</gd;
+  const textRe = />\s*([^<>{}][^<>{}]*?)\s*</dg;
   let tm: RegExpExecArray | null;
   while ((tm = textRe.exec(src)) !== null) {
     const txt = tm[1]!.trim();
@@ -270,12 +280,14 @@ function scanFile(rel: string): Violation[] {
   // Uses `d` (indices) so each branch reports ITS OWN line, not the `?` line
   // (a multiline ternary otherwise gets both branches mis-anchored to the
   // condition's line).
-  const ternaryRe = /\?\s*(['"])((?:(?!\1)[\s\S])*?)\1\s*:\s*(['"])((?:(?!\3)[\s\S])*?)\3/gd;
+  const ternaryRe = /\?\s*(['"])((?:(?!\1)[\s\S])*?)\1\s*:\s*(['"])((?:(?!\3)[\s\S])*?)\3/dg;
   let nm: RegExpExecArray | null;
   while ((nm = ternaryRe.exec(src)) !== null) {
     const indices = (nm as unknown as { indices: Array<[number, number] | undefined> }).indices;
-    if (looksLikeProse(nm[2]!)) out.push({ file: rel, line: lineForIndex(offsets, indices[2]![0]), vector: 'ternary', text: nm[2]! });
-    if (looksLikeProse(nm[4]!)) out.push({ file: rel, line: lineForIndex(offsets, indices[4]![0]), vector: 'ternary', text: nm[4]! });
+    if (looksLikeProse(nm[2]!))
+      out.push({ file: rel, line: lineForIndex(offsets, indices[2]![0]), vector: 'ternary', text: nm[2]! });
+    if (looksLikeProse(nm[4]!))
+      out.push({ file: rel, line: lineForIndex(offsets, indices[4]![0]), vector: 'ternary', text: nm[4]! });
   }
 
   return out;
@@ -288,14 +300,17 @@ function scanFile(rel: string): Violation[] {
 // scanner newly catches, add the file:line to KNOWN_DEBT with a reason —
 // don't widen ALLOWLIST for that (it would hide the same string everywhere).
 describe('i18n: no hardcoded user-facing strings in apps/web components', () => {
-  const files = SCAN_DIRS.flatMap((d) => walk(resolve(ROOT, d)).map((f) => f.replace(ROOT + '/', '')))
-    .filter((f) => !EXCLUDE_PATHS.some((ex) => f.startsWith(ex)));
+  const files = SCAN_DIRS.flatMap((d) => walk(resolve(ROOT, d)).map((f) => f.replace(ROOT + '/', ''))).filter(
+    (f) => !EXCLUDE_PATHS.some((ex) => f.startsWith(ex)),
+  );
   const violations = files.flatMap(scanFile).filter((v) => !KNOWN_DEBT.has(`${v.file}:${v.line}:${v.vector}`));
 
   it('all user-facing text is routed through t.* (zero hardcoded literals)', () => {
     if (violations.length > 0) {
       // eslint-disable-next-line no-console
-      console.log(`\n[i18n] ${violations.length} hardcoded literal(s) — route through t.* (or allowlist if locale-invariant):`);
+      console.log(
+        `\n[i18n] ${violations.length} hardcoded literal(s) — route through t.* (or allowlist if locale-invariant):`,
+      );
       for (const v of violations.slice(0, 100)) {
         console.log(`  ${v.file}:${v.line} [${v.vector}] ${JSON.stringify(v.text)}`); // eslint-disable-line no-console
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,9 +28,10 @@
       "exceljs": ["./packages/api/node_modules/exceljs"],
       // The platform-api hook-path tests (tests/platform/*.test.tsx) import react and
       // @tanstack/react-query directly, and neither is hoisted to the root node_modules —
-      // apps/web owns both. Mirrors the same two aliases in vitest.config.ts. (The portal .tsx
-      // tests never needed this: they import only @testing-library/react, whose own react
-      // resolution rides on skipLibCheck.)
+      // apps/web owns both. Counterparts of (not copies of) the two vitest.config.ts aliases:
+      // vitest maps `react` to the runtime package, this maps it to @types/react — each tool
+      // needs its own kind. (The portal .tsx tests never needed this: they import only
+      // @testing-library/react, whose own react resolution rides on skipLibCheck.)
       "react": ["./apps/web/node_modules/@types/react"],
       "@tanstack/react-query": ["./apps/web/node_modules/@tanstack/react-query"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,14 @@
       "@tims/ai": ["./packages/ai/src/index.ts"],
       "@trpc/server": ["./packages/api/node_modules/@trpc/server"],
       "@prisma/client": ["./packages/api/node_modules/@prisma/client"],
-      "exceljs": ["./packages/api/node_modules/exceljs"]
+      "exceljs": ["./packages/api/node_modules/exceljs"],
+      // The platform-api hook-path tests (tests/platform/*.test.tsx) import react and
+      // @tanstack/react-query directly, and neither is hoisted to the root node_modules —
+      // apps/web owns both. Mirrors the same two aliases in vitest.config.ts. (The portal .tsx
+      // tests never needed this: they import only @testing-library/react, whose own react
+      // resolution rides on skipLibCheck.)
+      "react": ["./apps/web/node_modules/@types/react"],
+      "@tanstack/react-query": ["./apps/web/node_modules/@tanstack/react-query"]
     }
   },
   "exclude": ["node_modules"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,15 @@ export default defineConfig({
       // Allow component tests to resolve React from apps/web
       react: resolve(__dirname, 'apps/web/node_modules/react'),
       'react/jsx-dev-runtime': resolve(__dirname, 'apps/web/node_modules/react/jsx-dev-runtime'),
+      // Same single-instance requirement as `react` above, for the platform-api hook-path tests:
+      // the wrapper under test resolves @tanstack/react-query via apps/web/node_modules, and the
+      // test's QueryClientProvider must be the SAME module instance or the context lookup fails
+      // ("No QueryClient set"). Root node_modules has no copy, so without this the test cannot
+      // resolve the import at all.
+      '@tanstack/react-query': resolve(__dirname, 'apps/web/node_modules/@tanstack/react-query'),
+      // Lets tests vi.mock('@tims/auth/client'): the wrapper's client.ts resolves that specifier
+      // via apps/web's workspace dep; the mock must resolve it to the same module id to intercept.
+      '@tims/auth/client': resolve(__dirname, 'packages/auth/src/client.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## What

The FE half of #81's step 4, for the thirteenth-and-final-read cluster shipped in #237: `apps/web/lib/platform-api/dashboard.ts` — **twelve dual-path hooks** routing every consumed platform-dashboard read to the C# `/platform/dashboard/*` endpoints when `NEXT_PUBLIC_TIMS_PLATFORM_API_URL` + `NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP` are both set (the same reversible dual-path shape monitoring still has). All **16 raw `trpc.platform.*` dashboard call sites across 14 files** now go through the wrapper. Everything stays DARK: the flag is unset everywhere, and the C# side's `Platform:PlatformDashboardReadEnabled` is dark too — a real cutover needs three env conditions, now written into the new `cutover.sh` `dashboard` surface row (status **BLOCKED** on the never-run step-5 `verify dashboard`, #211).

Twelve hooks for thirteen reads, deliberately: `getUserGrowth` has **zero** apps/web consumers (no chart exists), so a hook would be an orphan — the exception is pinned by name in the wiring test, whose raw-tRPC scan still quantifies over all thirteen.

`platformGetRaw`, not `platformGet`: all 13 endpoints declare untyped `.Produces(200)`, so the contract types the 200 as `content?: never` and paths are not compile-checked — the wiring test cross-checks every path literal against `contracts/openapi/Tims.Api.json` instead. `schema.d.ts` regenerated from the committed contract (8 days stale, zero `/platform/*` paths before; key-set delta 21 added / 0 removed — but note the regen absorbs pre-existing drift for ~10 unrelated surfaces; freshness-check follow-up filed as #240).

Null-preserving pins (`Number(null) === 0`, all three INVERT meaning at 0): churn `daysSinceLastLogin` (null = no login ever), customer-health `trialDaysLeft` (null = not on a trial), ai `monthlyBudget` (null = no budget configured). customer-health `daysSinceLastLogin` faithfully keeps the TS 999 sentinel.

## Review — tier-3 panel + second pass (check 15 could not run)

Cross-model review **NOT RUN** (exit 2 — Codex quota-blocked until ~Sep 9 per the live CLI refusal; no OmniRoute upstream configured). Substitute per `.claude/rules/verification.md` tier 3: a 3-lens same-model adversarial panel (security / claim-auditor / coverage, each prompted to refute), **plus a second pass over the panel fixes themselves**. This is same-model review, weaker than cross-model — recorded as such.

Panel results, acted on in `1702f0d5`/`6ceed445`/`3956e9e4`:
- **Security: 0 HIGH, 2 MED, 3 LOW.** The MEDs are pre-flip decisions, filed not fixed: #238 (search terms reach the C# Serilog request log via the query string) and #239 (impersonation containment diverges — `credentials:'omit'` drops the cookie `PrincipalResolver` reads; pre-existing in client.ts, broadened here from 2 surfaces to 13). Fixed now: `maxLength={100}` on the ⌘K input matching the Zod/C# bound. Refuted after real tracing: MFA step-up parity holds (the C# middleware's `{"message":"MFA_REQUIRED"}` body is load-bearing for the shared QueryCache matcher), rate-limit parity holds (same Redis bucket), no injection, no token/PII sink, schema.d.ts churn is 100% type declarations.
- **Claim auditor: 1 FALSE + 3 OVERSTATED**, all corrected: "same shape as monitoring/billing/dei" (only monitoring is dual-path today), "zero invalidate calls" (36 exist, zero targeting dashboard reads), "eleven serve month labels or day counts", "steps 1–4 done in full" / "BOTH flags" (really three env conditions). All counts verified exact: 16 call sites / 14 files / 21-added-0-removed / 13 endpoints / 12 hooks; the three hardest wire interfaces diffed field-for-field clean.
- **Coverage: 5 MED.** Fixed: `mapChurnRisk` extracted (the summary coercion was reachable by neither test nor compiler — a total-equals-red copy-paste passed the whole suite), runtime hook-path tests added (a representative hook executed under happy-dom on BOTH flag states; search's `callerEnabled` gate killed at runtime), queryKey uniqueness pinned, the `cutover.sh`/README `dashboard` row added, slice-23 doc's stale "wrapper does not exist" passages updated. One coverage finding **refuted** (C-6: MFA redirect blind on the C# path — the security lens's trace is correct, verified directly). #240 filed for the schema.d.ts freshness gap.
- **Second pass over the fixes found 4 more** (fixed in `3956e9e4`): the invalidate count wrong a THIRD time (36, not 35 — the comment now defers to the wiring test's scan); "BOTH flags" surviving in the wrapper header itself; the `.env.example` premise wrong by ~10 (monitoring's own flag was undocumented — stanza added; **8 FE-read flags remain undocumented**: ACCESS_REVIEW_READ/WRITE, BILLING_SELF_SERVE_WRITE, ENGAGEMENT_READ/WRITE, NINEBOX_READ/WRITE, SUCCESSION_WRITE — recorded here, not silently backfilled); the churn test's total equalling green+yellow+red. It also proved by re-execution that the pre-flush "fires nothing" assertion was vacuous and the flush made it bite.

**Commit-message errata** (messages can't be rewritten post-push): `1702f0d5` says "six do not" serve month labels or day counts — INVERTED, six DO and five do not; its "17 siblings were all documented" premise is false as above. `27e706ba` says prettier ran over "five dashboard consumer files" — it ran over all 14; five held KNOWN_DEBT anchors.

## Mutation proofs (all RED, reverted)

M1 `monthlyBudget` numberOrNull→Number · M2 `trialDaysLeft` · M3 churn `daysSinceLastLogin` · M4 path typo `/kpis-typo` · M5 consumer reverted to raw tRPC · M6 `NEXT_PUBLIC_` prefix dropped · M7 dual-path return collapsed · M8 orphan hook added — plus MC2 summary cross-wire (`total: red`), MC3 `&& callerEnabled` dropped (now killed by BOTH the text pin and the runtime test — the runtime kill was vacuous pre-flush and is proven post-flush), MC5 duplicated queryKey. MC2/MC5/MC3 re-run against the committed baseline after an earlier run was invalidated by a `git checkout` revert racing uncommitted fixes.

## Verification

- `pnpm --filter @tims/api exec tsc --noEmit` ✅ · `apps/web npx tsc --noEmit` ✅
- `npx vitest run` ✅ **3227 tests / 323 files** (main baseline 3185/319; +42/+4 = the two FE test files, the two runtime hook-path files, and pins)
- `SKIP_ENV_VALIDATION=true pnpm --filter @tims/web build` ✅ · `gitleaks git` full history ✅ (702 commits)
- No C# changes — `services/` untouched; the C# suites re-anchored on main `b10948fb` this session at 1288 unit / 1454 integration.
- /gate: checks 1–14, 17, 18 ✅ · **check 15 ⚠️ NOT RUN** (exit 2, tier-3 substitute above) · **check 16 ❌ known drift only** — re-verified as exactly the `ci_readonly` grants + `audit_logs_organization_id_action_idx` families, zero removals, zero new hunks; baseline deliberately not re-captured (Federico's standing call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)