### PR TITLE
docs(env): flag truth — one live stanza, seven retirements, one corrected claim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,17 @@ NEXT_PUBLIC_REPORTING_READ_VIA_CSHARP=false
 # gates all three routes. Requires NEXT_PUBLIC_TIMS_PLATFORM_API_URL to also be set. Anything
 # other than the exact string 'true' (including unset) keeps the tRPC path. Default off.
 NEXT_PUBLIC_BILLING_USAGE_VIA_CSHARP=false
+
+# Per-surface flag, and the ONLY live-but-undocumented one found by the 2026-08-17 audit: routes
+# the THREE billing self-serve WRITE mutations (create-checkout-session / create-portal-session /
+# cancel-subscription) to the C# service. UNLIKE most flags in this file the TS tRPC mutations
+# still exist and are the DEFAULT path — this switch is dark pending the Stripe live-key cutover
+# decision (#53, declined so far). Mirrors the backend `Platform:BillingSelfServeEnabled` flag.
+# NOT in scripts/deploy/cutover.sh's surface table: billing-self-serve is deliberately out of
+# that script's scope (different auth mechanism; separate workstream — see cutover.sh's header).
+# Requires NEXT_PUBLIC_TIMS_PLATFORM_API_URL to also be set. Anything other than the exact
+# string 'true' (including unset) keeps the tRPC path. Default off.
+NEXT_PUBLIC_BILLING_SELF_SERVE_WRITE_VIA_CSHARP=false
 # Per-surface flag: route the tenant invoice-history read (listInvoices / getInvoice) to the
 # C# service. Mirrors the backend `Platform:BillingReadEnabled` flag (independent of
 # BillingUsageEnabled above — cuts over on its own). Requires
@@ -123,11 +134,26 @@ NEXT_PUBLIC_DASHBOARD_READ_VIA_CSHARP=false
 # alerts / action-plan-alerts / cross-module-trend / alert-rules) to the C# service. Mirrors the
 # backend `Platform:MonitoringReadEnabled` flag that gates all six routes. Added 2026-08-17: the
 # second-pass audit found this flag undocumented here while being the dual-path comparator the
-# dashboard stanza above is modeled on — 8 more FE-read flags remain undocumented, recorded in
-# the PR that added these two rather than silently backfilled.
+# dashboard stanza above is modeled on. (Its companion claim "8 more FE-read flags remain
+# undocumented" was then itself falsified: 7 of those 8 are DEAD — comment-only mentions with no
+# runtime reader — and are listed in the RETIRED block below; only the billing self-serve write
+# flag was a live undocumented switch, documented with the billing flags above.)
 # Requires NEXT_PUBLIC_TIMS_PLATFORM_API_URL to also be set. Anything other than the exact
 # string 'true' (including unset) keeps the tRPC path. Default off.
 NEXT_PUBLIC_MONITORING_READ_VIA_CSHARP=false
+
+# RETIRED CUTOVER FLAGS — DEAD, deliberately NOT given settable lines here (a settable line for a
+# flag nothing reads invites the belief that setting it does something). Verified 2026-08-17: none
+# of these has a `process.env.` reader anywhere in apps/web — each survives only in header prose.
+# Their C# paths were confirmed live in prod and the TS fallbacks deleted, so C# is the sole path
+# and the flags are inert. Listed so their absence from this file reads as retirement, not omission:
+#   NEXT_PUBLIC_ACCESS_REVIEW_READ_VIA_CSHARP    (dead 2026-07-31 — TS router deleted outright)
+#   NEXT_PUBLIC_ACCESS_REVIEW_WRITE_VIA_CSHARP   (dead 2026-07-31 — C# sole writer of access_reviews)
+#   NEXT_PUBLIC_ENGAGEMENT_READ_VIA_CSHARP       (dead 2026-07-31 — all 8 wrapped reads' TS deleted)
+#   NEXT_PUBLIC_ENGAGEMENT_WRITE_VIA_CSHARP      (dead 2026-08-05 — last 2 TS writes deleted, #56)
+#   NEXT_PUBLIC_NINEBOX_READ_VIA_CSHARP          (dead 2026-08-05 — TS router deleted, #57)
+#   NEXT_PUBLIC_NINEBOX_WRITE_VIA_CSHARP         (dead 2026-08-05 — C# sole calibration writer)
+#   NEXT_PUBLIC_SUCCESSION_WRITE_VIA_CSHARP      (dead 2026-08-03 — routers/succession.ts deleted, #58)
 
 # RETIRED 2026-07-29 — DEAD FLAG, no code reads it. It used to route the FIVE FE-consumed FX-FREE
 # compensation reads (getSalaryBands / getBenefitsUtilization / getCompaRatioDistribution /


### PR DESCRIPTION
## What

Closes out the flag-documentation thread from #241's second pass — with the premise corrected first.

The 2026-08-17 inventory (re-verified per flag against apps/web source) found **7 of the 8 "undocumented FE flags" are DEAD**: no `process.env` reader anywhere in apps/web — they survive only in wrapper header prose, their TS fallbacks are deleted, C# is the sole path. Documenting them as live toggles would be actively misleading, so they get a **RETIRED comment block with no settable lines** (a settable line for a flag nothing reads invites the belief that setting it does something).

The **one genuinely live undocumented switch** — `NEXT_PUBLIC_BILLING_SELF_SERVE_WRITE_VIA_CSHARP` (`billing.ts:340`, real dual-path, TS mutations still the default path, dark pending the declined Stripe live-key cutover #53) — gets a real stanza. It is also the only one of the eight with no cutover.sh surface row, which is correct: billing-self-serve is explicitly out of that script's scope.

The monitoring stanza's own "8 more remain undocumented" line is corrected in place — the audit trail of a wrong count is worth more than a clean page.

## Verification

- Doc-only change (.env.example comments + one `=false` line for a flag genuinely read at `apps/web/lib/platform-api/billing.ts:340`).
- Per-flag reader evidence gathered by repo-wide grep; an erratum for #241's body is posted as a comment there.
- Check 15 NOT RUN (Codex quota); no dedicated panel for a doc-only diff — the claim-audit lens of the #195 PR's panel covers this PR's claims too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)