### PR TITLE
ci: schema.d.ts freshness check — the FE twin of the OpenAPI contract gate (#240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,16 @@ jobs:
       - name: Type check Web
         if: matrix.target == 'web'
         run: cd apps/web && npx tsc --noEmit
+      # schema.d.ts must not drift from the committed OpenAPI contract (#240) — the FE-side twin
+      # of dotnet-platform.yml's "OpenAPI contract is up to date". Nothing else regenerates the
+      # TS types: before this step existed they went 8 days stale (zero /platform/* paths) and a
+      # dashboard-scoped PR silently absorbed ~10 unrelated surfaces' drift. Regeneration is
+      # deterministic: openapi-typescript is exact-pinned in apps/web's devDependencies.
+      - name: platform-api schema.d.ts is up to date
+        if: matrix.target == 'web'
+        run: |
+          pnpm --filter @tims/web gen:platform-types
+          git diff --exit-code apps/web/lib/platform-api/schema.d.ts
 
   # ========================================
   # Security Tests (56 tests)


### PR DESCRIPTION
## What

One CI step in the web typecheck leg: `pnpm --filter @tims/web gen:platform-types` then `git diff --exit-code apps/web/lib/platform-api/schema.d.ts` — the FE-side twin of dotnet-platform.yml's "OpenAPI contract is up to date". Closes #240 (found by the tier-3 coverage lens on #241: the generated types had gone 8 days stale with zero `/platform/*` paths, and the regen absorbed ~10 unrelated surfaces' drift inside a dashboard-scoped PR).

## Verification

- GREEN path: fresh regen on main-derived tree → `git diff --exit-code` exits 0 ✅
- RED path proven by mutation: removing `/platform/dashboard/kpis` from the contract → step exits 1 ✅ (first mutation attempt via `info.description` was a NON-proof — openapi-typescript never emits the info block; the honest scope statement is that this check guards the **generated types**, not every contract byte)
- Post-revert GREEN re-confirmed ✅; determinism rests on the exact-pinned `openapi-typescript@7.13.0`
- This PR's own CI run exercises the new step live.
- Check 15 NOT RUN (Codex quota) — change is one CI step, self-verifying on this PR; no tier-3 panel convened for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)